### PR TITLE
update: change the self approval flag since the old one was deprecated

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -4,7 +4,7 @@ approve:
     - falcosecurity/office-hours
     - falcosecurity/test-infra
     lgtm_acts_as_approve: true
-    implicit_self_approve: false
+    require_self_approval: true
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>