### PR TITLE
Fix drivers build jobs triggers

### DIFF
--- a/config/jobs/build-drivers/build-drivers.yaml
+++ b/config/jobs/build-drivers/build-drivers.yaml
@@ -6,7 +6,7 @@ presubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit\/(?!README.md)'
+    run_if_changed: '^driverkit\/'
     spec:
       containers:
       - command:
@@ -25,7 +25,7 @@ presubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit\/(?!README.md)'
+    run_if_changed: '^driverkit\/'
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ presubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit\/(?!README.md)'
+    run_if_changed: '^driverkit\/'
     spec:
       containers:
       - command:
@@ -63,7 +63,7 @@ presubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit\/(?!README.md)'
+    run_if_changed: '^driverkit\/'
     spec:
       containers:
       - command:
@@ -82,7 +82,7 @@ presubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit\/(?!README.md)'
+    run_if_changed: '^driverkit\/'
     spec:
       containers:
       - command:
@@ -101,7 +101,7 @@ presubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit\/(?!README.md)'
+    run_if_changed: '^driverkit\/'
     spec:
       containers:
       - command:

--- a/config/jobs/build-drivers/build-drivers.yaml
+++ b/config/jobs/build-drivers/build-drivers.yaml
@@ -2,7 +2,8 @@ presubmits:
   falcosecurity/test-infra:
   - name: build-drivers-amazonlinux-presubmit
     decorate: true
-    skip_report: false
+    always_run: false
+    skip_report: true
     agent: kubernetes
     branches:
       - ^master$
@@ -21,7 +22,8 @@ presubmits:
           privileged: true
   - name: build-drivers-amazonlinux2-presubmit
     decorate: true
-    skip_report: false
+    always_run: false
+    skip_report: true
     agent: kubernetes
     branches:
       - ^master$
@@ -40,7 +42,8 @@ presubmits:
           privileged: true
   - name: build-drivers-centos-presubmit
     decorate: true
-    skip_report: false
+    always_run: false
+    skip_report: true
     agent: kubernetes
     branches:
       - ^master$
@@ -59,7 +62,8 @@ presubmits:
           privileged: true
   - name: build-drivers-debian-presubmit
     decorate: true
-    skip_report: false
+    always_run: false
+    skip_report: true
     agent: kubernetes
     branches:
       - ^master$
@@ -78,7 +82,8 @@ presubmits:
           privileged: true
   - name: build-drivers-ubuntu-aws-presubmit
     decorate: true
-    skip_report: false
+    always_run: false
+    skip_report: true
     agent: kubernetes
     branches:
       - ^master$
@@ -97,7 +102,8 @@ presubmits:
           privileged: true
   - name: build-drivers-ubuntu-generic-presubmit
     decorate: true
-    skip_report: false
+    always_run: false
+    skip_report: true
     agent: kubernetes
     branches:
       - ^master$


### PR DESCRIPTION
We need to set a proper changes trigger for the drivers build jobs.

(Something to consider for the regex format in Prow job's `run_if_changed` is that negative look aheads are not supported in Golang).