### PR TITLE
update(dbg): new drivers for new kernels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - run:
           name: Build drivers
           command: |
+            touch driverkit/output/failing.log
             DRIVERKIT_COMMIT=$(git log -1 --format=format:%H --full-diff -- driverkit/)
             if [ $CIRCLE_SHA1 = $DRIVERKIT_COMMIT ];
             then
@@ -59,10 +60,6 @@ workflows:
     jobs:
       - "driverkit/build":
           context: falco
-          filters:
-            branches:
-              only:
-                - master
       - "driverkit/publish":
           context: falco
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
-            cp output/failing.log /tmp/dbg-logs/failing.log
+            cp driverkit/output/failing.log /tmp/dbg-logs/failing.log
       - store_artifacts:
           path: /tmp/dbg-logs
           destination: /dbg-logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             if [ $CIRCLE_SHA1 = $DRIVERKIT_COMMIT ];
             then
               cd driverkit
-              make -j2 all
+              make all
             fi
       - run:
           name: Prepare artifacts

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -17,7 +17,7 @@ publish: $(addprefix publish_,$(VERSIONS))
 define gen_build_targets
 $(1): $(3)
 	@mkdir -p output/$(2)
-	@${DRIVERKIT} docker --loglevel=debug -c $(3) --driverversion $(2) --timeout 120 || echo $(3) >> output/failing.log
+	@${DRIVERKIT} docker --loglevel=debug -c $(3) --driverversion $(2) --timeout 1000 || echo $(3) >> output/failing.log
 endef
 $(foreach CONFIG,$(CONFIGS),\
 	$(eval INNER := $(patsubst config/%,%,$(CONFIG)))\

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -17,7 +17,7 @@ publish: $(addprefix publish_,$(VERSIONS))
 define gen_build_targets
 $(1): $(3)
 	@mkdir -p output/$(2)
-	@${DRIVERKIT} docker --loglevel=debug -c $(3) --driverversion $(2) || echo $(3) >> output/failing.log
+	@${DRIVERKIT} docker --loglevel=debug -c $(3) --driverversion $(2) --timeout 120 || echo $(3) >> output/failing.log
 endef
 $(foreach CONFIG,$(CONFIGS),\
 	$(eval INNER := $(patsubst config/%,%,$(CONFIG)))\

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.101-91.76.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.101-91.76.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.101-91.76.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.101-91.76.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.104-95.84.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.104-95.84.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.104-95.84.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.104-95.84.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.106-97.85.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.106-97.85.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.106-97.85.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.106-97.85.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.109-99.92.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.109-99.92.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.109-99.92.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.109-99.92.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.114-103.97.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.114-103.97.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.114-103.97.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.114-103.97.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.114-105.126.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.114-105.126.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.114-105.126.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.114-105.126.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.121-109.96.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.121-109.96.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.121-109.96.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.121-109.96.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.123-111.109.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.123-111.109.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.123-111.109.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.123-111.109.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.128-112.105.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.128-112.105.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.128-112.105.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.128-112.105.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.133-113.105.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.133-113.105.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.133-113.105.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.133-113.105.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.133-113.112.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.133-113.112.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.133-113.112.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.133-113.112.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.138-114.102.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.138-114.102.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.138-114.102.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.138-114.102.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.143-118.123.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.143-118.123.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.143-118.123.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.143-118.123.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.146-119.123.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.146-119.123.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.146-119.123.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.146-119.123.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.146-120.181.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.146-120.181.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.146-120.181.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.146-120.181.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.152-124.171.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.152-124.171.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.152-124.171.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.152-124.171.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.152-127.182.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.152-127.182.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.152-127.182.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.152-127.182.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.154-128.181.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.154-128.181.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.154-128.181.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.154-128.181.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.158-129.185.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.158-129.185.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.158-129.185.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.158-129.185.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.165-131.185.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.165-131.185.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.165-131.185.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.165-131.185.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.165-133.209.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.165-133.209.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.165-133.209.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.165-133.209.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.171-136.231.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.171-136.231.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.171-136.231.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.171-136.231.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.173-137.228.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.173-137.228.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.173-137.228.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.173-137.228.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.173-137.229.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.173-137.229.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.173-137.229.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.173-137.229.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.26-54.32.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.26-54.32.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.26-54.32.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.26-54.32.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.33-59.34.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.33-59.34.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.33-59.34.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.33-59.34.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.33-59.37.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.33-59.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.33-59.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.33-59.37.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.42-61.37.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.42-61.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.42-61.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.42-61.37.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.47-63.37.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.47-63.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.47-63.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.47-63.37.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.47-64.38.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.47-64.38.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.47-64.38.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.47-64.38.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.51-66.38.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.51-66.38.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.51-66.38.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.51-66.38.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.55-68.37.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.55-68.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.55-68.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.55-68.37.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.59-68.43.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.59-68.43.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.59-68.43.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.59-68.43.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.62-70.117.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.62-70.117.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.62-70.117.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.62-70.117.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.67-71.56.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.67-71.56.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.67-71.56.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.67-71.56.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.70-72.55.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.70-72.55.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.70-72.55.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.70-72.55.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.72-73.55.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.72-73.55.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.72-73.55.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.72-73.55.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.77-80.57.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.77-80.57.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.77-80.57.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.77-80.57.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.77-81.59.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.77-81.59.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.77-81.59.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.77-81.59.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.77-86.82.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.77-86.82.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.77-86.82.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.77-86.82.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.88-88.73.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.88-88.73.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.88-88.73.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.88-88.73.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.88-88.76.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.88-88.76.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.88-88.76.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.88-88.76.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.94-89.73.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.94-89.73.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.94-89.73.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.94-89.73.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.97-90.72.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.97-90.72.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.97-90.72.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.97-90.72.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.62-10.57.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.62-10.57.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.62-10.57.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.62-10.57.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.70-2.243.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.70-2.243.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.70-2.243.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.70-2.243.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.75-1.56.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.75-1.56.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.75-1.56.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.75-1.56.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.76-38.79.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.76-38.79.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.76-38.79.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.76-38.79.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.77-41.59.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.77-41.59.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.77-41.59.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.77-41.59.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.81-44.57.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.81-44.57.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.81-44.57.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.81-44.57.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.85-46.56.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.85-46.56.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.85-46.56.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.85-46.56.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.85-47.59.amzn2.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.9.85-47.59.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.85-47.59.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.85-47.59.amzn2.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/centos_2.6.32-754.14.2.el6.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/centos_2.6.32-754.14.2.el6.x86_64.yaml
@@ -1,4 +1,0 @@
-kernelrelease: 2.6.32-754.14.2.el6.x86_64
-target: centos
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_centos_2.6.32-754.14.2.el6.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/centos_3.10.0-957.12.2.el7.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/centos_3.10.0-957.12.2.el7.x86_64.yaml
@@ -1,4 +1,0 @@
-kernelrelease: 3.10.0-957.12.2.el7.x86_64
-target: centos
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_centos_3.10.0-957.12.2.el7.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/centos_4.18.0-147.5.1.el8_1.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/centos_4.18.0-147.5.1.el8_1.x86_64.yaml
@@ -1,4 +1,0 @@
-kernelrelease: 4.18.0-147.5.1.el8_1.x86_64
-target: centos
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_centos_4.18.0-147.5.1.el8_1.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_3.16.0-10-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_3.16.0-10-amd64.yaml
@@ -1,4 +1,4 @@
 kernelrelease: 3.16.0-10-amd64
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_3.16.0-10-amd64.ko
 target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_3.16.0-10-amd64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_3.16.0-6-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_3.16.0-6-amd64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 3.16.0-6-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_3.16.0-6-amd64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-0.bpo.6-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-0.bpo.6-amd64.yaml
@@ -1,5 +1,5 @@
 kernelrelease: 4.19.0-0.bpo.6-amd64
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-0.bpo.6-amd64.ko
-    probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-0.bpo.6-amd64.o
 target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-0.bpo.6-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-0.bpo.6-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-0.bpo.8-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-0.bpo.8-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 4.19.0-0.bpo.8-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-0.bpo.8-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-0.bpo.8-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-6-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-6-amd64.yaml
@@ -1,4 +1,5 @@
 kernelrelease: 4.19.0-6-amd64
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-6-amd64.ko
 target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-6-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-6-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-8-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.19.0-8-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 4.19.0-8-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-8-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.19.0-8-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.9.0-11-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.9.0-11-amd64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.0-11-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.9.0-11-amd64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.9.0-12-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_4.9.0-12-amd64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.0-12-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_4.9.0-12-amd64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-0.bpo.2-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-0.bpo.2-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.4.0-0.bpo.2-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-0.bpo.2-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-0.bpo.2-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-0.bpo.3-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-0.bpo.3-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.4.0-0.bpo.3-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-0.bpo.3-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-0.bpo.3-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-0.bpo.4-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-0.bpo.4-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.4.0-0.bpo.4-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-0.bpo.4-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-0.bpo.4-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-4-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.4.0-4-amd64.yaml
@@ -1,5 +1,0 @@
-kernelrelease: 5.4.0-4-amd64
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-4-amd64.ko
-    probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.4.0-4-amd64.o
-target: debian

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.5.0-1-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.5.0-1-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.5.0-1-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.5.0-1-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.5.0-1-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.5.0-2-amd64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/debian_5.5.0-2-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.5.0-2-amd64
+target: debian
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.5.0-2-amd64.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_debian_5.5.0-2-amd64.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-1057-aws_59.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-1057-aws_59.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-1057-aws
-kernelversion: 59
-target: ubuntu-aws
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-1057-aws_59.ko
-    probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-1057-aws_59.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-1063-aws_67.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-1063-aws_67.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-1063-aws
-kernelversion: 67
-target: ubuntu-aws
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-1063-aws_67.ko
-    probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-1063-aws_67.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-72-generic_81.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-72-generic_81.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-72-generic
-kernelversion: 81
-target: ubuntu-generic
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-72-generic_81.ko
-    probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-72-generic_81.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-91-generic_92.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.15.0-91-generic_92.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-91-generic
-kernelversion: 92
-target: ubuntu-generic
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-91-generic_92.ko
-    probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.15.0-91-generic_92.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.4.0-174-generic_204.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu_4.4.0-174-generic_204.yaml
@@ -1,5 +1,0 @@
-kernelrelease: 4.4.0-174-generic
-kernelversion: 204
-target: ubuntu-generic
-output:
-    module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu_4.4.0-174-generic_204.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.101-91.76.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.101-91.76.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.101-91.76.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.101-91.76.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.104-95.84.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.104-95.84.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.104-95.84.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.104-95.84.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.106-97.85.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.106-97.85.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.106-97.85.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.106-97.85.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.109-99.92.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.109-99.92.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.109-99.92.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.109-99.92.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.114-103.97.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.114-103.97.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.114-103.97.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.114-103.97.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.114-105.126.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.114-105.126.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.114-105.126.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.114-105.126.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.121-109.96.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.121-109.96.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.121-109.96.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.121-109.96.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.123-111.109.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.123-111.109.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.123-111.109.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.123-111.109.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.128-112.105.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.128-112.105.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.128-112.105.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.128-112.105.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.133-113.105.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.133-113.105.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.133-113.105.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.133-113.105.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.133-113.112.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.133-113.112.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.133-113.112.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.133-113.112.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.138-114.102.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.138-114.102.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.138-114.102.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.138-114.102.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.143-118.123.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.143-118.123.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.143-118.123.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.143-118.123.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.146-119.123.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.146-119.123.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.146-119.123.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.146-119.123.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.146-120.181.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.146-120.181.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.146-120.181.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.146-120.181.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.152-124.171.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.152-124.171.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.152-124.171.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.152-124.171.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.152-127.182.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.152-127.182.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.152-127.182.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.152-127.182.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.154-128.181.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.154-128.181.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.154-128.181.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.154-128.181.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.158-129.185.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.158-129.185.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.158-129.185.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.158-129.185.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.165-131.185.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.165-131.185.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.165-131.185.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.165-131.185.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.165-133.209.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.165-133.209.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.165-133.209.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.165-133.209.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.171-136.231.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.171-136.231.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.171-136.231.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.171-136.231.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.173-137.228.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.173-137.228.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.173-137.228.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.173-137.228.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.173-137.229.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.173-137.229.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.173-137.229.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.173-137.229.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.26-54.32.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.26-54.32.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.26-54.32.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.26-54.32.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.33-59.34.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.33-59.34.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.33-59.34.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.33-59.34.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.33-59.37.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.33-59.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.33-59.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.33-59.37.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.42-61.37.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.42-61.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.42-61.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.42-61.37.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.47-63.37.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.47-63.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.47-63.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.47-63.37.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.47-64.38.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.47-64.38.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.47-64.38.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.47-64.38.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.51-66.38.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.51-66.38.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.51-66.38.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.51-66.38.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.55-68.37.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.55-68.37.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.55-68.37.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.55-68.37.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.59-68.43.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.59-68.43.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.59-68.43.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.59-68.43.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.62-70.117.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.62-70.117.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.62-70.117.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.62-70.117.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.67-71.56.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.67-71.56.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.67-71.56.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.67-71.56.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.70-72.55.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.70-72.55.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.70-72.55.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.70-72.55.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.72-73.55.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.72-73.55.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.72-73.55.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.72-73.55.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.77-80.57.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.77-80.57.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.77-80.57.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.77-80.57.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.77-81.59.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.77-81.59.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.77-81.59.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.77-81.59.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.77-86.82.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.77-86.82.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.77-86.82.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.77-86.82.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.88-88.73.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.88-88.73.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.88-88.73.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.88-88.73.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.88-88.76.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.88-88.76.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.88-88.76.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.88-88.76.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.94-89.73.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.94-89.73.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.94-89.73.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.94-89.73.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.14.97-90.72.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.14.97-90.72.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.14.97-90.72.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.14.97-90.72.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.62-10.57.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.62-10.57.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.62-10.57.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.62-10.57.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.70-2.243.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.70-2.243.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.70-2.243.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.70-2.243.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.75-1.56.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.75-1.56.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.75-1.56.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.75-1.56.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.76-38.79.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.76-38.79.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.76-38.79.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.76-38.79.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.77-41.59.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.77-41.59.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.77-41.59.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.77-41.59.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.81-44.57.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.81-44.57.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.81-44.57.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.81-44.57.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.85-46.56.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.85-46.56.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.85-46.56.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.85-46.56.amzn2.x86_64.ko

--- a/driverkit/config/dev/amazonlinux2_4.9.85-47.59.amzn2.x86_64.yaml
+++ b/driverkit/config/dev/amazonlinux2_4.9.85-47.59.amzn2.x86_64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.85-47.59.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/dev/falco_amazonlinux2_4.9.85-47.59.amzn2.x86_64.ko

--- a/driverkit/config/dev/centos_2.6.32-754.14.2.el6.x86_64.yaml
+++ b/driverkit/config/dev/centos_2.6.32-754.14.2.el6.x86_64.yaml
@@ -1,4 +1,0 @@
-kernelrelease: 2.6.32-754.14.2.el6.x86_64
-target: centos
-output:
-    module: output/dev/falco_centos_2.6.32-754.14.2.el6.x86_64.ko

--- a/driverkit/config/dev/centos_3.10.0-957.12.2.el7.x86_64.yaml
+++ b/driverkit/config/dev/centos_3.10.0-957.12.2.el7.x86_64.yaml
@@ -1,4 +1,0 @@
-kernelrelease: 3.10.0-957.12.2.el7.x86_64
-target: centos
-output:
-    module: output/dev/falco_centos_3.10.0-957.12.2.el7.x86_64.ko

--- a/driverkit/config/dev/centos_4.18.0-147.5.1.el8_1.x86_64.yaml
+++ b/driverkit/config/dev/centos_4.18.0-147.5.1.el8_1.x86_64.yaml
@@ -1,4 +1,0 @@
-kernelrelease: 4.18.0-147.5.1.el8_1.x86_64
-target: centos
-output:
-    module: output/dev/falco_centos_4.18.0-147.5.1.el8_1.x86_64.ko

--- a/driverkit/config/dev/debian_3.16.0-10-amd64.yaml
+++ b/driverkit/config/dev/debian_3.16.0-10-amd64.yaml
@@ -1,4 +1,4 @@
 kernelrelease: 3.16.0-10-amd64
-output:
-    module: output/dev/falco_debian_3.16.0-10-amd64.ko
 target: debian
+output:
+  module: output/dev/falco_debian_3.16.0-10-amd64.ko

--- a/driverkit/config/dev/debian_3.16.0-6-amd64.yaml
+++ b/driverkit/config/dev/debian_3.16.0-6-amd64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 3.16.0-6-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_3.16.0-6-amd64.ko

--- a/driverkit/config/dev/debian_4.19.0-0.bpo.6-amd64.yaml
+++ b/driverkit/config/dev/debian_4.19.0-0.bpo.6-amd64.yaml
@@ -1,5 +1,5 @@
 kernelrelease: 4.19.0-0.bpo.6-amd64
-output:
-    module: output/dev/falco_debian_4.19.0-0.bpo.6-amd64.ko
-    probe: output/dev/falco_debian_4.19.0-0.bpo.6-amd64.o
 target: debian
+output:
+  module: output/dev/falco_debian_4.19.0-0.bpo.6-amd64.ko
+  probe: output/dev/falco_debian_4.19.0-0.bpo.6-amd64.o

--- a/driverkit/config/dev/debian_4.19.0-0.bpo.8-amd64.yaml
+++ b/driverkit/config/dev/debian_4.19.0-0.bpo.8-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 4.19.0-0.bpo.8-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_4.19.0-0.bpo.8-amd64.ko
+  probe: output/dev/falco_debian_4.19.0-0.bpo.8-amd64.o

--- a/driverkit/config/dev/debian_4.19.0-6-amd64.yaml
+++ b/driverkit/config/dev/debian_4.19.0-6-amd64.yaml
@@ -1,4 +1,5 @@
 kernelrelease: 4.19.0-6-amd64
-output:
-    module: output/dev/falco_debian_4.19.0-6-amd64.ko
 target: debian
+output:
+  module: output/dev/falco_debian_4.19.0-6-amd64.ko
+  probe: output/dev/falco_debian_4.19.0-6-amd64.o

--- a/driverkit/config/dev/debian_4.19.0-8-amd64.yaml
+++ b/driverkit/config/dev/debian_4.19.0-8-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 4.19.0-8-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_4.19.0-8-amd64.ko
+  probe: output/dev/falco_debian_4.19.0-8-amd64.o

--- a/driverkit/config/dev/debian_4.9.0-11-amd64.yaml
+++ b/driverkit/config/dev/debian_4.9.0-11-amd64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.0-11-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_4.9.0-11-amd64.ko

--- a/driverkit/config/dev/debian_4.9.0-12-amd64.yaml
+++ b/driverkit/config/dev/debian_4.9.0-12-amd64.yaml
@@ -1,0 +1,4 @@
+kernelrelease: 4.9.0-12-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_4.9.0-12-amd64.ko

--- a/driverkit/config/dev/debian_5.4.0-0.bpo.2-amd64.yaml
+++ b/driverkit/config/dev/debian_5.4.0-0.bpo.2-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.4.0-0.bpo.2-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_5.4.0-0.bpo.2-amd64.ko
+  probe: output/dev/falco_debian_5.4.0-0.bpo.2-amd64.o

--- a/driverkit/config/dev/debian_5.4.0-0.bpo.3-amd64.yaml
+++ b/driverkit/config/dev/debian_5.4.0-0.bpo.3-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.4.0-0.bpo.3-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_5.4.0-0.bpo.3-amd64.ko
+  probe: output/dev/falco_debian_5.4.0-0.bpo.3-amd64.o

--- a/driverkit/config/dev/debian_5.4.0-0.bpo.4-amd64.yaml
+++ b/driverkit/config/dev/debian_5.4.0-0.bpo.4-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.4.0-0.bpo.4-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_5.4.0-0.bpo.4-amd64.ko
+  probe: output/dev/falco_debian_5.4.0-0.bpo.4-amd64.o

--- a/driverkit/config/dev/debian_5.4.0-4-amd64.yaml
+++ b/driverkit/config/dev/debian_5.4.0-4-amd64.yaml
@@ -1,5 +1,0 @@
-kernelrelease: 5.4.0-4-amd64
-output:
-    module: output/dev/falco_debian_5.4.0-4-amd64.ko
-    probe: output/dev/falco_debian_5.4.0-4-amd64.o
-target: debian

--- a/driverkit/config/dev/debian_5.5.0-1-amd64.yaml
+++ b/driverkit/config/dev/debian_5.5.0-1-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.5.0-1-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_5.5.0-1-amd64.ko
+  probe: output/dev/falco_debian_5.5.0-1-amd64.o

--- a/driverkit/config/dev/debian_5.5.0-2-amd64.yaml
+++ b/driverkit/config/dev/debian_5.5.0-2-amd64.yaml
@@ -1,0 +1,5 @@
+kernelrelease: 5.5.0-2-amd64
+target: debian
+output:
+  module: output/dev/falco_debian_5.5.0-2-amd64.ko
+  probe: output/dev/falco_debian_5.5.0-2-amd64.o

--- a/driverkit/config/dev/ubuntu_4.15.0-1057-aws_59.yaml
+++ b/driverkit/config/dev/ubuntu_4.15.0-1057-aws_59.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-1057-aws
-kernelversion: 59
-target: ubuntu-aws
-output:
-    module: output/dev/falco_ubuntu_4.15.0-1057-aws_59.ko
-    probe: output/dev/falco_ubuntu_4.15.0-1057-aws_59.o

--- a/driverkit/config/dev/ubuntu_4.15.0-1063-aws_67.yaml
+++ b/driverkit/config/dev/ubuntu_4.15.0-1063-aws_67.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-1063-aws
-kernelversion: 67
-target: ubuntu-aws
-output:
-    module: output/dev/falco_ubuntu_4.15.0-1063-aws_67.ko
-    probe: output/dev/falco_ubuntu_4.15.0-1063-aws_67.o

--- a/driverkit/config/dev/ubuntu_4.15.0-72-generic_81.yaml
+++ b/driverkit/config/dev/ubuntu_4.15.0-72-generic_81.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-72-generic
-kernelversion: 81
-target: ubuntu-generic
-output:
-    module: output/dev/falco_ubuntu_4.15.0-72-generic_81.ko
-    probe: output/dev/falco_ubuntu_4.15.0-72-generic_81.o

--- a/driverkit/config/dev/ubuntu_4.15.0-91-generic_92.yaml
+++ b/driverkit/config/dev/ubuntu_4.15.0-91-generic_92.yaml
@@ -1,6 +1,0 @@
-kernelrelease: 4.15.0-91-generic
-kernelversion: 92
-target: ubuntu-generic
-output:
-    module: output/dev/falco_ubuntu_4.15.0-91-generic_92.ko
-    probe: output/dev/falco_ubuntu_4.15.0-91-generic_92.o

--- a/driverkit/config/dev/ubuntu_4.4.0-174-generic_204.yaml
+++ b/driverkit/config/dev/ubuntu_4.4.0-174-generic_204.yaml
@@ -1,5 +1,0 @@
-kernelrelease: 4.4.0-174-generic
-kernelversion: 204
-target: ubuntu-generic
-output:
-    module: output/dev/falco_ubuntu_4.4.0-174-generic_204.ko


### PR DESCRIPTION
This PR aims to update the prebuilt drivers (kernel modules and eBPF probes) for new kernels.

It also removes the config that we can't build anymore for.

- [x] debian
- [x] amazon linux 2
- [ ] centos
- [ ] ubuntu
- [ ] amazon linux

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>