### PR TITLE
Automatic drivers cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,21 @@ jobs:
               cd driverkit
               make publish
             fi
+  "drivers/cleanup":
+    docker:
+      - image: docker.bintray.io/jfrog/jfrog-cli-go:latest
+    steps:
+      - checkout
+      - run:
+          name: Prepare env
+          command: |
+            apk add --no-cache --update
+            apk add curl jq
+      - run:
+          name: Cleanup
+          command: |
+              cd driverkit
+              make cleanup
 workflows:
   version: 2
   build:
@@ -254,3 +269,11 @@ workflows:
             - "drivers/build/debian"
             - "drivers/build/ubuntu-aws"
             - "drivers/build/ubuntu-generic"
+      - "drivers/cleanup":
+          context: falco
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - "drivers/publish"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  "driverkit/build/amazonlinux":
+  "drivers/build/amazonlinux":
     docker:
       - image: docker.io/falcosecurity/driverkit:latest
     steps:
@@ -34,7 +34,7 @@ jobs:
           root: driverkit
           paths:
             - output
-  "driverkit/build/amazonlinux2":
+  "drivers/build/amazonlinux2":
     docker:
       - image: docker.io/falcosecurity/driverkit:latest
     steps:
@@ -68,7 +68,7 @@ jobs:
           root: driverkit
           paths:
             - output
-  "driverkit/build/centos":
+  "drivers/build/centos":
     docker:
       - image: docker.io/falcosecurity/driverkit:latest
     steps:
@@ -102,7 +102,7 @@ jobs:
           root: driverkit
           paths:
             - output
-  "driverkit/build/debian":
+  "drivers/build/debian":
     docker:
       - image: docker.io/falcosecurity/driverkit:latest
     steps:
@@ -136,7 +136,7 @@ jobs:
           root: driverkit
           paths:
             - output
-  "driverkit/build/ubuntu-aws":
+  "drivers/build/ubuntu-aws":
     docker:
       - image: docker.io/falcosecurity/driverkit:latest
     steps:
@@ -170,7 +170,7 @@ jobs:
           root: driverkit
           paths:
             - output
-  "driverkit/build/ubuntu-generic":
+  "drivers/build/ubuntu-generic":
     docker:
       - image: docker.io/falcosecurity/driverkit:latest
     steps:
@@ -204,7 +204,7 @@ jobs:
           root: driverkit
           paths:
             - output
-  "driverkit/publish":
+  "drivers/publish":
     docker:
       - image: docker.bintray.io/jfrog/jfrog-cli-go:latest
     steps:
@@ -229,28 +229,28 @@ workflows:
   version: 2
   build:
     jobs:
-      - "driverkit/build/amazonlinux":
+      - "drivers/build/amazonlinux":
           context: falco
-      - "driverkit/build/amazonlinux2":
+      - "drivers/build/amazonlinux2":
           context: falco
-      - "driverkit/build/centos":
+      - "drivers/build/centos":
           context: falco
-      - "driverkit/build/debian":
+      - "drivers/build/debian":
           context: falco
-      - "driverkit/build/ubuntu-aws":
+      - "drivers/build/ubuntu-aws":
           context: falco
-      - "driverkit/build/ubuntu-generic":
+      - "drivers/build/ubuntu-generic":
           context: falco
-      - "driverkit/publish":
+      - "drivers/publish":
           context: falco
           filters:
             branches:
               only:
                 - master
           requires:
