### PR TITLE
Put the CI branch filters (for driverkit/publish job) back to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ workflows:
           filters:
             branches:
               only:
-                - fix/ci-publish # temporary test
+                - master
           requires:
             - "driverkit/build/amazonlinux"
             - "driverkit/build/amazonlinux2"


### PR DESCRIPTION
put the CI branch filters (for driverkit/publish job) back to normal, ie. `master` branch.

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>