### PR TITLE
Others branch protections

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -1,4 +1,15 @@
 branch-protection:
+  enforce_admins: true # rules apply to admins
+  restrictions:
+    teams: ["maintainers", "machine_users"]
+  required_pull_request_reviews:
+    dismiss_stale_reviews: true # automat dismiss old reviews
+    dismissal_restrictions: # allow review dismissals
+      teams:
+      - admins
+    required_approving_review_count: 1 # number of approvals
+  required_status_checks:
+    strict: true # require PR branch to be up to date
   orgs:
     falcosecurity:
       repos:
@@ -10,47 +21,14 @@ branch-protection:
               protect: true
             master:
               protect: true
-          enforce_admins: true # rules apply to admins
-          restrictions:
-            teams: ["maintainers", "machine_users"]
-          required_pull_request_reviews:
-            dismiss_stale_reviews: true # automatically dismiss old reviews
-            dismissal_restrictions: # allow review dismissals
-              teams:
-              - admins
-            required_approving_review_count: 1 # number of approvals
-          required_status_checks:
-            strict: true # require PR branch to be up to date
         office-hours:
           branches:
             master:
               protect: true
-          enforce_admins: true # rules apply to admins
-          restrictions:
-            teams: ["maintainers", "machine_users"]
-          required_pull_request_reviews:
-            dismiss_stale_reviews: true # automatically dismiss old reviews
-            dismissal_restrictions: # allow review dismissals
-              teams:
-              - admins
-            required_approving_review_count: 1 # number of approvals
-          required_status_checks:
-            strict: true # require PR branch to be up to date
         test-infra:
           branches:
             master:
               protect: true
-          enforce_admins: true # rules apply to admins
-          restrictions:
-            teams: ["maintainers", "machine_users"]
-          required_pull_request_reviews:
-            dismiss_stale_reviews: true # automatically dismiss old reviews
-            dismissal_restrictions: # allow review dismissals
-              teams:
-              - admins
-            required_approving_review_count: 1 # number of approvals
-          required_status_checks:
-            strict: true # require PR branch to be up to date
 
 log_level: debug
 

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -4,11 +4,15 @@ branch-protection:
       repos:
         falco:
           branches:
+            agent-master:
+              protect: true
+            dev:
+              protect: true
             master:
               protect: true
           enforce_admins: true # rules apply to admins
           restrictions:
-            teams: ["admins", "machine_users"]
+            teams: ["maintainers", "machine_users"]
           required_pull_request_reviews:
             dismiss_stale_reviews: true # automatically dismiss old reviews
             dismissal_restrictions: # allow review dismissals
@@ -23,7 +27,7 @@ branch-protection:
               protect: true
           enforce_admins: true # rules apply to admins
           restrictions:
-            teams: ["admins", "machine_users"] # always allow team "admins" to push
+            teams: ["maintainers", "machine_users"]
           required_pull_request_reviews:
             dismiss_stale_reviews: true # automatically dismiss old reviews
             dismissal_restrictions: # allow review dismissals
@@ -38,7 +42,7 @@ branch-protection:
               protect: true
           enforce_admins: true # rules apply to admins
           restrictions:
-            teams: ["admins", "machine_users"]
+            teams: ["maintainers", "machine_users"]
           required_pull_request_reviews:
             dismiss_stale_reviews: true # automatically dismiss old reviews
             dismissal_restrictions: # allow review dismissals


### PR DESCRIPTION
Restrictions apply now to maintainers team.

Please notice that to be working this means that the @falcosecurity/maintainers team needs to explicitly have permissions on the repo for which we are enabling branch protection rules.

Same applies for review dismissal capabilitites.