### PR TITLE
prow for cloudnativesecurityhub* repos

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -32,6 +32,18 @@ branch-protection:
           branches:
             master:
               protect: true
+        cloud-native-security-hub:
+          branches:
+            master:
+              protect: true
+        cloud-native-security-hub-frontend:
+          branches:
+            master:
+              protect: true
+        cloud-native-security-hub-backend:
+          branches:
+            master:
+              protect: true
         community:
           branches:
             master:
@@ -83,6 +95,9 @@ tide:
     falcosecurity/advocacy: rebase
     falcosecurity/client-go: rebase
     falcosecurity/client-py: rebase
+    falcosecurity/cloud-native-security-hub: rebase
+    falcosecurity/cloud-native-security-hub-frontend: rebase
+    falcosecurity/cloud-native-security-hub-backend: rebase
     falcosecurity/community: rebase
     falcosecurity/falco: rebase
     falcosecurity/falco-exporter: rebase
@@ -143,6 +158,45 @@ tide:
     - needs-rebase
   - repos:
     - falcosecurity/client-py
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/cloud-native-security-hub
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/cloud-native-security-hub-frontend
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
+  - repos:
+    - falcosecurity/cloud-native-security-hub-backend
     labels:
     - approved
     - lgtm

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -4,6 +4,9 @@ approve:
     - falcosecurity/advocacy
     - falcosecurity/client-go
     - falcosecurity/client-py
+    - falcosecurity/cloud-native-security-hub
+    - falcosecurity/cloud-native-security-hub-frontend
+    - falcosecurity/cloud-native-security-hub-backend
     - falcosecurity/community
     - falcosecurity/falco
     - falcosecurity/falco-exporter
@@ -38,6 +41,9 @@ lgtm:
     - falcosecurity/advocacy
     - falcosecurity/client-go
     - falcosecurity/client-py
+    - falcosecurity/cloud-native-security-hub
+    - falcosecurity/cloud-native-security-hub-frontend
+    - falcosecurity/cloud-native-security-hub-backend
     - falcosecurity/community
     - falcosecurity/falco
     - falcosecurity/falco-exporter
@@ -79,6 +85,30 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: client-py
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: cloud-native-security-hub
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: cloud-native-security-hub-frontend
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: cloud-native-security-hub-backend
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -194,6 +224,58 @@ plugins:
     - branchcleaner
     - cat
     - dco
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - release-note
+    - require-matching-label
+    - size
+    - verify-owners
+    - welcome
+    - wip
+  falcosecurity/cloud-native-security-hub:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - release-note
+    - require-matching-label
+    - size
+    - verify-owners
+    - welcome
+    - wip
+  falcosecurity/cloud-native-security-hub-frontend:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - release-note
+    - require-matching-label
+    - size
+    - verify-owners
+    - welcome
+    - wip
+  falcosecurity/cloud-native-security-hub-backend:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - golint
     - hold
     - label
     - lifecycle
@@ -343,6 +425,18 @@ external_plugins:
   - name: needs-rebase
     events:
       - pull_request
+  falcosecurity/cloud-native-security-hub:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/cloud-native-security-hub-frontend:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/cloud-native-security-hub-backend:
+    - name: needs-rebase
+      events:
+        - pull_request
   falcosecurity/community:
     - name: needs-rebase
       events:


### PR DESCRIPTION
See issue #68 for more details about the configs and plugins this PR puts in place for the cloud-native-security-hub* repositories.

I need @bencer and @nestorsalceda at least to take a look at this before merging.

Fixes #68.