### PR TITLE
Prow setup for falcosidekick

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -64,11 +64,11 @@ branch-protection:
           branches:
             master:
               protect: true
-        evolution:
+        driverkit:
           branches:
             master:
               protect: true
-        driverkit:
+        evolution:
           branches:
             master:
               protect: true
@@ -86,6 +86,10 @@ branch-protection:
             contexts:
               - "ci/circleci: integration"
               - "ci/circleci: centos7"
+          branches:
+            master:
+              protect: true
+        falcosidekick:
           branches:
             master:
               protect: true
@@ -149,10 +153,11 @@ tide:
     falcosecurity/cloud-native-security-hub-frontend: rebase
     falcosecurity/cloud-native-security-hub-backend: rebase
     falcosecurity/community: rebase
-    falcosecurity/evolution: rebase
     falcosecurity/driverkit: rebase
+    falcosecurity/evolution: rebase
     falcosecurity/event-generator: rebase
     falcosecurity/falco: rebase
+    falcosecurity/falcosidekick: rebase
     falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
     falcosecurity/falco-website: rebase
@@ -209,18 +214,6 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
-        - needs-rebase
-    - repos:
-        - falcosecurity/driverkit
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
         - needs-rebase
     - repos:
         - falcosecurity/event-generator
@@ -325,6 +318,18 @@ tide:
         - do-not-merge/work-in-progress
         - needs-rebase
     - repos:
+        - falcosecurity/driverkit
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
         - falcosecurity/evolution
       labels:
         - approved
@@ -350,7 +355,20 @@ tide:
         - do-not-merge/release-note-label-needed
         - needs-rebase
     - repos:
-        - falcosecurity/falco-exporter
+        - falcosecurity/falcosidekick
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/falcoctl
       labels:
         - approved
         - lgtm
@@ -376,7 +394,7 @@ tide:
         - do-not-merge/release-note-label-needed
         - needs-rebase
     - repos:
-        - falcosecurity/falcoctl
+        - falcosecurity/falco-exporter
       labels:
         - approved
         - lgtm

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -14,8 +14,9 @@ approve:
       - falcosecurity/driverkit
       - falcosecurity/event-generator
       - falcosecurity/falco
-      - falcosecurity/falco-exporter
       - falcosecurity/falcoctl
+      - falcosecurity/falcosidekick
+      - falcosecurity/falco-exporter
       - falcosecurity/falco-website
       - falcosecurity/pdig
       - falcosecurity/template-repository
@@ -62,8 +63,9 @@ lgtm:
       - falcosecurity/driverkit
       - falcosecurity/event-generator
       - falcosecurity/falco
-      - falcosecurity/falco-exporter
       - falcosecurity/falcoctl
+      - falcosecurity/falcosidekick
+      - falcosecurity/falco-exporter
       - falcosecurity/falco-website
       - falcosecurity/pdig
       - falcosecurity/template-repository
@@ -151,7 +153,7 @@ require_matching_label:
       In case you do not know which kind this proposal is please mention the maintainers using `@team/maintainers`.
   - missing_label: needs-kind
     org: falcosecurity
-    repo: evolution
+    repo: driverkit
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -159,7 +161,7 @@ require_matching_label:
       Please specify it either using `/kind <group>` or manually from the side menu.
   - missing_label: needs-kind
     org: falcosecurity
-    repo: driverkit
+    repo: evolution
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -180,6 +182,14 @@ require_matching_label:
     regexp: ^kind/
     missing_comment: |
       There is not a label identifying the kind of this issue.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: falcosidekick
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
       Please specify it either using `/kind <group>` or manually from the side menu.
   - missing_label: needs-kind
     org: falcosecurity
@@ -504,6 +514,29 @@ plugins:
     - verify-owners
     - welcome
     - wip
+  falcosecurity/falcosidekick:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - dog
+    - golint
+    - goose
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - mergecommitblocker
+    - release-note
+    - require-matching-label
+    - retitle
+    - size
+    - verify-owners
+    - welcome
+    - wip
   falcosecurity/falco-exporter:
     - approve
     - assign
@@ -670,11 +703,11 @@ external_plugins:
     - name: needs-rebase
       events:
         - pull_request
-  falcosecurity/evolution:
+  falcosecurity/driverkit:
     - name: needs-rebase
       events:
         - pull_request
-  falcosecurity/driverkit:
+  falcosecurity/evolution:
     - name: needs-rebase
       events:
         - pull_request
@@ -683,6 +716,10 @@ external_plugins:
       events:
         - pull_request
   falcosecurity/falco:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/falcosidekick:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
Depends on https://github.com/falcosecurity/falcosidekick/pull/65 and https://github.com/falcosecurity/falcosidekick/pull/64.

Fixes https://github.com/falcosecurity/test-infra/issues/146.

---

Plugins:
- approve
- assign
- blunderbuss
- branchcleaner
- cat
- dco
- golint
- goose
- help
- hold
- label
- lifecycle
- lgtm
- release-note
- mergecommitblocker
- require-matching-label
- size
- verify-owners
- welcome
- wip

Labels:

- At least a "kind/*" label
Protected branches:

- master

Merging strategy:

- rebase

PR checks & auto-merge (tide):

- must be "approved"
- must have a "lgtm" review
- commits must be signed-off (DCO)
- must NOT have "do-not-merge/*" labels
- must NOT have "needs-rebase" label

## TODOs

- [x] create `kind/*` labels on the repo
- [ ] get PRs on falcosidekick merged in