### PR TITLE
override (and disable) the pull request reviews for falcosecurity/charts#gh-pages branch

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -1,6 +1,6 @@
 branch-protection:
   enforce_admins: true # rules apply to admins too!
-  restrictions:
+  restrictions: # restrict who can push
     teams: ["maintainers", "machine_users"]
   required_pull_request_reviews:
     dismiss_stale_reviews: true # automat dismiss old reviews
@@ -33,6 +33,9 @@ branch-protection:
               protect: true
             gh-pages:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: false
+                required_approving_review_count: 0
         client-go:
           branches:
             master:

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -33,7 +33,7 @@ branch-protection:
               protect: true
             gh-pages:
               protect: true
-              required_pull_request_reviews:
+              required_pull_request_reviews: # disable PR reviews since our bot needs to push while the CI workflow is running
                 require_code_owner_reviews: false
                 required_approving_review_count: 0
         client-go:


### PR DESCRIPTION
In an attempt to let @poiana push to `gh-pages` branch of `falcosecurity/charts` as per @leogr needs about the charts release process.

The idea here is to remove the need of (at least 1) reviewer on pull-requests.

Note that the `gh-pages` branch is still protected but users in `maintainers` and bot dedicated GitHub teams can still push to it.

As per branchprotector [docs](https://github.com/kubernetes/test-infra/tree/8c8546d74168a57d0a3d22b17d98eb09bbf70601/prow/cmd/branchprotector#scope) bool/int values should override (not merge) with parent hierarchical YAML keys.

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>