### PR TITLE
Filter driver build targets also per kernel version

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -5,16 +5,14 @@ DRIVERKIT ?= $(shell which driverkit)
 CONFIGS := $(wildcard config/*/*.yaml)
 VERSIONS := $(patsubst config/%,%,$(sort $(dir $(wildcard config/*/))))
 VERSIONS := $(VERSIONS:/=)
+TARGET_VERSION ?= *
 TARGET_DISTRO ?= *
 TARGET_KERNEL ?= *
 S3_DRIVERS_BUCKET ?= "falco-distribution/driver"
 
 all: $(patsubst config_%,%,$(subst /,_,$(CONFIGS)))
 
-specific_target: $(patsubst config_%,%,$(subst /,_,$(wildcard config/*/${TARGET_DISTRO}_${TARGET_KERNEL}-*)))
-
-count_specific_target:
-	@echo $(words $(patsubst config_%,%,$(subst /,_,$(wildcard config/*/${TARGET_DISTRO}_${TARGET_KERNEL}-*))))
+specific_target: $(patsubst config_%,%,$(subst /,_,$(wildcard config/${TARGET_VERSION}*/${TARGET_DISTRO}_${TARGET_KERNEL}-*)))
 
 prepare: $(addprefix prepare_,$(VERSIONS))
 publish: $(addprefix publish_,$(VERSIONS))
@@ -85,7 +83,7 @@ $(foreach VERSION,$(VERSIONS),\
 
 .PHONY: clean
 clean:
-	@find output -type f -not -name '.gitignore' -delete
+	find output/ -not -name '.gitignore' -not -name 'output' -delete
 
 stats:
 	@utils/driverstats $(CONFIGS)

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -86,4 +86,4 @@ clean:
 	find output/ -not -name '.gitignore' -not -name 'output' -delete
 
 stats:
-	@utils/driverstats $(CONFIGS)
+	@utils/driverstats

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -5,12 +5,16 @@ DRIVERKIT ?= $(shell which driverkit)
 CONFIGS := $(wildcard config/*/*.yaml)
 VERSIONS := $(patsubst config/%,%,$(sort $(dir $(wildcard config/*/))))
 VERSIONS := $(VERSIONS:/=)
-TARGET_DISTRO ?=
+TARGET_DISTRO ?= *
+TARGET_KERNEL ?= *
 S3_DRIVERS_BUCKET ?= "falco-distribution/driver"
 
 all: $(patsubst config_%,%,$(subst /,_,$(CONFIGS)))
 