-            - "driverkit/build/amazonlinux"
-            - "driverkit/build/amazonlinux2"
-            - "driverkit/build/centos"
-            - "driverkit/build/debian"
-            - "driverkit/build/ubuntu-aws"
-            - "driverkit/build/ubuntu-generic"
+            - "drivers/build/amazonlinux"
+            - "drivers/build/amazonlinux2"
+            - "drivers/build/centos"
+            - "drivers/build/debian"
+            - "drivers/build/ubuntu-aws"
+            - "drivers/build/ubuntu-generic"

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -14,6 +14,9 @@ specific_target: $(patsubst config_%,%,$(subst /,_,$(wildcard config/*/${TARGET_
 prepare: $(addprefix prepare_,$(VERSIONS))
 publish: $(addprefix publish_,$(VERSIONS))
 
+cleanup:
+	utils/cleanup -p ${BINTRAY_SECRET} $(addprefix -v ,$(VERSIONS))
+
 # $(1): pseudo-target name
 # $(2): driver version
 # $(3): config file path

--- a/driverkit/utils/cleanup
+++ b/driverkit/utils/cleanup
@@ -14,15 +14,15 @@ filterout_versions() {
         printf "%s\t%s\n" "$i" "${all[$i]}"
         if [[ ! " ${keep[*]}" =~  ${all[$i]} ]]; then
             printf " \tremoving..."
-            yes N | JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/kernel-module/${all[$i]}" # --quiet (remove yes)
-            yes N | JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/ebpf-probe/${all[$i]}" # --quiet (remove yes)
+            JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/kernel-module/${all[$i]}" --quiet
+            JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/ebpf-probe/${all[$i]}" -quiet
             unset -v 'all[$i]'
         fi
     done
 }
 
 usage() {
-    echo "usage: $0 -p 123 -v \"abcd efgh\""
+    echo "usage: $0 -p 123 -v abcd -v efgh"
 }
 
 while getopts ":p::v:" opt; do

--- a/driverkit/utils/cleanup
+++ b/driverkit/utils/cleanup
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+user=poiana
+
+# Assuming the drivers versions of Falco eBPF probes and Falco kernel modules are always in pair.
+# For this reason, obtain all the version by only querying the Falco kernel modules versions.
+get_bintray_versions() {
+    IFS=$'\n' read -r -d '' -a all < <(curl -s -u "${user}:${pass}" --header "Content-Type: application/json" https://api.bintray.com/packages/falcosecurity/driver/kernel-module | jq -r '.versions | .[]')
+}
+
+filterout_versions() {
+    for i in "${!all[@]}";
+    do
+        printf "%s\t%s\n" "$i" "${all[$i]}"
+        if [[ ! " ${keep[*]}" =~  ${all[$i]} ]]; then
+            printf " \tremoving..."
+            yes N | JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/kernel-module/${all[$i]}" # --quiet (remove yes)
+            yes N | JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/ebpf-probe/${all[$i]}" # --quiet (remove yes)
+            unset -v 'all[$i]'
+        fi
+    done
+}
+
+usage() {
+    echo "usage: $0 -p 123 -v \"abcd efgh\""
+}
+
+while getopts ":p::v:" opt; do
+    case "${opt}" in
+        p )
+          pass=${OPTARG}
+          ;;
+        v )
+          keep+=("${OPTARG}")
+          ;;
+        : )
+          echo "invalid option: ${OPTARG} requires an argument" 1>&2
+          exit 1
+          ;;
+        \?)
+          echo "invalid option: ${OPTARG}" 1>&2
+          exit 1
+          ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${pass}" ] || [ "${#keep[@]}" -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+get_bintray_versions
+echo "# versions: ${#all[@]}"
+filterout_versions

--- a/driverkit/utils/cleanup
+++ b/driverkit/utils/cleanup
@@ -14,8 +14,8 @@ filterout_versions() {
         printf "%s\t%s\n" "$i" "${all[$i]}"
         if [[ ! " ${keep[*]}" =~  ${all[$i]} ]]; then
             printf " \tremoving..."
-            JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/kernel-module/${all[$i]}" --quiet
-            JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --user "${user}" --key "${pass}" "falcosecurity/driver/ebpf-probe/${all[$i]}" -quiet
+            JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --quiet --user "${user}" --key "${pass}" "falcosecurity/driver/kernel-module/${all[$i]}"
+            JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --quiet --user "${user}" --key "${pass}" "falcosecurity/driver/ebpf-probe/${all[$i]}"
             unset -v 'all[$i]'
         fi
     done


### PR DESCRIPTION
This PR introduces:

- a script into `driverkit/utils` that (given the bintray secret plus a list of driver versions to keep) queries bintray API to obtain all the existing driver versions and filter them out by keeping only the two driver versions specified as input
- a make command that calls the above script specifying the bintray secret and passes to it the driver versions currently in the `driverkit/config` directory
- adds to the CI a job (`drivers/cleanup`) that puts all the pieces together and runs on every merge into master

