### PR TITLE
fix(prow/config): remove external plugin from the list of prow plugins

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -509,7 +509,6 @@ plugins:
     - release-note
     - require-matching-label
     - retitle
-    - saymyname
     - size
     - verify-owners
     - welcome


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

They don't have to be in that list (look at needs-rebase for example).