### PR TITLE
enable prow for event-generator

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -1,5 +1,5 @@
 branch-protection:
-  enforce_admins: true # rules apply to admins
+  enforce_admins: true # rules apply to admins too!
   restrictions:
     teams: ["maintainers", "machine_users"]
   required_pull_request_reviews:
@@ -61,6 +61,10 @@ branch-protection:
           required_status_checks:
             contexts:
               - "ci/circleci: test"
+        event-generator:
+          branches:
+            master:
+              protect: true
         falco:
           required_pull_request_reviews:
             required_approving_review_count: 2
@@ -113,6 +117,7 @@ tide:
     falcosecurity/cloud-native-security-hub-backend: rebase
     falcosecurity/community: rebase
     falcosecurity/driverkit: rebase
+    falcosecurity/event-generator: rebase
     falcosecurity/falco: rebase
     falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
@@ -159,6 +164,18 @@ tide:
     - needs-rebase
   - repos:
     - falcosecurity/driverkit
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - falcosecurity/event-generator
     labels:
     - approved
     - lgtm

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -10,6 +10,7 @@ approve:
       - falcosecurity/cloud-native-security-hub-backend
       - falcosecurity/community
       - falcosecurity/driverkit
+      - falcosecurity/event-generator
       - falcosecurity/falco
       - falcosecurity/falco-exporter
       - falcosecurity/falcoctl
@@ -52,6 +53,7 @@ lgtm:
       - falcosecurity/cloud-native-security-hub-backend
       - falcosecurity/community
       - falcosecurity/driverkit
+      - falcosecurity/event-generator
       - falcosecurity/falco
       - falcosecurity/falco-exporter
       - falcosecurity/falcoctl
@@ -132,6 +134,14 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: driverkit
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: event-generator
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -392,6 +402,27 @@ plugins:
     - verify-owners
     - welcome
     - wip
+  falcosecurity/event-generator:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - dog
+    - golint
+    - goose
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - require-matching-label
+    - retitle
+    - size
+    - verify-owners
+    - welcome
+    - wip
   falcosecurity/falco:
     - approve
     - assign
@@ -558,6 +589,10 @@ external_plugins:
       events:
         - pull_request
   falcosecurity/driverkit:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/event-generator:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

We just moved the new https://github.com/falcosecurity/event-generator by @leogr to the org.

This PR adds @poiana to it!