### PR TITLE
Pin Terraform v0.13.5 in CI/CD pipeline

### DIFF
--- a/tools/deploy_terraform.sh
+++ b/tools/deploy_terraform.sh
@@ -22,7 +22,8 @@ function terraform-install() {
     jq -r '.versions[].builds[].url | select(.|test("alpha|beta|rc")|not) | select(.|contains("linux_amd64"))' |
     sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n |
     tail -n1)
-  curl ${LATEST_URL} > terraform.zip
+  STABLE_URL="https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip"
+  curl ${STABLE_URL} > terraform.zip
   unzip terraform.zip
   rm -rf terraform.zip
   install terraform /usr/local/bin/


### PR DESCRIPTION
Switch from Terraform latest to 0.13.5 version.
Terraform 0.14.0 introduces incompatibilities with current code.