### PR TITLE
Increase default job timeout from 3h to 6h

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,7 +32,7 @@ plank:
   pod_pending_timeout: 60m
   default_decoration_configs:
     '*':
-      timeout: 3h # Up to 3 hours for driverkit jobs
+      timeout: 6h # Up to 6 hours for driverkit jobs
       grace_period: 10m
       utility_images:
         clonerefs: "gcr.io/k8s-prow/clonerefs:v20200921-becd8c9356"


### PR DESCRIPTION
Increase timeout in Plank default decoration, in order to enable driverkit jobs to complete.