### PR TITLE
lifecycle bot

### DIFF
--- a/config/jobs/lifecycle-bot/periodic-close.yaml
+++ b/config/jobs/lifecycle-bot/periodic-close.yaml
@@ -1,0 +1,39 @@
+periodics:
+  - name: periodic-close
+    interval: 1h
+    decorate: true
+    annotations:
+      description: Closes rotten issues after 30d of inactivity
+    agent: kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20201116-dbd60ab192
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:falcosecurity
+              -label:lifecycle/frozen
+              label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/github/oauth
+            - |-
+              --comment=Rotten issues close after 30d of inactivity.
+
+              Reopen the issue with `/reopen`.
+
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+              Provide feedback via https://github.com/falcosecurity/community.
+              /close
+            - --template
+            - --confirm
+            - --ceiling=10
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+      volumes:
+        - name: oauth
+          secret:
+          secretName: oauth-token

--- a/config/jobs/lifecycle-bot/periodic-close.yaml
+++ b/config/jobs/lifecycle-bot/periodic-close.yaml
@@ -1,6 +1,6 @@
 periodics:
   - name: periodic-close
-    interval: 1h
+    interval: 6h
     decorate: true
     annotations:
       description: Closes rotten issues after 30d of inactivity

--- a/config/jobs/lifecycle-bot/periodic-rotten.yaml
+++ b/config/jobs/lifecycle-bot/periodic-rotten.yaml
@@ -1,0 +1,42 @@
+periodics:
+  - name: periodic-rotten
+    interval: 1h
+    decorate: false
+    annotations:
+      description: ...
+    agent: kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20201116-dbd60ab192
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:falcosecurity
+              -label:lifecycle/frozen
+              label:lifecycle/stale
+              -label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/github/oauth
+            - |-
+              --comment=Stale issues rot after 30d of inactivity.
+
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+              Rotten issues close after an additional 30d of inactivity.
+
+              If this issue is safe to close now please do so with `/close`.
+
+              Provide feedback via https://github.com/falcosecurity/community.
+
+              /lifecycle rotten
+            - --template
+            - --confirm
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+          volumes:
+            - name: oauth
+              secret:
+              secretName: oauth-token

--- a/config/jobs/lifecycle-bot/periodic-rotten.yaml
+++ b/config/jobs/lifecycle-bot/periodic-rotten.yaml
@@ -1,6 +1,6 @@
 periodics:
   - name: periodic-rotten
-    interval: 1h
+    interval: 6h
     decorate: false
     annotations:
       description: ...

--- a/config/jobs/lifecycle-bot/periodic-stale.yaml
+++ b/config/jobs/lifecycle-bot/periodic-stale.yaml
@@ -1,0 +1,43 @@
+periodics:
+  - name: periodic-stale
+    interval: 1h
+    decorate: true
+    annotations:
+      description: Adds lifecycle/stale to issues after 90d of inactivity
+    agent: kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20201116-dbd60ab192
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:falcosecurity
+              -label:lifecycle/frozen
+              -label:lifecycle/stale
+              -label:lifecycle/rotten
+            - --updated=2160h
+            - --token=/etc/github/oauth
+            - |-
+              --comment=Issues go stale after 90d of inactivity.
+
+              Mark the issue as fresh with `/remove-lifecycle stale`.
+
+              Stale issues rot after an additional 30d of inactivity and eventually close.
+
+              If this issue is safe to close now please do so with `/close`.
+
+              Provide feedback via https://github.com/falcosecurity/community.
+
+              /lifecycle stale
+            - --template
+            - --confirm
+            - --ceiling=10
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+      volumes:
+        - name: oauth
+          secret:
+            secretName: oauth-token

--- a/config/jobs/lifecycle-bot/periodic-stale.yaml
+++ b/config/jobs/lifecycle-bot/periodic-stale.yaml
@@ -1,6 +1,6 @@
 periodics:
   - name: periodic-stale
-    interval: 1h
+    interval: 6h
     decorate: true
     annotations:
       description: Adds lifecycle/stale to issues after 90d of inactivity


### PR DESCRIPTION
Fixes #40 (where you can find detailed information about the resulting behavior of these 2 periodic `ProwJob`s.)

The lifecycle transitions are:

1. issue or PR becomes stale after 90 days of inactivity
2. stale issue or PR becomes rotten after 30 days of inactivity
3. rotten issues close after 30 days of inactivity

WIP because some points are still open:

- [ ] should we build and publish our `commenter` image?
- [ ] disable existing GitHub stale bot action