### PR TITLE
New custom external Prow plugin (saymyname)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ This assumes that you are in the `prow` directory and that you can reach your wo
 
 4. Setup the hook
 
-    4.1. Install the `add-hook` tool
+    4.1. Install the `update-hook` tool
 
     ```bash
-	go get -u k8s.io/test-infra/experiment/add-hook
+	go get -u k8s.io/test-infra/experiment/update-hook
     ```
 
     4.2. Attach it to the organisation using `--repo` flag (or to a precise repo using `MY_ORG/MY_REPO` convention)
 
     ```bash
-	add-hook --hmac-path=path/to/hmac/secret --github-token-path=path/to/oauth/secret --hook-url http://an.ip.addr.ess/hook --repo MY_ORG --confirm=true
+	update-hook --hmac-path=path/to/hmac/secret --github-token-path=path/to/oauth/secret --hook-url http://an.ip.addr.ess/hook --repo MY_ORG --confirm=true
     ```
 
 5. Setup or update your plugins and configs with

--- a/prow/cluster/saymyname.yaml
+++ b/prow/cluster/saymyname.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: saymyname
+spec:
+  selector:
+    app: saymyname
+  ports:
+    - port: 8787
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: saymyname
+  labels:
+    app: saymyname
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: saymyname
+  template:
+    metadata:
+      labels:
+        app: saymyname
+    spec:
+      serviceAccountName: "hook"
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: saymyname
+          image: leodido/saymyname-prow-plugin:latest
+          imagePullPolicy: Always
+          args:
+            - --dry-run=false
+            - --github-token-path=/etc/github/oauth
+          ports:
+            - name: http
+              containerPort: 8787
+          volumeMounts:
+            - name: hmac
+              mountPath: /etc/webhook
+              readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            timeoutSeconds: 600
+      volumes:
+        - name: hmac
+          secret:
+            secretName: hmac-token
+        - name: oauth
+          secret:
+            secretName: oauth-token

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -509,6 +509,7 @@ plugins:
     - release-note
     - require-matching-label
     - retitle
+    - saymyname
     - size
     - verify-owners
     - welcome
@@ -716,6 +717,10 @@ external_plugins:
     - name: needs-rebase
       events:
         - pull_request
+    - name: saymyname
+      endpoint: http://saymyname.default.svc.cluster.local:8787
+      events:
+        - issue_comment
   falcosecurity/falcosidekick:
     - name: needs-rebase
       events:


### PR DESCRIPTION
For my talk at [KubeCon Europe 2020](https://sched.co/ZenU), I am prepping a custom Prow external plugin in order to show the audience how to create one and further extend the already awesome [Prow](https://github.com/kubernetes/test-infra/blob/master/prow) features.

So, I just made this last-minute attempt to create a plugin for our beloved @poiana that introduces the `/poiana` slash command.

With this PR, I add some YAML specs (🧶  YAML engineering!), and configure the abovementioned custom external plugin.

You can find its source code at https://github.com/leodido/saymyname-prow-plugin