### PR TITLE
Enable poiana for falcosecurity/kilt

### DIFF
--- a/proposals/20200915-prow.md
+++ b/proposals/20200915-prow.md
@@ -4,18 +4,20 @@ This document reflects the way we test Falco Security using Prow, and how it sho
 
 ## Terms & Definitions
 
-- [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) is an open source testing framework built on top on Kubernetes.
+- [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) is an open-source testing framework built on top on Kubernetes.
 
 ## Motivation
 
 Today Falco pull requests use github automation for labels via Prow. The proposal is to fully setup prow testing infrastructure on top of AWS to utilize the functional testing aspect of prow. This will provide users, and maintainers a streamlined way to display test results, and control testing workflows.
 
 ## Goals
-- To Setup test workflow for [Falco](https://github.com/falcosecurity/falco) and repositories needing testing on EKS
-- Provide community visibility on falco compatability through test results
-## Non-Goals
-- To replace the existing CICD pipeline
 
+- To Setup test workflow for [Falco](https://github.com/falcosecurity/falco) and repositories needing testing on EKS
+- Provide community visibility on Falco compatibility through test results
+
+## Non-Goals
+
+- To replace the existing CICD pipeline
 
 ## Proposal
 
@@ -24,7 +26,6 @@ Today Falco pull requests use github automation for labels via Prow. The proposa
 - Provide central UI for checking test logs/results during PR's
 - Provide distributed method for handling PR merging.
 - Utilize Github PR commands to control testing workflow such as re-tests
-
 
 ### Prerequisites
 Install Prow on AWS EKS, the only prerequisite is that we have an AWS account, and an S3 bucket to store artifacts for Prow.

--- a/prow/config/configs.yaml
+++ b/prow/config/configs.yaml
@@ -113,6 +113,10 @@ branch-protection:
           required_status_checks:
             contexts:
               - "netlify/falcosecurity/deploy-preview"
+        kilt:
+          branches:
+            master:
+              protect: true
         pdig:
           branches:
             master:
@@ -163,6 +167,7 @@ tide:
     falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
     falcosecurity/falco-website: rebase
+    falcosecurity/kilt: rebase
     falcosecurity/pdig: rebase
     falcosecurity/template-repository: rebase
     falcosecurity/test-infra: rebase
@@ -409,6 +414,18 @@ tide:
         - needs-rebase
     - repos:
         - falcosecurity/falco-website
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/kilt
       labels:
         - approved
         - lgtm

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -625,7 +625,8 @@ plugins:
     - lifecycle
     - lgtm
     - mergecommitblocker
-    - milestone
+    - release-note
+    - require-matching-label
     - retitle
     - size
     - verify-owners

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -18,6 +18,7 @@ approve:
       - falcosecurity/falcosidekick
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
+      - falcosecurity/kilt
       - falcosecurity/pdig
       - falcosecurity/template-repository
       - falcosecurity/test-infra
@@ -67,6 +68,7 @@ lgtm:
       - falcosecurity/falcosidekick
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
+      - falcosecurity/kilt
       - falcosecurity/pdig
       - falcosecurity/template-repository
       - falcosecurity/test-infra
@@ -210,6 +212,14 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: falco-website
+    issues: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this issue.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: kilt
     issues: true
     regexp: ^kind/
     missing_comment: |
@@ -600,6 +610,27 @@ plugins:
     - verify-owners
     - welcome
     - wip
+  falcosecurity/kilt:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - dog
+    - goose
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - mergecommitblocker
+    - milestone
+    - retitle
+    - size
+    - verify-owners
+    - welcome
+    - wip
   falcosecurity/pdig:
     - approve
     - assign
@@ -733,6 +764,10 @@ external_plugins:
       events:
         - pull_request
   falcosecurity/falco-website:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/kilt:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
This PR adds @poiana (stop the drama!) to the [pdig](https://github.com/falcosecurity/pdig) repository.

Plugins:
- approve
- assign
- blunderbuss
- branchcleaner
- cat
- dco
- dog 
- goose
- help
- hold
- label
- lifecycle
- lgtm
- mergecommitblocker
- release-note (needs PR templates to contain release-note block)
- require-matching-label (needs PR templates to contain /kind <label>)
- retitle
- size
- verify-owners
- welcome
- wip

Labels:

- At least a "kind/*" label

Protected branches:

- master

Merging strategy:

- rebase

PR checks & auto-merge (tide):

- must be "approved"
- must have a "lgtm" review
- commits must be signed-off (DCO)
- must NOT have "do-not-merge/*" labels
- must NOT have "needs-rebase" label