### PR TITLE
check drivers config conventions + new drivers

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -16,6 +16,7 @@ publish: $(addprefix publish_,$(VERSIONS))
 # $(3): config file path
 define gen_build_targets
 $(1): $(3)
+	utils/checkfiles $(3)
 	@mkdir -p output/$(2)
 	@${DRIVERKIT} docker --loglevel=debug -c $(3) --driverversion $(2) --timeout 1000 || echo $(3) >> output/failing.log
 endef

--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.177-139.254.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.ko

--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-aws_5.3.0-1019-aws_21.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-aws_5.3.0-1019-aws_21.yaml
@@ -1,0 +1,6 @@
+kernelversion: 21
+kernelrelease: 5.3.0-1019-aws
+target: ubuntu-aws
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-aws_5.3.0-1019-aws_21.ko
+  probe: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-aws_5.3.0-1019-aws_21.o

--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-aws_5.4.0-1011-aws_11.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-aws_5.4.0-1011-aws_11.yaml
@@ -1,0 +1,6 @@
+kernelversion: 11
+kernelrelease: 5.4.0-1011-aws
+target: ubuntu-aws
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-aws_5.4.0-1011-aws_11.ko
+  probe: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-aws_5.4.0-1011-aws_11.o

--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-generic_4.15.0-101-generic_102.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-generic_4.15.0-101-generic_102.yaml
@@ -1,0 +1,6 @@
+kernelversion: 102
+kernelrelease: 4.15.0-101-generic
+target: ubuntu-generic
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-generic_4.15.0-101-generic_102.ko
+  probe: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-generic_4.15.0-101-generic_102.o

--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-generic_5.3.0-53-generic_47.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-generic_5.3.0-53-generic_47.yaml
@@ -1,0 +1,6 @@
+kernelversion: 47
+kernelrelease: 5.3.0-53-generic
+target: ubuntu-generic
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-generic_5.3.0-53-generic_47.ko
+  probe: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-generic_5.3.0-53-generic_47.o

--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-generic_5.4.0-31-generic_35.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/ubuntu-generic_5.4.0-31-generic_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 5.4.0-31-generic
+target: ubuntu-generic
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-generic_5.4.0-31-generic_35.ko
+  probe: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_ubuntu-generic_5.4.0-31-generic_35.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.177-139.253.amzn2.x86_64_1.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.177-139.253.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.177-139.253.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_amazonlinux2_4.14.177-139.253.amzn2.x86_64_1.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.177-139.254.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-aws_5.3.0-1019-aws_21.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-aws_5.3.0-1019-aws_21.yaml
@@ -1,0 +1,6 @@
+kernelversion: 21
+kernelrelease: 5.3.0-1019-aws
+target: ubuntu-aws
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-aws_5.3.0-1019-aws_21.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-aws_5.3.0-1019-aws_21.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-aws_5.4.0-1011-aws_11.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-aws_5.4.0-1011-aws_11.yaml
@@ -1,0 +1,6 @@
+kernelversion: 11
+kernelrelease: 5.4.0-1011-aws
+target: ubuntu-aws
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-aws_5.4.0-1011-aws_11.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-aws_5.4.0-1011-aws_11.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-generic_4.15.0-101-generic_102.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-generic_4.15.0-101-generic_102.yaml
@@ -1,0 +1,6 @@
+kernelversion: 102
+kernelrelease: 4.15.0-101-generic
+target: ubuntu-generic
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-generic_4.15.0-101-generic_102.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-generic_4.15.0-101-generic_102.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-generic_5.3.0-53-generic_47.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-generic_5.3.0-53-generic_47.yaml
@@ -1,0 +1,6 @@
+kernelversion: 47
+kernelrelease: 5.3.0-53-generic
+target: ubuntu-generic
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-generic_5.3.0-53-generic_47.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-generic_5.3.0-53-generic_47.o

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-generic_5.4.0-31-generic_35.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/ubuntu-generic_5.4.0-31-generic_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 5.4.0-31-generic
+target: ubuntu-generic
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-generic_5.4.0-31-generic_35.ko
+  probe: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_ubuntu-generic_5.4.0-31-generic_35.o

--- a/driverkit/utils/checkfiles
+++ b/driverkit/utils/checkfiles
@@ -15,16 +15,25 @@ output_probe=
 create_variables "$input"
 
 # Check whether the config filename follows the convention otherwise exit
-[ "$filename" = "${target}_${kernelrelease}_${kernelversion}.yaml" ] || >&2 echo "config filename is wrong (${1})"
+if [ "$filename" != "${target}_${kernelrelease}_${kernelversion}.yaml" ]; then
+    >&2 echo "config filename is wrong (${1})"
+    exit 1
+fi
 
 # Check whether the eBPF probe filename follows the convention otherwise exit
 if [ -n "${output_probe}" ]; then
     output_probe_filename="${output_probe##*/}"
