### PR TITLE
fix: do not count on travis branch ci check

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -20,7 +20,6 @@ branch-protection:
         falco:
           required_status_checks:
             contexts:
-            - Travis CI - Branch
             - Travis CI - Pull Request
           branches:
             agent-master:


### PR DESCRIPTION
As shown in picture, when an external contributor (or anyone using a fork) does a PR the Travis branch check does not trigger so the PR can never be merged.

I disabled this check on Prow with this PR.

Also, that check just gets reported when the other Travis check passes (when it works) so it's not useful to have it in place.

<img width="711" alt="Screenshot 2019-07-18 at 13 51 09" src="https://user-images.githubusercontent.com/3083633/61491095-4f5f1a80-a963-11e9-8cea-5d180b2e3967.png">

Signed-off-by: Lorenzo Fontana <lo@linux.com>