### PR TITLE
contrib -> evolution

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -62,7 +62,7 @@ branch-protection:
           branches:
             master:
               protect: true
-        contrib:
+        evolution:
           branches:
             master:
               protect: true
@@ -142,7 +142,7 @@ tide:
     falcosecurity/cloud-native-security-hub-frontend: rebase
     falcosecurity/cloud-native-security-hub-backend: rebase
     falcosecurity/community: rebase
-    falcosecurity/contrib: rebase
+    falcosecurity/evolution: rebase
     falcosecurity/driverkit: rebase
     falcosecurity/event-generator: rebase
     falcosecurity/falco: rebase
@@ -153,279 +153,279 @@ tide:
     falcosecurity/template-repository: rebase
     falcosecurity/test-infra: rebase
   queries:
-  - repos:
-    - falcosecurity/.github
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/advocacy
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/charts
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/client-go
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/driverkit
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/event-generator
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/falco
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/client-py
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/client-rs
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/cloud-native-security-hub
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/cloud-native-security-hub-frontend
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/cloud-native-security-hub-backend
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/community
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/contrib
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/falco
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/falco-exporter
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/falco
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/falcoctl
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
-    - needs-rebase
-  - repos:
-    - falcosecurity/falco-website
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/pdig
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/test-infra
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-  - repos:
-    - falcosecurity/template-repository
-    labels:
-    - approved
-    - lgtm
-    - "dco-signoff: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
+    - repos:
+        - falcosecurity/.github
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/advocacy
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/charts
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/client-go
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/driverkit
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/event-generator
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/falco
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/client-py
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/client-rs
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/cloud-native-security-hub
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/cloud-native-security-hub-frontend
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/cloud-native-security-hub-backend
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/community
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/evolution
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/falco
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/falco-exporter
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/falco
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/falcoctl
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/falco-website
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/pdig
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/test-infra
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/template-repository
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -10,7 +10,7 @@ approve:
       - falcosecurity/cloud-native-security-hub-frontend
       - falcosecurity/cloud-native-security-hub-backend
       - falcosecurity/community
-      - falcosecurity/contrib
+      - falcosecurity/evolution
       - falcosecurity/driverkit
       - falcosecurity/event-generator
       - falcosecurity/falco
@@ -43,6 +43,10 @@ label:
   additional_labels:
     - kind/pr
     - kind/issue
+    # Custom kind/* lables for evolution repository
+    - kind/sandbox
+    - kind/incubation
+    - kind/officialsupport
 
 lgtm:
   - repos:
@@ -56,7 +60,7 @@ lgtm:
       - falcosecurity/cloud-native-security-hub-frontend
       - falcosecurity/cloud-native-security-hub-backend
       - falcosecurity/community
-      - falcosecurity/contrib
+      - falcosecurity/evolution
       - falcosecurity/driverkit
       - falcosecurity/event-generator
       - falcosecurity/falco
@@ -149,7 +153,7 @@ require_matching_label:
       In case you do not know which kind this proposal is please mention the maintainers using `@team/maintainers`.
   - missing_label: needs-kind
     org: falcosecurity
-    repo: contrib
+    repo: evolution
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -415,7 +419,7 @@ plugins:
     - verify-owners
     - welcome
     - wip
-  falcosecurity/contrib:
+  falcosecurity/evolution:
     - approve
     - assign
     - blunderbuss
@@ -668,7 +672,7 @@ external_plugins:
     - name: needs-rebase
       events:
         - pull_request
-  falcosecurity/contrib:
+  falcosecurity/evolution:
     - name: needs-rebase
       events:
         - pull_request

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -41,9 +41,7 @@ goose:
 
 label:
   additional_labels:
-    - kind/pr
-    - kind/issue
-    # Custom kind/* lables for evolution repository
+    # Custom kind/* labels for evolution repository
     - kind/sandbox
     - kind/incubation
     - kind/officialsupport


### PR DESCRIPTION
This PR is related to https://github.com/falcosecurity/contrib/pull/24 about the renaming of the `contrib` repo to `evolution`.

Furthermore, it adds custom `kind/sandbox` etc. labels for it (as per https://github.com/falcosecurity/contrib/issues/14),

while at the same moment it also deletes custom `kind/pr` and `kind/issues` labels for https://github.com/falcosecurity/community (which ISSUE_TEMPLATEs do not use anymore).