### PR TITLE
fix(driverkit): workspace during publish drivers must not contain file names with same name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
-            cp driverkit/output/failing.log /tmp/dbg-logs/failing-amazonlinux.log
+            mv driverkit/output/failing.log /tmp/dbg-logs/failing-amazonlinux.log
       - store_artifacts:
           path: /tmp/dbg-logs
           destination: /dbg-logs
@@ -58,7 +58,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
-            cp driverkit/output/failing.log /tmp/dbg-logs/failing-amazonlinux2.log
+            mv driverkit/output/failing.log /tmp/dbg-logs/failing-amazonlinux2.log
       - store_artifacts:
           path: /tmp/dbg-logs
           destination: /dbg-logs
@@ -91,7 +91,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
-            cp driverkit/output/failing.log /tmp/dbg-logs/failing-centos.log
+            mv driverkit/output/failing.log /tmp/dbg-logs/failing-centos.log
       - store_artifacts:
           path: /tmp/dbg-logs
           destination: /dbg-logs
@@ -124,7 +124,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
-            cp driverkit/output/failing.log /tmp/dbg-logs/failing-debian.log
+            mv driverkit/output/failing.log /tmp/dbg-logs/failing-debian.log
       - store_artifacts:
           path: /tmp/dbg-logs
           destination: /dbg-logs
@@ -157,7 +157,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
-            cp driverkit/output/failing.log /tmp/dbg-logs/failing-ubuntu-aws.log
+            mv driverkit/output/failing.log /tmp/dbg-logs/failing-ubuntu-aws.log
       - store_artifacts:
           path: /tmp/dbg-logs
           destination: /dbg-logs
@@ -190,7 +190,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
-            cp driverkit/output/failing.log /tmp/dbg-logs/failing-ubuntu-generic.log
+            mv driverkit/output/failing.log /tmp/dbg-logs/failing-ubuntu-generic.log
       - store_artifacts:
           path: /tmp/dbg-logs
           destination: /dbg-logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
+            rm -f driverkit/output/.gitignore
             mv driverkit/output/failing.log /tmp/dbg-logs/failing-amazonlinux.log
       - store_artifacts:
           path: /tmp/dbg-logs
@@ -58,6 +59,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
+            rm -f driverkit/output/.gitignore
             mv driverkit/output/failing.log /tmp/dbg-logs/failing-amazonlinux2.log
       - store_artifacts:
           path: /tmp/dbg-logs
@@ -91,6 +93,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
+            rm -f driverkit/output/.gitignore
             mv driverkit/output/failing.log /tmp/dbg-logs/failing-centos.log
       - store_artifacts:
           path: /tmp/dbg-logs
@@ -124,6 +127,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
+            rm -f driverkit/output/.gitignore
             mv driverkit/output/failing.log /tmp/dbg-logs/failing-debian.log
       - store_artifacts:
           path: /tmp/dbg-logs
@@ -157,6 +161,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
+            rm -f driverkit/output/.gitignore
             mv driverkit/output/failing.log /tmp/dbg-logs/failing-ubuntu-aws.log
       - store_artifacts:
           path: /tmp/dbg-logs
@@ -190,6 +195,7 @@ jobs:
           name: Prepare artifacts
           command: |
             mkdir -p /tmp/dbg-logs
+            rm -f driverkit/output/.gitignore
             mv driverkit/output/failing.log /tmp/dbg-logs/failing-ubuntu-generic.log
       - store_artifacts:
           path: /tmp/dbg-logs
@@ -240,7 +246,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - fix/ci-publish # temporary test
           requires:
             - "driverkit/build/amazonlinux"
             - "driverkit/build/amazonlinux2"

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -5,7 +5,7 @@ DRIVERKIT ?= $(shell which driverkit)
 CONFIGS := $(wildcard config/*/*.yaml)
 VERSIONS := $(patsubst config/%,%,$(sort $(dir $(wildcard config/*/))))
 VERSIONS := $(VERSIONS:/=)
-TARGET_DISTRO ?= 
+TARGET_DISTRO ?=
 
 all: $(patsubst config_%,%,$(subst /,_,$(CONFIGS)))
 


### PR DESCRIPTION
- Avoid duplicated .gitignore files for the CircleC workspaces to be merged without conflicts
- Rename failing.log files (for the same reason)