### PR TITLE
new: prebuild module for bottlerocketos_5.4.50_1

### DIFF
--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/bottlerocket_5.4.50_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/bottlerocket_5.4.50_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.50
+target: bottlerocket
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_bottlerocket_5.4.50_1.ko


### PR DESCRIPTION
Signed-off-by: Fahad Arshad <fahad.arshad@hobsons.com>

This is for bottlerocketos with the AMI name `bottlerocket-aws-k8s-1.16-x86_64-v1.0.1-2a181156`.