### PR TITLE
update(prow/config): do not enforce restrictions for admins in `gh-pages` of `charts` repo

### DIFF
--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -33,6 +33,7 @@ branch-protection:
               protect: true
             gh-pages:
               protect: true
+              enforce_admins: false # do not enforce all configured restrictions for admins, since our bot needs to push while the CI workflow is running
               required_pull_request_reviews: # disable PR reviews since our bot needs to push while the CI workflow is running
                 require_code_owner_reviews: false
                 required_approving_review_count: 0


### PR DESCRIPTION
As we discovered, [this setting]() is not enough to allow @poiana to push on a protected branch, since GH still requires that commits pass thru a PR.

For the reason above, and since @poiana is an admin user, with this PR we are disabling the enforcement of the restrictions for admins only on the `gh-pages` of https://github.com/falcosecurity/charts

The `enforce_admins` parameter description can be found here: https://developer.github.com/v3/repos/branches/#parameters-1

The reason why we need this in described in the [charts release.md doc](https://github.com/falcosecurity/charts/blob/master/release.md#circleci-workflow) and the action (that will be performed by @poiana) is coded [here](https://github.com/falcosecurity/charts/blob/c657933144fbfdf1bef9e12040492119128d98c8/.circleci/release.sh#L74-L80).

/cc @leodido 