### PR TITLE
update(prow/config): falco uses One Flow git branching model now, so poiana only needs to protect its master

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -62,8 +62,6 @@ branch-protection:
               - "ci/circleci: integration"
               - "ci/circleci: centos7"
           branches:
-            dev:
-              protect: true
             master:
               protect: true
         falco-exporter:


### PR DESCRIPTION
…
Co-authored-by: Lorenzo Fontana <lo@linux.com>

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>