### PR TITLE
Switch update-jobs to postsubmit now that check-config works for PR

### DIFF
--- a/config/jobs/update-jobs/update-jobs.yaml
+++ b/config/jobs/update-jobs/update-jobs.yaml
@@ -1,11 +1,9 @@
-presubmits:
+postsubmits:
   falcosecurity/test-infra:
   - name: update-jobs-pr
     decorate: true
     path_alias: github.com/falcosecurity/test-infra
-    skip_report: false
     agent: kubernetes
-    run_if_changed: '^config/jobs/'
     branches:
       - ^master$
     spec:


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

Update-jobs should run on PR's getting merged, not on every commit on a PR. This is causing job contention issues, where an older PR #225 can update-jobs to an older backport and force jobs to run on newer PR's. #241 

https://prow.falco.org/log?job=update-jobs-pr&id=1334569592248340480

