### PR TITLE
new: add golint plugins to go-only repositories

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -89,6 +89,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - golint
     - hold
     - label
     - lifecycle
@@ -124,6 +125,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - golint
     - help
     - hold
     - label


### PR DESCRIPTION
On the `falcoctl` and `client-go` repos we'll have the `/lint` command  if this get merged in.
This plugins lints the Go code.

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>