### PR TITLE
new: prebuild module for amazonlinux2 amzn2_4.14.181-142.260_1

### DIFF
--- a/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.yaml
+++ b/driverkit/config/96bd9bc560f67742738eb7255aeb4d03046b8045/amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.181-142.260.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/96bd9bc560f67742738eb7255aeb4d03046b8045/falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.ko


### PR DESCRIPTION
The 4.14.181-142.260.amzn2.x86_64_1 version (`/aws/service/eks/optimized-ami/1.15/amazon-linux-2/recommended/image_id` (ami-0f433dffa73f54ea2) is not available at https://dl.bintray.com/falcosecurity/driver/96bd9bc560f67742738eb7255aeb4d03046b8045/ and therefore the community is not able to deploy falco-probe with eks-1.15 ami

Signed-off-by: Fahad Arshad <fahad.arshad@hobsons.com>