### PR TITLE
Initial stats command for the Drivers Build Grid

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -64,3 +64,6 @@ $(foreach VERSION,$(VERSIONS),\
 .PHONY: clean
 clean:
 	@find output -type f -not -name '.gitignore' -delete
+
+stats:
+	@utils/driverstats $(CONFIGS)

--- a/driverkit/utils/checkfiles
+++ b/driverkit/utils/checkfiles
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1090
 
 currentdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 

--- a/driverkit/utils/driverstats
+++ b/driverkit/utils/driverstats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090
+
+currentdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+source "${currentdir}/parseyaml"
+
+configs=("$@")
+
+total_ebpf_drivers=0
+total_kmod_drivers=0
+
+for file in "${configs[@]}"
+do
+    output_module=
+    output_probe=
+    create_variables "$file"
+    if [ -n "${output_probe}" ]; then
+        ((total_ebpf_drivers=total_ebpf_drivers+1))
+    fi
+    if [ -n "${output_module}" ]; then
+        ((total_kmod_drivers=total_kmod_drivers+1))
+    fi
+done
+
+echo -e "eBPF probes:${total_ebpf_drivers}\nkernel modules:${total_kmod_drivers}" | column -t -s':'


### PR DESCRIPTION
This PR introduces an (initial) script to generate some numbers about the prebuilt drivers.

For now, it just aggregates the number of prebuilt eBPF probes and the number of prebuilt kernel modules we tentatively (in case they build successfully) ship for Falco.

Anyways, here there are some simple ideas that can be built on top of this skeleton script:

- segment the number of prebuilt drivers by driver version
- count the number of prebuilt drivers by distro
- count the number of prebuilt drivers by kernel release major