### PR TITLE
Prow for advocacy repo

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -17,11 +17,18 @@ branch-protection:
         contexts:
         - dco
       repos:
+        advocacy:
+          branches: master
+            protect: true
         client-go:
           branches:
             master:
               protect: true
         client-py:
+          branches:
+            master:
+              protect: true
+        community:
           branches:
             master:
               protect: true
@@ -48,10 +55,6 @@ branch-protection:
           branches:
             master:
               protect: true
-        community:
-          branches:
-            master:
-              protect: true
         test-infra:
           branches:
             master:
@@ -68,15 +71,28 @@ tide:
     skip-unknown-contexts: true
     from-branch-protection: true
   merge_method:
+    falcosecurity/advocacy: rebase
     falcosecurity/client-go: rebase
     falcosecurity/client-py: rebase
+    falcosecurity/community: rebase
     falcosecurity/falco: rebase
     falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
     falcosecurity/falco-website: rebase
-    falcosecurity/community: rebase
     falcosecurity/test-infra: rebase
   queries:
+  - repos:
+    - falcosecurity/advocacy
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
   - repos:
     - falcosecurity/client-go
     labels:
@@ -115,6 +131,18 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/community
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
     - needs-rebase
   - repos:
     - falcosecurity/falco
@@ -170,18 +198,6 @@ tide:
     - needs-rebase
   - repos:
     - falcosecurity/falco-website
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/community
     labels:
     - approved
     - lgtm

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1,12 +1,13 @@
 approve:
   - repos:
+    - falcosecurity/advocacy
     - falcosecurity/client-go
     - falcosecurity/client-py
+    - falcosecurity/community
     - falcosecurity/falco
     - falcosecurity/falco-exporter
     - falcosecurity/falcoctl
     - falcosecurity/falco-website
-    - falcosecurity/community
     - falcosecurity/test-infra
     lgtm_acts_as_approve: true
     require_self_approval: true
@@ -31,13 +32,14 @@ label:
 
 lgtm:
   - repos:
+    - falcosecurity/advocacy
     - falcosecurity/client-go
     - falcosecurity/client-py
+    - falcosecurity/community
     - falcosecurity/falco
     - falcosecurity/falco-exporter
     - falcosecurity/falcoctl
     - falcosecurity/falco-website
-    - falcosecurity/community
     - falcosecurity/test-infra
     review_acts_as_lgtm: true
     store_tree_hash: true
@@ -121,6 +123,23 @@ size:
   xxl: 520
 
 plugins:
+  falcosecurity/advocacy:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - require-matching-label
+    - size
+    - verify-owners
+    - welcome
+    - wip
   falcosecurity/client-go:
     - approve
     - assign
@@ -151,6 +170,23 @@ plugins:
     - lifecycle
     - lgtm
     - release-note
+    - require-matching-label
+    - size
+    - verify-owners
+    - welcome
+    - wip
+  falcosecurity/community:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
     - require-matching-label
     - size
     - verify-owners
@@ -230,23 +266,6 @@ plugins:
     - verify-owners
     - welcome
     - wip
-  falcosecurity/community:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - size
-    - verify-owners
-    - welcome
-    - wip
   falcosecurity/test-infra:
     - approve
     - assign
@@ -264,6 +283,10 @@ plugins:
     - wip
 
 external_plugins:
+  falcosecurity/advocacy:
+  - name: needs-rebase
+    events:
+      - pull_request
   falcosecurity/client-go:
   - name: needs-rebase
     events:
@@ -272,6 +295,10 @@ external_plugins:
   - name: needs-rebase
     events:
       - pull_request
+  falcosecurity/community:
+    - name: needs-rebase
+      events:
+        - pull_request
   falcosecurity/falco:
   - name: needs-rebase
     events:
@@ -285,10 +312,6 @@ external_plugins:
     events:
       - pull_request
   falcosecurity/falco-website:
-  - name: needs-rebase
-    events:
-      - pull_request
-  falcosecurity/community:
   - name: needs-rebase
     events:
       - pull_request


### PR DESCRIPTION
Adding Prow for [falcosecurity/advocacy](https://github.com/falcosecurity/advocacy) repository.

Completes and fixes #69 

/cc @kris-nova 

Plugins:

    approve
    assign
    blunderbuss
    branchcleaner
    cat
    dco
    help
    hold
    label
    lifecycle
    lgtm
    require-matching-label
    size
    verify-owners
    welcome
    wip

Labels:

    At least a "kind/*" label

Protected branches:

    master

Merging strategy:

    rebase

PR checks & auto-merge (tide):

    must be "approved"
    must have a "lgtm" review
    commits must be signed-off
    must NOT have "do-not-merge/*" labels
    must NOT have "needs-rebase" label
