### PR TITLE
Prow for client-py

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -21,6 +21,10 @@ branch-protection:
           branches:
             master:
               protect: true
+        client-py:
+          branches:
+            master:
+              protect: true
         falco:
           required_status_checks:
             contexts:
@@ -65,6 +69,7 @@ tide:
     from-branch-protection: true
   merge_method:
     falcosecurity/client-go: rebase
+    falcosecurity/client-py: rebase
     falcosecurity/falco: rebase
     falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
@@ -74,6 +79,32 @@ tide:
   queries:
   - repos:
     - falcosecurity/client-go
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/falco
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/client-py
     labels:
     - approved
     - lgtm

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1,6 +1,7 @@
 approve:
   - repos:
     - falcosecurity/client-go
+    - falcosecurity/client-py
     - falcosecurity/falco
     - falcosecurity/falco-exporter
     - falcosecurity/falcoctl
@@ -31,6 +32,7 @@ label:
 lgtm:
   - repos:
     - falcosecurity/client-go
+    - falcosecurity/client-py
     - falcosecurity/falco
     - falcosecurity/falco-exporter
     - falcosecurity/falcoctl
@@ -55,6 +57,14 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: client-go
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: client-py
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -119,6 +129,23 @@ plugins:
     - cat
     - dco
     - golint
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - release-note
+    - require-matching-label
+    - size
+    - verify-owners
+    - welcome
+    - wip
+  falcosecurity/client-py:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
     - hold
     - label
     - lifecycle
@@ -238,6 +265,10 @@ plugins:
 
 external_plugins:
   falcosecurity/client-go:
+  - name: needs-rebase
+    events:
+      - pull_request
+  falcosecurity/client-py:
   - name: needs-rebase
     events:
       - pull_request


### PR DESCRIPTION
Fixes #66 

This PR adds PROW support to the client-py repository.

Plugins:
- approve
- assign
- blunderbuss
- branchcleaner
- cat
- dco
- help
- hold
- label
- lifecycle
- lgtm
- release-note
- require-matching-label
- size
- verify-owners
- welcome
- wip

Labels:

- At least a "kind/*" label

Protected branches:

- master

Merging strategy:

- rebase

PR checks & auto-merge (tide):

- must be "approved"
- must have a "lgtm" review
- commits must be signed-off
- must NOT have "do-not-merge/*" labels
- must NOT have "needs-rebase" label
