### PR TITLE
remove release-note plugin for event-generator and falco-exporter

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -484,7 +484,6 @@ plugins:
     - lifecycle
     - lgtm
     - require-matching-label
-    - release-note
     - retitle
     - size
     - verify-owners

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -551,7 +551,6 @@ plugins:
     - label
     - lifecycle
     - lgtm
-    - release-note
     - require-matching-label
     - retitle
     - size


### PR DESCRIPTION
Since both `event-generator` and `falco-exporter` (that I'm maintaining) are using goreleaser to handle the changelog ([here](https://github.com/falcosecurity/falco-exporter/releases/tag/v0.2.0) an example) I'd like to do not have the `release-note` block.

I believe the changelog based on the commit message is already enough to document changes of these two relatively small tools. 