### PR TITLE
new: enable help plugin

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -77,6 +77,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - help
     - hold
     - label
     - lifecycle
@@ -94,6 +95,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - help
     - hold
     - label
     - lifecycle
@@ -110,6 +112,7 @@ plugins:
     - branchcleaner
     - config-updater
     - dco
+    - help
     - hold
     - lifecycle
     - lgtm


### PR DESCRIPTION
The help plugin provides commands that add or remove the 'help wanted' and the 'good first issue' labels from issues.

Syntax:
```
/[remove-](help|good-first-issue)
```

Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>