-    [ "${output_probe_filename}" = "falco_${target}_${kernelrelease}_${kernelversion}.o" ] || >&2 echo "output probe filename is wrong (${1})"
+    if [ "${output_probe_filename}" != "falco_${target}_${kernelrelease}_${kernelversion}.o" ]; then
+        >&2 echo "output probe filename is wrong (${1})"
+        exit 1
+    fi
 fi
 
 # Check whether the kernel module filename follows the convention otherwise exit
 if [ -n "${output_module}" ]; then
     output_module_filename="${output_module##*/}"
-    [ "${output_module_filename}" = "falco_${target}_${kernelrelease}_${kernelversion}.ko" ] || >&2 echo "output module filename is wrong (${1})"
+    if [ "${output_module_filename}" != "falco_${target}_${kernelrelease}_${kernelversion}.ko" ]; then
+        >&2 echo "output module filename is wrong (${1})"
+        exit 1
+    fi
 fi

--- a/driverkit/utils/checkfiles
+++ b/driverkit/utils/checkfiles
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+currentdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+source "${currentdir}/parseyaml"
+
+input="$1"
+filename="${input##*/}"
+
+target=
+kernelrelease=
+kernelversion=
+output_module=
+output_probe=
+create_variables "$input"
+
+# Check whether the config filename follows the convention otherwise exit
+[ "$filename" = "${target}_${kernelrelease}_${kernelversion}.yaml" ] || >&2 echo "config filename is wrong (${1})"
+
+# Check whether the eBPF probe filename follows the convention otherwise exit
+if [ -n "${output_probe}" ]; then
+    output_probe_filename="${output_probe##*/}"
+    [ "${output_probe_filename}" = "falco_${target}_${kernelrelease}_${kernelversion}.o" ] || >&2 echo "output probe filename is wrong (${1})"
+fi
+
+# Check whether the kernel module filename follows the convention otherwise exit
+if [ -n "${output_module}" ]; then
+    output_module_filename="${output_module##*/}"
+    [ "${output_module_filename}" = "falco_${target}_${kernelrelease}_${kernelversion}.ko" ] || >&2 echo "output module filename is wrong (${1})"
+fi

--- a/driverkit/utils/parseyaml
+++ b/driverkit/utils/parseyaml
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1003
+
+parse_yaml() {
+    local yaml_file=$1
+    local prefix=$2
+    local s
+    local w
+    local fs
+
+    s='[[:space:]]*'
+    w='[a-zA-Z0-9_.-]*'
+    fs="$(echo @|tr @ '\034')"
+
+    (
+        sed -e '/- [^\“]'"[^\']"'.*: /s|\([ ]*\)- \([[:space:]]*\)|\1-\'$'\n''  \1\2|g' |
+
+        sed -ne '/^--/s|--||g; s|\"|\\\"|g; s/[[:space:]]*$//g;' \
+            -e "/#.*[\"\']/!s| #.*||g; /^#/s|#.*||g;" \
+            -e "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+            -e "s|^\($s\)\($w\)${s}[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" |
+
+        awk -F"$fs" '{
+            indent = length($1)/2;
+            if (length($2) == 0) { conj[indent]="+";} else {conj[indent]="";}
+            vname[indent] = $2;
+            for (i in vname) {if (i > indent) {delete vname[i]}}
+                if (length($3) > 0) {
+                    vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+                    printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1],$3);
+                }
+            }' |
+
+        sed -e 's/_=/+=/g' |
+
+        awk 'BEGIN {
+                FS="=";
+                OFS="="
+            }
+            /(-|\.).*=/ {
+                gsub("-|\\.", "_", $1)
+            }
+            { print }'
+    ) < "$yaml_file"
+}
+
+create_variables() {
+    local yaml_file="$1"
+    local prefix="$2"
+    eval "$(parse_yaml "$yaml_file" "$prefix")"
+}


### PR DESCRIPTION
Introduced a script to checks:
- the config file names are correct - ie., `config/${driver_version}/${target}_${kernelrelease}_${kernelversion}.yaml`
- the kernel module driver name is correct. - ie., `falco_${target}_${kernelrelease}_${kernelversion}.ko`
- the eBPF probe driver name is correct - ie., `falco_${target}_${kernelrelease}_${kernelversion}.o`

Also, this PR, adds some new drivers for `ubuntu-aws`, `ubuntu-generic`, and `amazonlinux2`.