### PR TITLE
update(driverkit/config): bump drivers to September 30th 2020

### DIFF
--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-0.bpo.6-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-0.bpo.6-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.6-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-0.bpo.6-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-0.bpo.6-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-0.bpo.8-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-0.bpo.8-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.8-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-0.bpo.8-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-0.bpo.8-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-0.bpo.9-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-0.bpo.9-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.9-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-0.bpo.9-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-0.bpo.9-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-10-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-10-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-10-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-10-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-10-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-11-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-11-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-11-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-11-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-11-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-6-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-6-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-6-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-6-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-6-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-8-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-8-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-8-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-8-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-8-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-9-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_4.19.0-9-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-9-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-9-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_4.19.0-9-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.4.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.4.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.4.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.4.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.4.0-0.bpo.3-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.4.0-0.bpo.3-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.3-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.4.0-0.bpo.3-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.4.0-0.bpo.3-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.4.0-0.bpo.4-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.4.0-0.bpo.4-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.4-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.4.0-0.bpo.4-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.4.0-0.bpo.4-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.5.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.5.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.5.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.5.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.5.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.6.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.6.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.6.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.6.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.6.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.7.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.7.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.7.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.7.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.7.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-0.bpo.2-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-0.bpo.2-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-0.bpo.2-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-0.bpo.2-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-0.bpo.2-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-2-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-2-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-2-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-2-cloud-amd64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-aws_4.4.0-1116-aws_129.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-aws_4.4.0-1116-aws_129.yaml
@@ -1,0 +1,5 @@
+kernelversion: 129
+kernelrelease: 4.4.0-1116-aws
+target: ubuntu-aws
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-aws_4.4.0-1116-aws_129.ko

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.4.0-192-generic_222.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.4.0-192-generic_222.yaml
@@ -1,0 +1,5 @@
+kernelversion: 222
+kernelrelease: 4.4.0-192-generic
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.4.0-192-generic_222.ko

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-0.bpo.6-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-0.bpo.6-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.6-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-0.bpo.6-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-0.bpo.6-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-0.bpo.8-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-0.bpo.8-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.8-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-0.bpo.8-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-0.bpo.8-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-0.bpo.9-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-0.bpo.9-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.9-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-0.bpo.9-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-0.bpo.9-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-10-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-10-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-10-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-10-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-10-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-11-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-11-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-11-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-11-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-11-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-6-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-6-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-6-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-6-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-6-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-8-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-8-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-8-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-8-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-8-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-9-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_4.19.0-9-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-9-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-9-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_4.19.0-9-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.4.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.4.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.4.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.4.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.4.0-0.bpo.3-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.4.0-0.bpo.3-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.3-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.4.0-0.bpo.3-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.4.0-0.bpo.3-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.4.0-0.bpo.4-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.4.0-0.bpo.4-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.4-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.4.0-0.bpo.4-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.4.0-0.bpo.4-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.5.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.5.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.5.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.5.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.5.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.6.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.6.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.6.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.6.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.6.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.7.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.7.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.7.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.7.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.7.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-0.bpo.2-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-0.bpo.2-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-0.bpo.2-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-0.bpo.2-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-0.bpo.2-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-2-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-2-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-2-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-2-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-aws_4.4.0-1116-aws_129.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-aws_4.4.0-1116-aws_129.yaml
@@ -1,0 +1,5 @@
+kernelversion: 129
+kernelrelease: 4.4.0-1116-aws
+target: ubuntu-aws
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-aws_4.4.0-1116-aws_129.ko

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.4.0-192-generic_222.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.4.0-192-generic_222.yaml
@@ -1,0 +1,5 @@
+kernelversion: 222
+kernelrelease: 4.4.0-192-generic
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.4.0-192-generic_222.ko

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-0.bpo.6-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-0.bpo.6-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.6-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-0.bpo.6-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-0.bpo.6-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-0.bpo.8-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-0.bpo.8-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.8-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-0.bpo.8-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-0.bpo.8-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-0.bpo.9-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-0.bpo.9-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-0.bpo.9-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-0.bpo.9-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-0.bpo.9-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-10-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-10-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-10-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-10-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-10-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-11-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-11-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-11-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-11-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-11-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-6-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-6-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-6-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-6-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-6-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-8-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-8-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-8-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-8-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-8-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-9-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_4.19.0-9-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 4.19.0-9-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-9-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_4.19.0-9-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.4.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.4.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.4.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.4.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.4.0-0.bpo.3-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.4.0-0.bpo.3-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.3-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.4.0-0.bpo.3-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.4.0-0.bpo.3-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.4.0-0.bpo.4-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.4.0-0.bpo.4-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-0.bpo.4-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.4.0-0.bpo.4-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.4.0-0.bpo.4-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.5.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.5.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.5.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.5.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.5.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.6.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.6.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.6.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.6.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.6.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.7.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.7.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.7.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.7.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.7.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-0.bpo.2-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-0.bpo.2-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-0.bpo.2-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-0.bpo.2-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-0.bpo.2-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-0.bpo.2-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-0.bpo.2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-0.bpo.2-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-0.bpo.2-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-0.bpo.2-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-2-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-2-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-2-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-2-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-2-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-aws_4.4.0-1116-aws_129.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-aws_4.4.0-1116-aws_129.yaml
@@ -1,0 +1,5 @@
+kernelversion: 129
+kernelrelease: 4.4.0-1116-aws
+target: ubuntu-aws
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-aws_4.4.0-1116-aws_129.ko

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.4.0-192-generic_222.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.4.0-192-generic_222.yaml
@@ -1,0 +1,5 @@
+kernelversion: 222
+kernelrelease: 4.4.0-192-generic
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.4.0-192-generic_222.ko


### PR DESCRIPTION
Adding the `cloud-amd64` drivers too as described in
falcosecurity/driverkit#72


Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>