### PR TITLE
PROW for falco-exporter

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -32,6 +32,10 @@ branch-protection:
               protect: true
             master:
               protect: true
+        falco-exporter:
+          branches:
+            master:
+              protect: true
         falcoctl:
           branches:
             master:
@@ -62,6 +66,7 @@ tide:
   merge_method:
     falcosecurity/client-go: rebase
     falcosecurity/falco: rebase
+    falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
     falcosecurity/falco-website: rebase
     falcosecurity/community: rebase
@@ -69,6 +74,32 @@ tide:
   queries:
   - repos:
     - falcosecurity/client-go
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/falco
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/falco-exporter
     labels:
     - approved
     - lgtm

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -2,6 +2,7 @@ approve:
   - repos:
     - falcosecurity/client-go
     - falcosecurity/falco
+    - falcosecurity/falco-exporter
     - falcosecurity/falcoctl
     - falcosecurity/falco-website
     - falcosecurity/community
@@ -31,6 +32,7 @@ lgtm:
   - repos:
     - falcosecurity/client-go
     - falcosecurity/falco
+    - falcosecurity/falco-exporter
     - falcosecurity/falcoctl
     - falcosecurity/falco-website
     - falcosecurity/community
@@ -61,6 +63,14 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: falco
+    issues: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this issue.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: falco-exporter
     issues: true
     regexp: ^kind/
     missing_comment: |
@@ -132,6 +142,25 @@ plugins:
     - lifecycle
     - lgtm
     - milestone
+    - release-note
+    - require-matching-label
+    - size
+    - verify-owners
+    - welcome
+    - wip
+  falcosecurity/falco-exporter:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - golint
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
     - release-note
     - require-matching-label
     - size
@@ -213,6 +242,10 @@ external_plugins:
     events:
       - pull_request
   falcosecurity/falco:
+  - name: needs-rebase
+    events:
+      - pull_request
+  falcosecurity/falco-exporter:
   - name: needs-rebase
     events:
       - pull_request


### PR DESCRIPTION
This PR adds PROW support to falco-exporter repository.

Plugins:
    - approve
    - assign
    - blunderbuss
    - branchcleaner
    - cat
    - dco
    - golint
    - help
    - hold
    - label
    - lifecycle
    - lgtm
    - release-note
    - require-matching-label
    - size
    - verify-owners
    - welcome
    - wip

Labels:
- At least a "kind/*" label

Protected branches:
- master

Merging strategy:
- rebase

PR checks & automerge (tide):
- must be "approved"
- must have a "lgtm" review
- commits must be signed-off
- must NOT have "do-not-merge/*" labels
- must NOT have "needs-rebase" label


Fixes #63 
