### PR TITLE
feat(driverkit): Add rhel/openshift kernel

### DIFF
--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/rhel-openshift_3.10.0-1127.8.2.el7.x86_64.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/rhel-openshift_3.10.0-1127.8.2.el7.x86_64.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 3.10.0-1127.8.2.el7.x86_64
+target: centos
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_rhel-openshift_3.10.0-1127.8.2.el7.x86_64.ko

--- a/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/rhel-openshift_3.10.0-1127.8.2.el7.x86_64.yaml
+++ b/driverkit/config/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/rhel-openshift_3.10.0-1127.8.2.el7.x86_64.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 3.10.0-1127.8.2.el7.x86_64
+target: centos
+output:
+  module: output/a259b4bf49c3330d9ad6c3eed9eb1a31954259a6/falco_rhel-openshift_3.10.0-1127.8.2.el7.x86_64.ko


### PR DESCRIPTION
This is used by OpenShift 4.3.x on IBM Cloud

Signed-off-by: Spencer Krum <nibz@spencerkrum.com>


Details from a node:

```
root@shell:/# uname -r
3.10.0-1127.8.2.el7.x86_64
root@shell:/# uname -v
#1 SMP Thu May 7 19:30:37 EDT 2020
```

I have no idea if I've done this correctly. Sorry in advance if not!
