### PR TITLE
new: prebuilt module for ubuntu-aws 5.4.0-1024-aws_24

### DIFF
--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-aws_5.4.0-1024-aws_24.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-aws_5.4.0-1024-aws_24.yaml
@@ -1,0 +1,6 @@
+kernelversion: 24
+kernelrelease: 5.4.0-1024-aws
+target: ubuntu-aws
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-aws_5.4.0-1024-aws_24.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-aws_5.4.0-1024-aws_24.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-aws_5.4.0-1024-aws_24.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-aws_5.4.0-1024-aws_24.yaml
@@ -1,0 +1,6 @@
+kernelversion: 24
+kernelrelease: 5.4.0-1024-aws
+target: ubuntu-aws
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-aws_5.4.0-1024-aws_24.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-aws_5.4.0-1024-aws_24.o


### PR DESCRIPTION
```
* Trying to download prebuilt module from https://dl.bintray.com/falcosecurity/driver/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-aws_5.4.0-1024-aws_24.ko
curl: (22) The requested URL returned error: 404 Not Found
Download failed, consider compiling your own falco module and loading it or getting in touch with the Falco community
```

This should fix my issue.