### PR TITLE
new: add Flatcar stable support

### DIFF
--- a/driverkit/config/dev/flatcar_stable_4.19.106-flatcar.yaml
+++ b/driverkit/config/dev/flatcar_stable_4.19.106-flatcar.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 4.19.106-flatcar
+target: flatcar-stable
+output:
+    module: output/dev/falco_flatcar_stable_4.19.106-flatcar.ko
+    probe: output/dev/falco_flatcar_stable_4.19.106-flatcar.o


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

Flatcar brought the CoreOS legacy and it will be the replacement.

Flatcar releases the OS into different channels flatcar-linux.org/releases

I'm targetting here Flatcar stable.