### PR TITLE
Add https redirect to deck

### DIFF
--- a/config/prow/deck.yaml
+++ b/config/prow/deck.yaml
@@ -131,6 +131,7 @@ spec:
         # - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --redirect-http-to=prow.falco.org
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
Add HTTP redirect to HTTPS when host is "prow.falco.org".

As implemented here: https://github.com/kubernetes/test-infra/pull/6122