### PR TITLE
update prow images, add retitle, docs-no-retest plugins, cat, dog, goose

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -6,6 +6,9 @@ cluster/oauth-token.yaml: oauth_secret
 cluster/hmac-token.yaml: hmac_secret
 	kubectl create secret generic --dry-run -o yaml hmac-token --from-file=$< >> $@
 
+cluster/unsplash-token.yaml: unsplash_secret
+	kubectl create secret generic --dry-run -o yaml unsplash-token --from-file=$< >> $@
+
 prow: cluster/oauth-token.yaml cluster/hmac-token.yaml cluster/*.yaml
 	kubectl apply -f cluster
 

--- a/prow/cluster/branchprotector.yaml
+++ b/prow/cluster/branchprotector.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20190909-c3ac80e32
+            image: gcr.io/k8s-prow/branchprotector:v20191202-824584dd0
             args:
             - --config-path=/etc/config/configs.yaml
             # fixme

--- a/prow/cluster/deck.yaml
+++ b/prow/cluster/deck.yaml
@@ -94,7 +94,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190528-0d7c4b53a
+        image: gcr.io/k8s-prow/deck:v20191202-824584dd0
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help

--- a/prow/cluster/hook.yaml
+++ b/prow/cluster/hook.yaml
@@ -63,7 +63,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190528-0d7c4b53a
+        image: gcr.io/k8s-prow/hook:v20191202-824584dd0
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/hook.yaml
+++ b/prow/cluster/hook.yaml
@@ -84,6 +84,8 @@ spec:
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
+        - name: unsplash
+          mountPath: /etc/unsplash
         livenessProbe:
           httpGet:
             path: /healthz
@@ -110,6 +112,12 @@ spec:
       - name: plugins
         configMap:
           name: plugins
+      - name: unsplash
+        secret:
+          secretName: unsplash-token
+          items:
+          - key: unsplash_secret
+            path: honk
 ---
 apiVersion: v1
 kind: Service

--- a/prow/cluster/horologium.yaml
+++ b/prow/cluster/horologium.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190528-0d7c4b53a
+        image: gcr.io/k8s-prow/horologium:v20191202-824584dd0
         args:
         - --config-path=/etc/config/configs.yaml
         volumeMounts:

--- a/prow/cluster/needs-rebase.yaml
+++ b/prow/cluster/needs-rebase.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190605-cc2fb1575
+        image: gcr.io/k8s-prow/needs-rebase:v20191202-824584dd0
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank.yaml
+++ b/prow/cluster/plank.yaml
@@ -82,7 +82,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190528-0d7c4b53a
+        image: gcr.io/k8s-prow/plank:v20191202-824584dd0
         args:
         - --dry-run=false
         - --config-path=/etc/config/configs.yaml

--- a/prow/cluster/sinker.yaml
+++ b/prow/cluster/sinker.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190528-0d7c4b53a
+        image: gcr.io/k8s-prow/sinker:v20191202-824584dd0
         args:
         - --config-path=/etc/config/configs.yaml
         volumeMounts:

--- a/prow/cluster/tide.yaml
+++ b/prow/cluster/tide.yaml
@@ -64,7 +64,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190528-0d7c4b53a
+        image: gcr.io/k8s-prow/tide:v20191202-824584dd0
         args:
         - --dry-run=false
         - --config-path=/etc/config/configs.yaml

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -8,6 +8,7 @@ branch-protection:
       teams:
       - maintainers
       - machine_users
+    require_code_owner_reviews: true  # require a code owner approval
     required_approving_review_count: 1 # number of approvals
   required_status_checks:
     strict: false # we don't want to block any PR if it's not up to date, we have the rebase merge strategy and needs-rebase plugin

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -328,6 +328,7 @@ plugins:
     - assign
     - blunderbuss
     - branchcleaner
+    - cat
     - dco
     - help
     - hold
@@ -343,6 +344,7 @@ plugins:
     - assign
     - blunderbuss
     - branchcleaner
+    - cat
     - config-updater
     - dco
     - docs-no-retest

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -148,6 +148,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - dog
     - goose
     - help
     - hold
@@ -166,6 +167,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - dog
     - goose
     - help
     - hold
@@ -185,6 +187,7 @@ plugins:
     - cat
     - dco
     - docs-no-retest
+    - dog
     - golint
     - goose
     - hold
@@ -206,6 +209,7 @@ plugins:
     - cat
     - dco
     - docs-no-retest
+    - dog
     - goose
     - hold
     - label
@@ -225,6 +229,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - dog
     - goose
     - help
     - hold
@@ -245,6 +250,7 @@ plugins:
     - cat
     - dco
     - docs-no-retest
+    - dog
     - goose
     - help
     - hold
@@ -268,6 +274,7 @@ plugins:
     - cat
     - dco
     - docs-no-retest
+    - dog
     - golint
     - goose
     - help
@@ -290,6 +297,7 @@ plugins:
     - cat
     - dco
     - docs-no-retest
+    - dog
     - golint
     - goose
     - help
@@ -311,6 +319,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - dog
     - goose
     - help
     - hold
@@ -330,6 +339,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - dog
     - help
     - hold
     - label
@@ -348,6 +358,7 @@ plugins:
     - config-updater
     - dco
     - docs-no-retest
+    - dog
     - goose
     - help
     - hold

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -27,6 +27,9 @@ config_updater:
     prow/config/plugins.yaml:
       name: plugins
 
+goose:
+  key_path: /etc/unsplash/honk
+
 label:
   additional_labels:
     - kind/pr
@@ -145,6 +148,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - goose
     - help
     - hold
     - label
@@ -162,6 +166,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - goose
     - help
     - hold
     - label
@@ -181,6 +186,7 @@ plugins:
     - dco
     - docs-no-retest
     - golint
+    - goose
     - hold
     - label
     - lifecycle
@@ -200,6 +206,7 @@ plugins:
     - cat
     - dco
     - docs-no-retest
+    - goose
     - hold
     - label
     - lifecycle
@@ -218,6 +225,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - goose
     - help
     - hold
     - label
@@ -237,6 +245,7 @@ plugins:
     - cat
     - dco
     - docs-no-retest
+    - goose
     - help
     - hold
     - label
@@ -260,6 +269,7 @@ plugins:
     - dco
     - docs-no-retest
     - golint
+    - goose
     - help
     - hold
     - label
@@ -281,6 +291,7 @@ plugins:
     - dco
     - docs-no-retest
     - golint
+    - goose
     - help
     - hold
     - label
@@ -300,6 +311,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - goose
     - help
     - hold
     - label
@@ -334,6 +346,7 @@ plugins:
     - config-updater
     - dco
     - docs-no-retest
+    - goose
     - help
     - hold
     - lifecycle

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -127,6 +127,9 @@ require_matching_label:
       Please specify it either using `/kind <group>` or manually from the side menu.
       In case you do not know which kind this proposal is please mention the maintainers using `@team/maintainers`.
 
+retitle:
+  allow_closed_issues: true
+
 size:
   s: 10
   m: 30
@@ -176,6 +179,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - docs-no-retest
     - golint
     - hold
     - label
@@ -183,6 +187,7 @@ plugins:
     - lgtm
     - release-note
     - require-matching-label
+    - retitle
     - size
     - verify-owners
     - welcome
@@ -194,12 +199,14 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - docs-no-retest
     - hold
     - label
     - lifecycle
     - lgtm
     - release-note
     - require-matching-label
+    - retitle
     - size
     - verify-owners
     - welcome
@@ -217,6 +224,7 @@ plugins:
     - lifecycle
     - lgtm
     - require-matching-label
+    - retitle
     - size
     - verify-owners
     - welcome
@@ -228,14 +236,17 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - docs-no-retest
     - help
     - hold
     - label
     - lifecycle
     - lgtm
+    - mergecommitblocker
     - milestone
     - release-note
     - require-matching-label
+    - retitle
     - size
     - verify-owners
     - welcome
@@ -247,6 +258,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - docs-no-retest
     - golint
     - help
     - hold
@@ -255,6 +267,7 @@ plugins:
     - lgtm
     - release-note
     - require-matching-label
+    - retitle
     - size
     - verify-owners
     - welcome
@@ -266,6 +279,7 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - docs-no-retest
     - golint
     - help
     - hold
@@ -274,6 +288,7 @@ plugins:
     - lgtm
     - release-note
     - require-matching-label
+    - retitle
     - size
     - verify-owners
     - welcome
@@ -291,6 +306,7 @@ plugins:
     - lifecycle
     - lgtm
     - require-matching-label
+    - retitle
     - size
     - verify-owners
     - welcome
@@ -317,10 +333,12 @@ plugins:
     - branchcleaner
     - config-updater
     - dco
+    - docs-no-retest
     - help
     - hold
     - lifecycle
     - lgtm
+    - retitle
     - size
     - verify-owners
     - welcome


### PR DESCRIPTION
This PR does two things:

- adds retitle plugin (`/retitle` issues and PR also if they are closed)
- adds `docs-no-retest` plugin
- adds missing `cat` plugins (eg., `/meow` 😸)
- adds `dog` plugin 🐶
- adds `goose` plugin 🦆 
- updates prow components to 2019 02 02 version (to contain such plugins and to obtain fixes/features)