### PR TITLE
adding in jobs and script to build images for prowjobs

### DIFF
--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -1,0 +1,107 @@
+
+presubmits:
+  falcosecurity/test-infra:
+  - name: build-images-autobump
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/autobump/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/autobump"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+  - name: build-images-build-drivers
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/build-drivers/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/build-drivers"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+  - name: build-images-golang
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/golang/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/golang"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+  - name: build-images-update-jobs
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-jobs/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-jobs"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true

--- a/images/publish.sh
+++ b/images/publish.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage () {
+    echo "Usage: \$ ${BASH_SOURCE[1]} /path/to/image"
+    exit 1
+}
+
+function start_docker() {
+    echo "Docker in Docker enabled, initializing..."
+    printf '=%.0s' {1..80}; echo
+    # If we have opted in to docker in docker, start the docker daemon,
+    service docker start
+    # the service can be started but the docker socket not ready, wait for ready
+    local WAIT_N=0
+    local MAX_WAIT=20
+    while true; do
+        # docker ps -q should only work if the daemon is ready
+        docker ps -q > /dev/null 2>&1 && break
+        if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+            WAIT_N=$((WAIT_N+1))
+            echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
+            sleep ${WAIT_N}
+        else
+            echo "Reached maximum attempts, not waiting any longer..."
+            exit 1
+        fi
+    done
+    printf '=%.0s' {1..80}; echo
+    echo "Done setting up docker in docker."
+}
+
+function aws_auth() {
+    echo "Logging into AWS ECR..."
+    printf '=%.0s' {1..80}; echo
+    # If we have opted in to docker in docker, start the docker daemon,
+    aws ecr get-login-password --region eu-west-1 \
+        | docker login \
+            --password-stdin \
+            --username AWS \
+            292999226676.dkr.ecr.us-west-2.amazonaws.com
+    local WAIT_N=0
+    local MAX_WAIT=5
+    while true; do
+        # aws ecr describe image should only work if the auth is working
+        aws ecr describe-images --repository-name test-infra/docker-dind --max-items 1 > /dev/null 2>&1 && break
+        if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+            WAIT_N=$((WAIT_N+1))
+            echo "Waiting for aws auth to work to be ready, sleeping for ${WAIT_N} seconds."
+            sleep ${WAIT_N}
+        else
+            echo "Reached maximum attempts, not waiting any longer..."
+            exit 1
+        fi
+    done
+    printf '=%.0s' {1..80}; echo
+    echo "Done setting up aws ecr auth"
+}
+
+
+start_docker
+
+aws_auth
+
+readonly SOURCES_DIR=$1
+
+if [[ -z "${SOURCES_DIR}" ]]; then
+    usage
+fi
+
+echo "using ${SOURCES_DIR} to build the image"
+
+make -C "${SOURCES_DIR}" build-push
+
+printf '=%.0s' {1..80}; echo
+echo "Pushing image to ECR: Success"


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

Finally getting around to adding these much needed prow jobs. These jobs will build and publish the base prow images used by the other tests. 

Can utilize the `docker-dind` image used by build-drivers since it has docker-dind and awscli installed already.

