### PR TITLE
Prow for contrib repo

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -54,6 +54,10 @@ branch-protection:
           branches:
             master:
               protect: true
+        contrib:
+          branches:
+            master:
+              protect: true
         driverkit:
           branches:
             master:
@@ -116,6 +120,7 @@ tide:
     falcosecurity/cloud-native-security-hub-frontend: rebase
     falcosecurity/cloud-native-security-hub-backend: rebase
     falcosecurity/community: rebase
+    falcosecurity/contrib: rebase
     falcosecurity/driverkit: rebase
     falcosecurity/event-generator: rebase
     falcosecurity/falco: rebase
@@ -266,6 +271,18 @@ tide:
     - needs-rebase
   - repos:
     - falcosecurity/community
+    labels:
+    - approved
+    - lgtm
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - falcosecurity/contrib
     labels:
     - approved
     - lgtm

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -97,6 +97,9 @@ branch-protection:
           branches:
             master:
               protect: true
+            required_status_checks:
+              contexts:
+                - "netlify/falcosecurity/deploy-preview"
         template-repository:
           branches:
             master:

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -14,6 +14,7 @@ branch-protection:
     strict: false # we don't want to block any PR if it's not up to date, we have the rebase merge strategy and needs-rebase plugin
   orgs:
     falcosecurity:
+      # dco check is required for all PRs of any falcosecurity project
       required_status_checks:
         contexts:
           - dco
@@ -30,9 +31,9 @@ branch-protection:
           branches:
             master:
               protect: true
-            required_status_checks:
-              contexts:
-                - "ci/circleci: test"
+          required_status_checks:
+            contexts:
+              - "ci/circleci: test"
         client-py:
           branches:
             master:
@@ -86,9 +87,9 @@ branch-protection:
           branches:
             master:
               protect: true
-            required_status_checks:
-              contexts:
-                - "ci/circleci: test"
+          required_status_checks:
+            contexts:
+              - "ci/circleci: test"
         falcoctl:
           branches:
             master:
@@ -97,9 +98,9 @@ branch-protection:
           branches:
             master:
               protect: true
-            required_status_checks:
-              contexts:
-                - "netlify/falcosecurity/deploy-preview"
+          required_status_checks:
+            contexts:
+              - "netlify/falcosecurity/deploy-preview"
         template-repository:
           branches:
             master:
@@ -108,6 +109,9 @@ branch-protection:
           branches:
             master:
               protect: true
+          required_status_checks:
+            contexts:
+              - "ci/circleci: build"
 
 log_level: debug
 

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -83,6 +83,9 @@ branch-protection:
           branches:
             master:
               protect: true
+            required_status_checks:
+              contexts:
+                - "ci/circleci: test"
         falcoctl:
           branches:
             master:

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -30,6 +30,9 @@ branch-protection:
           branches:
             master:
               protect: true
+            required_status_checks:
+              contexts:
+                - "ci/circleci: test"
         client-py:
           branches:
             master:

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -9,6 +9,7 @@ approve:
       - falcosecurity/cloud-native-security-hub-frontend
       - falcosecurity/cloud-native-security-hub-backend
       - falcosecurity/community
+      - falcosecurity/contrib
       - falcosecurity/driverkit
       - falcosecurity/event-generator
       - falcosecurity/falco
@@ -52,6 +53,7 @@ lgtm:
       - falcosecurity/cloud-native-security-hub-frontend
       - falcosecurity/cloud-native-security-hub-backend
       - falcosecurity/community
+      - falcosecurity/contrib
       - falcosecurity/driverkit
       - falcosecurity/event-generator
       - falcosecurity/falco
@@ -126,6 +128,14 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: cloud-native-security-hub-backend
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: contrib
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -381,6 +391,26 @@ plugins:
     - verify-owners
     - welcome
     - wip
+  falcosecurity/community:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - dog
+    - goose
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - require-matching-label
+    - retitle
+    - size
+    - verify-owners
+    - welcome
+    - wip
   falcosecurity/driverkit:
     - approve
     - assign
@@ -586,6 +616,10 @@ external_plugins:
       events:
         - pull_request
   falcosecurity/community:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/contrib:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
As decided during [yesterday's community call](https://github.com/falcosecurity/community/blob/master/meeting-notes/2020-04-15.md), we're going to move out from the main Falco repository its `integrations/` directory.

Refs https://github.com/falcosecurity/falco/issues/1114

That directory contains example YAML for using Falco with Kubernetes, or other configs/installation means and examples.

Moving them into the https://github.com/falcosecurity/contrib repository means that such artifacts do not make officially part of any new upcoming Falco release.

But this does not mean they will be abandoned: the community will contribute and maintain them.

The first maintainer for such effort is:
- https://github.com/maxgio92 (already in the org and in the OWNERS file of `contrib` repo) 🙇 

Next steps:

as soon this is merged in, https://github.com/maxgio92 can start moving the `integrations/` into https://github.com/falcosecurity/contrib repo

---

Aside from that this PR also instructs @poiana (tide bot) of some GitHub checks to look at on PRs of various repositories of the organization.