-specific_target: $(patsubst config_%,%,$(subst /,_,$(wildcard config/*/${TARGET_DISTRO}_*)))
+specific_target: $(patsubst config_%,%,$(subst /,_,$(wildcard config/*/${TARGET_DISTRO}_${TARGET_KERNEL}-*)))
+
+count_specific_target:
+	@echo $(words $(patsubst config_%,%,$(subst /,_,$(wildcard config/*/${TARGET_DISTRO}_${TARGET_KERNEL}-*))))
 
 prepare: $(addprefix prepare_,$(VERSIONS))
 publish: $(addprefix publish_,$(VERSIONS))

--- a/driverkit/README.md
+++ b/driverkit/README.md
@@ -21,7 +21,7 @@ make
 - `publish_s3_<driver_version>`: publish all the built Falco drivers to S3 filtering by the Falco driver version (those existing in the `output/<driver_version>` directory)
 - `cleanup`: delete from bintray the driver version no more supported (those present on bintray but not in the `config/` directory)
 - `cleanup_s3`: delete from S3 the driver version no more supported (those present on S3 but not in the `config/` directory)
-- `stats`:
+- `stats`: print counts about currently available Falco drivers
 
 #### Specific target
 
@@ -53,13 +53,21 @@ make -e TARGET_DISTRO="debian" -e TARGET_KERNEL="5.9.0" specific_target
 Or, you can ask it to make all the Falco drivers for debian 5.x kernels.
 
 ```console
-make -e TARGET_DISTRO="debian" -e TARGET_KERNEL="5.x" specific_target
+make -e TARGET_DISTRO="debian" -e TARGET_KERNEL="5.*" specific_target
 ```
 
 In case you're only interested in a precise Falco driver version, you can filter by it too:
 
 ```console
 make -e TARGET_VERSION="2aa88" -e TARGET_DISTRO="debian" -e TARGET_KERNEL="4.9.*" specific_target
+```
+
+Finally, notice you can use these filters also with the `stats` make target.
+
+Eg.,
+
+```console
+make -e TARGET_DISTRO=debian stats
 ```
 
 ## FAQ

--- a/driverkit/README.md
+++ b/driverkit/README.md
@@ -10,14 +10,22 @@ Just make is enough! :heart:
 make
 ```
 
-### Available Make targets
+### Available make targets
 
-- `specific_target`: build the filtered driver versions.
-- `count_specific_target`: count the filtered driver versions.
+- `all`: build all the Falco drivers (all the versions), for every supported distro, and every supported kernel release
+- `specific_target`: build the filtered driver versions
+- `clean`: remove everything in the `output/` directory (except it, and its `.gitignore` file)
+- `publish`: publish all the built Falco drivers (those existing in the `output/` directory) to bintray
+- `publish_<driver_version>`: publish all the built Falco drivers to bintray filtering by the Falco driver version (those existing in the `output/<driver_version>` directory)
+- `publish_s3`: publish all the built Falco drivers (those existing in the `output/` directory) to S3
+- `publish_s3_<driver_version>`: publish all the built Falco drivers to S3 filtering by the Falco driver version (those existing in the `output/<driver_version>` directory)
+- `cleanup`: delete from bintray the driver version no more supported (those present on bintray but not in the `config/` directory)
+- `cleanup_s3`: delete from S3 the driver version no more supported (those present on S3 but not in the `config/` directory)
+- `stats`:
 
 #### Specific target
 
-In case you want to build the drivers for just a distro or a specific kernel or both, use the `specific_target` make target:
+In case you want to build the Falco drivers (all the available versions) for just a distro or a specific kernel or both, use the `specific_target` make target:
 
 ```console
 make -e TARGET_DISTRO=amazonlinux2 specific_target
@@ -26,22 +34,41 @@ make -e TARGET_DISTRO=amazonlinux2 specific_target
 ##### Available filters
 
 These are the available filters as environment variables:
-- `TARGET_DISTRO`: a spefific Linux distribution.
-- `TARGET_KERNEL`: a specific Linux version, in <kernel_version>.<major_version>.<minor_version> format.
 
-Note: both are optional and cumulative. For instance you can filter a specific distro with a specific kernel version:
+- `TARGET_VERSION`: a specific Falco driver version
+- `TARGET_DISTRO`: a spefific Linux distribution
+- `TARGET_KERNEL`: a specific Linux version
+  - in <kernel_version>.<major_version>.<minor_version> format
+  - in <kernel_version>.<major_version>.* format
+  - in <kernel_version>.* format
+
+Notice all the filters are optional.
+
+You can also filter a specific distro with a specific kernel version:
 
 ```console
-make -e TARGET_DISTRO=debian -e TARGET_KERNEL=5.9.0 specific_target
+make -e TARGET_DISTRO="debian" -e TARGET_KERNEL="5.9.0" specific_target
+```
+
+Or, you can ask it to make all the Falco drivers for debian 5.x kernels.
+
+```console
+make -e TARGET_DISTRO="debian" -e TARGET_KERNEL="5.x" specific_target
+```
+
+In case you're only interested in a precise Falco driver version, you can filter by it too:
+
+```console
+make -e TARGET_VERSION="2aa88" -e TARGET_DISTRO="debian" -e TARGET_KERNEL="4.9.*" specific_target
 ```
 
 ## FAQ
 
 Q: Falco doesn't find the kernel module/ eBPF probe for my OS, what do I do?
-A: Go to the `config/` folder and add your kernel/OS combination there as a yaml file, then send a PR for everyone to profit!
+A: Go to the `config/` folder and add your kernel/OS combination there as a YAML file, then send a PR for everyone to profit!
 
 Q: How do you publish new drivers?
-A: If you have proper S3 permissions from terraform or prow, run
+A: If you have proper S3 permissions from Terraform or Prow, run
 
 ```console
 make publish_s3

--- a/driverkit/README.md
+++ b/driverkit/README.md
@@ -10,10 +10,29 @@ Just make is enough! :heart:
 make
 ```
 
-In case you want to build the drivers for just a distro, use the following make target as below.
+### Available Make targets
+
+- `specific_target`: build the filtered driver versions.
+- `count_specific_target`: count the filtered driver versions.
+
+#### Specific target
+
+In case you want to build the drivers for just a distro or a specific kernel or both, use the `specific_target` make target:
 
 ```console
 make -e TARGET_DISTRO=amazonlinux2 specific_target
+```
+
+##### Available filters
+
+These are the available filters as environment variables:
+- `TARGET_DISTRO`: a spefific Linux distribution.
+- `TARGET_KERNEL`: a specific Linux version, in <kernel_version>.<major_version>.<minor_version> format.
+
+Note: both are optional and cumulative. For instance you can filter a specific distro with a specific kernel version:
+
+```console
+make -e TARGET_DISTRO=debian -e TARGET_KERNEL=5.9.0 specific_target
 ```
 
 ## FAQ

--- a/driverkit/utils/driverstats
+++ b/driverkit/utils/driverstats
@@ -1,26 +1,83 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC1090
 
+shopt -s nullglob
+
 currentdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 source "${currentdir}/parseyaml"
 
-configs=("$@")
+TARGET_VERSION=${TARGET_VERSION:-"*"}
+TARGET_DISTRO=${TARGET_DISTRO:-"*"}
+TARGET_KERNEL=${TARGET_KERNEL:-"*"}
+
+configs=(config/${TARGET_VERSION}*/${TARGET_DISTRO}_${TARGET_KERNEL}-*.yaml)
 
 total_ebpf_drivers=0
 total_kmod_drivers=0
 
+# simulating hash tables with files
+# since cannot assume bash 4
+hinit() {
+    rm -rf "/tmp/hashmap.$1"
+    mkdir -p "/tmp/hashmap.$1"
+}
+
+hput() {
+    echo "$3" > "/tmp/hashmap.$1/$2"
+}
+
+hget() {
+    cat "/tmp/hashmap.$1/$2" 2>/dev/null
+}
+
+hkeys() {
+    ls -1 "/tmp/hashmap.$1"
+}
+
+hdestroy() {
+    rm -rf "/tmp/hashmap.$1"
+}
+
+hinit ebpf_drivers_by_version
+hinit kmod_drivers_by_version
+
+cleanup() {
+    hdestroy ebpf_drivers_by_version
+    hdestroy kmod_drivers_by_version
+}
+
 for file in "${configs[@]}"
 do
+    driver_version=${file%/*}
+    driver_version=${driver_version##config/}
     output_module=
     output_probe=
     create_variables "$file"
     if [ -n "${output_probe}" ]; then
         ((total_ebpf_drivers=total_ebpf_drivers+1))
+        current_num_ebpf_drivers=$(hget ebpf_drivers_by_version "${driver_version}") || current_num_ebpf_drivers=0
+        ((current_num_ebpf_drivers=current_num_ebpf_drivers+1))
+        hput ebpf_drivers_by_version "${driver_version}" "${current_num_ebpf_drivers}"
     fi
     if [ -n "${output_module}" ]; then
         ((total_kmod_drivers=total_kmod_drivers+1))
+        current_num_kmod_drivers=$(hget kmod_drivers_by_version "${driver_version}") || current_num_kmod_drivers=0
+        ((current_num_kmod_drivers=current_num_kmod_drivers+1))
+        hput kmod_drivers_by_version "${driver_version}" "${current_num_kmod_drivers}"
     fi
 done
 
-echo -e "eBPF probes:${total_ebpf_drivers}\nkernel modules:${total_kmod_drivers}" | column -t -s':'
+for driver_version in $(hkeys kmod_drivers_by_version)
+do
+    n_ebpf=$(hget ebpf_drivers_by_version "${driver_version}")
+    n_kmod=$(hget kmod_drivers_by_version "${driver_version}")
+    echo "+++ ${driver_version} +++"
+    printf "%-20s%5s\n%-20s%5s\n" "eBPF probes" "${n_ebpf}" "kernel modules" "${n_kmod}"
+done
+
+# todo > trap this correctly
+cleanup
+
+echo "+++ TOTALS +++"
+printf "%-20s%5s\n%-20s%5s\n" "eBPF probes" "${total_ebpf_drivers}" "kernel modules" "${total_kmod_drivers}"


### PR DESCRIPTION
## Related issues
Closes #250.

## New features

As for the related issue this PR enables to further filter Falco driver versions to pre-build by specifying both:
- Linux distribution
- Linux version

by enabling the `specific_target` Make target to accept a new parameter: `TARGET_KERNEL`.

This parameter as for `TARGET_DISTRO` is read from the environment and it accetps a Linux version in `<kernel_version>.<major_version>.<minor_version>` format.

For instance:

```bash
make -e TARGET_DISTRO=centos -e TARGET_KERNEL=3.10.0 specific_target
[...]
```

It introduces also a Make target `count_specific_target` to count the result of the filter as for the `TARGET_*` variables set.
For instance:
```bash
make -e TARGET_DISTRO=centos -e TARGET_KERNEL=3.10.0 count_specific_target
261
```

### Breaking changes
None.