### PR TITLE
remove release-note plugin for falcosidekick

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -365,7 +365,6 @@ tide:
         - do-not-merge/hold
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
         - needs-rebase
     - repos:
         - falcosecurity/falcoctl

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -530,7 +530,6 @@ plugins:
     - lifecycle
     - lgtm
     - mergecommitblocker
-    - release-note
     - require-matching-label
     - retitle
     - size


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

This deletes the `release-note` plugin for https://github.com/falcosecurity/falcosidekick since @Issif expressed the desire to do not have it.

Fixes #149 