### PR TITLE
Always run prow config check

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -195,8 +195,6 @@ branch-protection:
               protect: true
           required_status_checks:
             contexts:
-              - "ci/circleci: deploy/terraform"
-              - "ci/circleci: deploy/prow"
               - "check-prow-config"
 
 log_level: debug

--- a/config/jobs/check-prow-config/check-prow-config.yaml
+++ b/config/jobs/check-prow-config/check-prow-config.yaml
@@ -1,11 +1,11 @@
 presubmits:
   falcosecurity/test-infra:
     - name: check-prow-config
-      run_if_changed: '^(config/(config|plugins).yaml$|config/jobs/.*.yaml$)'
       branches:
         - ^master$
       decorate: true
       skip_report: false
+      always_run: true
       spec:
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20201124-061f85d859


### PR DESCRIPTION
Set the `check-prow-config` to always run and remove deployment jobs as required to report status on PRs.