### PR TITLE
adding autobump, and incrementing build-driver periodics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ workflows:
             branches:
               ignore:
                 - master
-                # - /pull\/[0-9]+/ #ignore forked PR's
+                - /pull\/[0-9]+/ #ignore forked PR's
       - "test-infra/deploy/prow":
           requires:
             - test-infra/deploy/terraform
@@ -338,4 +338,3 @@ workflows:
             branches:
               ignore:
                 - master
-                # - /pull\/[0-9]+/ #ignore forked PR's

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,7 @@ workflows:
             branches:
               ignore:
                 - master
+                - /pull\/[0-9]+/ #ignore forked PR's
       - "test-infra/deploy/terraform":
           requires:
             - test-infra/scan/terraform
@@ -328,6 +329,7 @@ workflows:
             branches:
               ignore:
                 - master
+                # - /pull\/[0-9]+/ #ignore forked PR's
       - "test-infra/deploy/prow":
           requires:
             - test-infra/deploy/terraform
@@ -336,3 +338,4 @@ workflows:
             branches:
               ignore:
                 - master
+                # - /pull\/[0-9]+/ #ignore forked PR's

--- a/config/jobs/autobump/autobump.yaml
+++ b/config/jobs/autobump/autobump.yaml
@@ -17,7 +17,7 @@ periodics:
       - /etc/github-token/oauth
       # Make the bot name and email match the user data of the provided token's user.
       - "Falco Automation"
-      - jonah.jones094@gmail.com # change after tests work
+      - leo+bot@sysdig.com
       volumeMounts:
       - name: service
         mountPath: /etc/service-account

--- a/config/jobs/autobump/autobump.yaml
+++ b/config/jobs/autobump/autobump.yaml
@@ -1,7 +1,7 @@
 periodics:
-- cron: "05 15 * * 1"  # Run at 15:05 PST (15:05 UTC) Mon
-- interval: 10m
-  name: ci-prow-autobump
+- name: ci-prow-autobump
+  # interval: 10m
+  cron: "05 15 * * 1"  # Run at 15:05 PST (15:05 UTC) Mon
   decorate: true
   extra_refs:
   # Check out the repo containing the config and deployment files for your Prow instance.

--- a/config/jobs/autobump/autobump.yaml
+++ b/config/jobs/autobump/autobump.yaml
@@ -1,0 +1,59 @@
+periodics:
+- cron: "05 15 * * 1"  # Run at 15:05 PST (15:05 UTC) Mon
+- interval: 10m
+  name: ci-prow-autobump
+  decorate: true
+  extra_refs:
+  # Check out the repo containing the config and deployment files for your Prow instance.
+  - org: falcosecurity
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/autobump # TODO: add a tag once we've push this the first time.
+      command:
+      - /autobump.sh
+      args:
+      - /etc/github-token/oauth
+      # Make the bot name and email match the user data of the provided token's user.
+      - "Falco Automation"
+      - jonah.jones094@gmail.com # change after tests work
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+      env:
+    # autobump.sh args
+      # GitHub org containing the repo where the Prow config and component files live.
+      - name: GH_ORG
+        value: falcosecurity
+      # GitHub repo where the Prow config and component deployment files live.
+      - name: GH_REPO
+        value: test-infra
+      # Repo relative path of the `plank` component k8s deployment file.
+      - name: PROW_CONTROLLER_MANAGER_FILE
+        value: config/prow/prow-controller-manager.yaml
+    # bump.sh args
+      # Directory containing k8s deployment YAMLs for Prow components.
+      - name: COMPONENT_FILE_DIR
+        value: config/prow
+      # Repo relative path of the core Prow config file (config.yaml).
+      - name: CONFIG_PATH
+        value: config/config.yaml
+      # Repo relative path of the ProwJob config file or directory.
+      # Omit this if ProwJobs are only defined in config.yaml (or are not configured at all).
+      - name: JOB_CONFIG_PATH
+        value: config/jobs/check-prow-config/check-prow-config.yaml
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+    volumes:
+    - name: service
+      secret:
+        secretName: gcloud-credentials
+    - name: github
+      secret:
+        # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+        secretName: oauth-token

--- a/config/jobs/build-drivers/build-drivers.yaml
+++ b/config/jobs/build-drivers/build-drivers.yaml
@@ -123,7 +123,7 @@ presubmits:
 periodics:
   - name: build-drivers-amazonlinux-periodic
     decorate: true
-    interval: 48h
+    cron: "0 03 * * 1"  
     extra_refs:
     - org: falcosecurity
       repo: test-infra
@@ -143,7 +143,7 @@ periodics:
           privileged: true
   - name: build-drivers-amazonlinux2-periodic
     decorate: true
-    interval: 48h
+    cron: "0 03 * * 2"  
     extra_refs:
     - org: falcosecurity
       repo: test-infra
@@ -163,7 +163,7 @@ periodics:
           privileged: true
   - name: build-drivers-centos-periodic
     decorate: true
-    interval: 48h
+    cron: "0 03 * * 3"  
     extra_refs:
     - org: falcosecurity
       repo: test-infra
@@ -183,7 +183,7 @@ periodics:
           privileged: true
   - name: build-drivers-debian-periodic
     decorate: true
-    interval: 48h
+    cron: "0 03 * * 4"  
     extra_refs:
     - org: falcosecurity
       repo: test-infra
@@ -203,7 +203,7 @@ periodics:
           privileged: true
   - name: build-drivers-ubuntu-aws-periodic
     decorate: true
-    interval: 48h
+    cron: "0 03 * * 5"  
     extra_refs:
     - org: falcosecurity
       repo: test-infra
@@ -223,7 +223,7 @@ periodics:
           privileged: true
   - name: build-drivers-ubuntu-generic-periodic
     decorate: true
-    interval: 48h
+    cron: "0 03 * * 6"  
     extra_refs:
     - org: falcosecurity
       repo: test-infra


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

1. Adding autobump.... need to figure out a way to make autobump DCO signoff the commit from pioana
2. Incrementing the build-drivers jobs so they don't ddos our others jobs running all at the same time.