### PR TITLE
update(prow/config): no status check for evolution repo

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -75,9 +75,6 @@ branch-protection:
           branches:
             master:
               protect: true
-          required_status_checks:
-            contexts:
-              - "ci/circleci: test"
         event-generator:
           branches:
             master:


### PR DESCRIPTION
The [falcosecurity/evolution](https://github.com/falcosecurity/evolution) repository has no CircleCI integration. Moreover, no status check is required.

Furthermore, since this check was introduced by https://github.com/falcosecurity/test-infra/commit/996f17d777045cadefb83707cebe636b0002b54f with message `new: driverkit checks for circleci`, I guess it was added in the wrong place by mistake, and `driverkit` is currently missing that.
