### PR TITLE
update maintainers periodic prow job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,13 @@ kubeconfig_falco-prow-test-infra
 tools/create_gencred.sh
 config/prow/poiana_gpg_secret.yaml
 
-#terraform files
+# terraform files
 .terraform
 **/.terraform/*
 *.tfstate
 *.tfstate.*
+
+# local prowjob tests
+pj.yaml
+temp-mkpod-kind-config.yaml
+pod.yaml

--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -105,3 +105,29 @@ presubmits:
             ephemeral-storage: "2Gi"
         securityContext:
           privileged: true
+  - name: build-images-update-maintainers
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-maintainers/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-maintainers"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true

--- a/config/jobs/update-maintainers/update-maintainers.yaml
+++ b/config/jobs/update-maintainers/update-maintainers.yaml
@@ -1,24 +1,24 @@
 periodics:
   - name: update-maintainers
-    # interval: 15m
-    cron: "0 9 * * 5" # Run at 09:00 only on Fridays
+    cron: "0 9 * * 5" # Run at 09:00 only on Fridays # Local testing: substitute with => interval: 15m
     decorate: true
     extra_refs:
     # Check out the repo containing the maintainers file
+    # This will be the working directory
     - org: falcosecurity
       repo: .github
       base_ref: master
+      workdir: true
     spec:
       containers:
       # See images/update-maintainers
-      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-maintainers
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-maintainers # Local testing: substite with => image: localhost:5000/update-maintainers
         imagePullPolicy: Always
         command:
-        - sleep
-        # - entrypoint.sh
+        - entrypoint.sh # Local testing: sleep
         args:
-        - "900"
-        # - /etc/github-token/oauth
+        -  /etc/github-token/oauth # Local testing: substite with => - "900"
+        # Local testing: comment
         volumeMounts:
         - name: github
           mountPath: /etc/github-token
@@ -26,12 +26,13 @@ periodics:
         - name: gpg-signing-key
           mountPath: /root/gpg-signing-key/
           readOnly: true
-    volumes:
-    - name: github
-      secret:
-        # Secret containing a GitHub user access token with `repo` scope for creating PRs.
-        secretName: oauth-token
-    - name: gpg-signing-key
-      secret:
-        secretName: poiana-gpg-signing-key
-        defaultMode: 0400
+      # Local testing: comment
+      volumes:
+      - name: github
+        secret:
+          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+          secretName: oauth-token
+      - name: gpg-signing-key
+        secret:
+          secretName: poiana-gpg-signing-key
+          defaultMode: 0400

--- a/config/jobs/update-maintainers/update-maintainers.yaml
+++ b/config/jobs/update-maintainers/update-maintainers.yaml
@@ -1,0 +1,37 @@
+periodics:
+  - name: update-maintainers
+    # interval: 15m
+    cron: "0 9 * * 5" # Run at 09:00 only on Fridays
+    decorate: true
+    extra_refs:
+    # Check out the repo containing the maintainers file
+    - org: falcosecurity
+      repo: .github
+      base_ref: master
+    spec:
+      containers:
+      # See images/update-maintainers
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-maintainers
+        imagePullPolicy: Always
+        command:
+        - sleep
+        # - entrypoint.sh
+        args:
+        - "900"
+        # - /etc/github-token/oauth
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+        - name: gpg-signing-key
+          mountPath: /root/gpg-signing-key/
+          readOnly: true
+    volumes:
+    - name: github
+      secret:
+        # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+        secretName: oauth-token
+    - name: gpg-signing-key
+      secret:
+        secretName: poiana-gpg-signing-key
+        defaultMode: 0400

--- a/config/jobs/update-maintainers/update-maintainers.yaml
+++ b/config/jobs/update-maintainers/update-maintainers.yaml
@@ -12,12 +12,12 @@ periodics:
     spec:
       containers:
       # See images/update-maintainers
-      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-maintainers # Local testing: substite with => image: localhost:5000/update-maintainers
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-maintainers # Local testing: substitute with => image: localhost:5000/update-maintainers
         imagePullPolicy: Always
         command:
         - entrypoint.sh # Local testing: sleep
         args:
-        -  /etc/github-token/oauth # Local testing: substite with => - "900"
+        -  /etc/github-token/oauth # Local testing: substitute with => - "900"
         # Local testing: comment
         volumeMounts:
         - name: github

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,25 +1,40 @@
 # Local Prow Testing
 
-We can locally test prowjobs using `KIND` before we make a PR. There are some limitations to tests, such that we cannot use AWS credentials so we cannot do
+We can locally test ProwJobs using Kind before we make a PR. There are some limitations to tests, such that we cannot use AWS credentials so we **cannot** do:
 
 - Container Build Pushes
 - Anything leveraging AWS CLI
 
 ## Local Prow Script
 
-Located at `tools/local_prowjob_test.sh` the local script will do
+First of all, ensure you have a local image to test against.
+
+To do so, execute `make build-image` in the `images/*` directory you are targeting.
+
+Then, located at `tools/local_prowjob.sh` there is a script that when executed will do:
 
 1. Create a local docker registry at `localhost:5000`
-2. Build local container and push to local registry
+2. Build a local container and push it to the local registry
 3. Spin up Local Kind Cluster, and patch to work on Prow
-4. Build Prowjob, using local image as job image.
+4. Build Prowjob, using the local image as the job image.
 5. Run Prowjob, and report status.
 
-## Testing Build-Drivers Prowjob locally
+Do not forget to provide correct environment variables to this script.
 
-1. Build local image, and push to local registry. 
+For example, from the `test-infra` repository root, run:
 
+```console
+DEBUG=true \
+JOB_CONFIG_PATH="$(pwd)/config/jobs/update-maintainers/update-maintainers.yaml" \
+IMAGE_PATH="$(pwd)/images/update-maintainers" \
+./tools/local_prowjob.sh update-maintainers
 ```
+
+## Testing the build-drivers ProwJobs locally
+
+### Build a local image, and push it to the local registry
+
+```makefile
 IMG_NAME = test-infra/build-drivers
 ACCOUNT=292999226676
 DOCKER_PUSH_REPOSITORY=dkr.ecr.eu-west-1.amazonaws.com
@@ -27,16 +42,20 @@ TAG?=latest
 IMAGE=$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_NAME)
 
 local-registry:
-	docker tag $(IMAGE):$(TAG) localhost:5000/build-drivers
-	docker push localhost:5000/build-drivers
+    docker tag $(IMAGE):$(TAG) localhost:5000/build-drivers
+    docker push localhost:5000/build-drivers
 ```
+
 Here we have our makefile, and can go into our image folder, and run `make local-registry`, or run the commands yourself.
 
-2. Build Prowjob local file, replacing image with our new `localhost:5000` image.
+### Build Prowjob local file, replacing the image with our new `localhost:5000` image
 
-Here we create a new file 
+Create a new file at the following path:
 
 `config/jobs/build-drivers/build-drivers.local`
+
+Put in it the following content:
+
 ```yaml
   falcosecurity/test-infra:
   - name: build-drivers-amazonlinux-presubmit
@@ -59,56 +78,28 @@ Here we create a new file
           privileged: true
 ```
 
-3. Go to `tools/local_prowjob_test.sh` and change these 3 values.
+### Change these 3 values
+
+Skip this if not performing image build in script
 
 ```bash
 export CONFIG_PATH="$(pwd)/config/config.yaml"
-
 export JOB_CONFIG_PATH="$(pwd)/config/jobs/build-drivers/build-drivers.local"
-
 export IMAGE_PATH="$(pwd)/images/build-drivers"
-#Skip this if not performing image build in script
 ```
 
-4. Run the script with the name of job to test, as the arguement.  `./tools/local_prowjob_test.sh build-drivers-amazonlinux-presubmit`
+### Run the script with the name of the job to test as the argument
 
+`./tools/local_prowjob.sh build-drivers-amazonlinux-presubmit`
 
-5. This will write the new cluster as your current Kube Config, and you can check the logs of your running job.
-
+### This will write the new cluster as your current Kube Config, and you can check the logs of your running job
 
 You can see the KIND cluster spin up, and begin to run the tests.
 
 [local](docs/images/local-testing.png)
 
-
-
 ## Cleanup of local testing
 
 Run the cleanup script, or delete the registry and kind cluster yourself.
 
-`./tools/delete_local_prowjob_test.sh`
-
-```bash
-set -o errexit
-
-# desired cluster name; default is "kind"
-KIND_CLUSTER_NAME="mkpod"
-
-kind_network='bridge'
-reg_name='kind-registry'
-reg_port='5000'
-
-# create registry container unless it already exists
-running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
-if [ "${running}" == 'true' ]; then
-  cid="$(docker inspect -f '{{.ID}}' "${reg_name}")"
-  echo "> Stopping and deleting Kind Registry container..."
-  docker stop $cid >/dev/null
-  docker rm $cid >/dev/null
-fi
-
-echo "> Deleting Kind cluster..."
-kind delete cluster --name=$KIND_CLUSTER_NAME
-```
-
-
+`./tools/delete_local_prowjob.sh`

--- a/images/update-maintainers/Dockerfile
+++ b/images/update-maintainers/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.14 AS pullrequestcreator
+
+RUN git clone https://github.com/kubernetes/test-infra
+RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
+
+FROM golang:1.14 AS maintainersgenerator
+
+RUN wget -qO- "https://api.github.com/repos/leodido/maintainers-generator/releases/latest" | grep -Po '"browser_download_url": "\K.*?(?=")' | xargs wget -qO- | tar -xvz
+
+FROM debian:buster
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    gnupg2 \
+    && apt-get clean
+
+COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin
+COPY --from=maintainersgenerator /go/maintainers-generator /bin
+COPY persons.json /
+COPY entrypoint.sh /
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/update-maintainers/Dockerfile
+++ b/images/update-maintainers/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     gnupg2 \
+    curl \
     && apt-get clean
 
 COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin

--- a/images/update-maintainers/Makefile
+++ b/images/update-maintainers/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+IMG_SLUG := test-infra
+IMG_NAME := update-maintainers
+IMG_TAG ?= latest
+
+ACCOUNT := 292999226676
+DOCKER_PUSH_REPOSITORY = dkr.ecr.eu-west-1.amazonaws.com
+
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME)"
+
+build-push: build-image push-image
+
+build-image:
+	docker build -t "$(IMG_SLUG)/$(IMG_NAME)" .
+
+push-image:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" "$(IMAGE):$(TAG)"
+	docker push "$(IMAGE):$(TAG)"
+
+local-registry:
+	docker tag "$(IMAGE):$(TAG)" localhost:5000/$(IMG_NAME)
+	docker push localhost:5000/$(IMG_NAME)

--- a/images/update-maintainers/Makefile
+++ b/images/update-maintainers/Makefile
@@ -7,7 +7,7 @@ IMG_TAG ?= latest
 ACCOUNT := 292999226676
 DOCKER_PUSH_REPOSITORY = dkr.ecr.eu-west-1.amazonaws.com
 
-IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME)"
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME):$(IMG_TAG)"
 
 build-push: build-image push-image
 
@@ -15,9 +15,9 @@ build-image:
 	docker build -t "$(IMG_SLUG)/$(IMG_NAME)" .
 
 push-image:
-	docker tag "$(IMG_SLUG)/$(IMG_NAME)" "$(IMAGE):$(TAG)"
-	docker push "$(IMAGE):$(TAG)"
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" $(IMAGE)
+	docker push $(IMAGE)
 
 local-registry:
-	docker tag "$(IMAGE):$(TAG)" localhost:5000/$(IMG_NAME)
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" localhost:5000/$(IMG_NAME)
 	docker push localhost:5000/$(IMG_NAME)

--- a/images/update-maintainers/entrypoint.sh
+++ b/images/update-maintainers/entrypoint.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2020 The Falco Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Args from environment (with defaults)
+GH_ORG="${GH_ORG:-"falcosecurity"}"
+GH_REPO="${GH_REPO:-".github"}"
+BOT_NAME="${BOT_NAME:-"poiana"}"
+BOT_MAIL="${BOT_MAIL:-"leo+bot@sysdig.com"}"
+BOT_GPG_KEY_PATH="${BOT_GPG_KEY_PATH:-"/root/gpg-signing-key/poiana.asc"}"
+BOT_GPG_PUBLIC_KEY="${BOT_GPG_PUBLIC_KEY:-"5B969CD19422B477E5609F8C900C09B3E21C193F"}"
+
+# Creates a maintainers.yaml file.
+# $1: path of the file containing the token
+get_maintainers() {
+    echo "> retrieving maintainers for GitHub organization ${GH_ORG}..." >&2
+    maintainers-generator \
+        --org "${GH_ORG}" \
+        --github-token-path "$1" \
+        --sort --dedupe \
+        --log-level debug \
+        --persons-db /persons.json \
+        --banner --output /maintainers.yaml
+}
+
+# Sets git user configs, otherwise errors out.
+# $1: git user name
+# $2: git user email
+ensure_git_config() {
+    echo "> configuring git user (name=$1, email=$2)..." >&2
+    git config user.name "$1"
+    git config user.email "$2"
+
+    git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    return 1
+}
+
+# Configures GPG key, otherwise errors out.
+# $1: GPG key location
+# $2: GPG ASCII armored public key
+ensure_gpg_key() {
+    echo "> configuring git with gpg key=$1..." >&2
+    gpg --import "$1"
+    git config --global commit.gpgsign true
+    git config --global user.signingkey "$2"
+
+    git config --global commit.gpgsign &>/dev/null && git config --global user.signingkey &>/dev/null && return 0
+    echo "ERROR: git gpg key location, public key ID unset. No defaults provided" >&2
+    return 1
+}
+
+# Creates a pull-request in case there are changes to commit and to push.
+# $1: path of the file containing the token
+create_pr() {
+    nchanges=$(git status --porcelain=v1 2> /dev/null | wc -l)
+    if [ "${nchanges}" -eq "0" ]; then
+        echo "> moving on since there are no changes..." >&2
+        return 0;
+    fi
+
+    echo "> creating commit..." >&2
+    title="update: maintainers list"
+    git add .
+    git commit -s -m "${title}"
+
+    echo "> pushing commit..." >&2
+    user=$(get_user_from_token "$1")
+    branch="maintainers-${GH_ORG}"
+    git push -f \
+        "https://${user}:$(cat "$1")@github.com/${GH_ORG}/${GH_REPO}" \
+        "HEAD:${branch}" 2>/dev/null
+
+    # TODO > COMPLETE
+    echo "> creating pull-request to merge ${user}:${branch} into master..." >&2
+    body="Updating maintainers list."
+    pr-creator \
+        --github-token-path="$1" \
+        --org="${GH_ORG}" --repo="${GH_REPO}" --branch=master \
+        --title="${title}" --match-title="${title}" \
+        --body="${body}" \
+        --local --source="${branch}" \
+        --allow-mods --confirm
+}
+
+# $1: path of the file containing the token
+get_user_from_token() {
+    curl --silent -H "Authorization: token $(cat "$1")" "https://api.github.com/user" | grep -Po '"login": "\K.*?(?=")'
+}
+
+# $1: the program to check
+function check_program {
+    if hash "$1" 2>/dev/null; then
+        type -P "$1"
+    else
+        echo "aborting because $1 is required..." >&2
+       return 1
+    fi
+}
+
+# Meant to be run in a GitHub repository
+# $1: path of the file containing the token
+main() {
+    # Checks
+    if [[ $# -lt 1 ]]; then
+        echo "Usage: $(basename "$0") <path to github token>" >&2
+        return 1
+    fi
+    check_program "gpg"
+    check_program "git"
+    check_program "curl"
+    check_program "maintainers-generator"
+    check_program "pr-creator"
+    # Settings
+    ensure_git_config "${BOT_NAME}" "${BOT_MAIL}"
+    ensure_gpg_key "${BOT_GPG_KEY_PATH}" "${BOT_GPG_PUBLIC_KEY}"
+    # Fetch maintainers
+    get_maintainers "$1"
+    # Create PR (in case there are changes)
+    create_pr "${user}"
+}
+
+main "@"

--- a/images/update-maintainers/persons.json
+++ b/images/update-maintainers/persons.json
@@ -1,0 +1,106 @@
+{
+    "leodido": {
+        "name": "Leonardo Di Donato",
+        "company": "Sysdig"
+    },
+    "fntlnz": {
+        "name": "Lorenzo Fontana",
+        "company": "Sysdig"
+    },
+    "leog": {
+        "name": "Leonardo Grasso",
+        "company": "Sysdig"
+    },
+    "issif": {
+        "name": "Thomas Labarussias",
+        "company": "Qonto"
+    },
+    "cpanato": {
+        "name": "Carlos Tadeu Panato Junior",
+        "company": "Mattermost"
+    },
+    "nibalizer": {
+        "name": "Spencer Krum",
+        "company": "IBM"
+    },
+    "ldegio": {
+        "name": "Loris Degioianni",
+        "company": "Sysdig"
+    },
+    "jonahjon": {
+        "name": "Jonah Jones",
+        "company": "Amazon"
+    },
+    "admiral0": {
+        "name": "Radu Andries",
+        "company": "Sysdig"
+    },
+    "airadier": {
+        "name": "Álvaro Iradier",
+        "company": "Sysdig"
+    },
+    "bencer": {
+        "name": "Jorge Salamero Sanz",
+        "company": "Sysdig"
+    },
+    "danpopsd": {
+        "name": "Dan POP Papandrea",
+        "company": "Sysdig"
+    },
+    "gnosek": {
+        "name": "Grzegorz Nosek",
+        "company": "Sysdig"
+    },
+    "kaizhe": {
+        "name": "Kaizhe Huang",
+        "company": "Sysdig"
+    },
+    "kris-nova": {
+        "name": "Kris Nóva",
+        "company": "Independent"
+    },
+    "lucperkins": {
+        "name": "Luc Perkins",
+        "company": "Timber"
+    },
+    "markyjackson-taulia": {
+        "name": "Marky Jackson",
+        "company": "Packet"
+    },
+    "mumoshu": {
+        "name": "Yusuke Kuoka",
+        "company": "Z Lab"
+    },
+    "maxgio92": {
+        "name": "Massimiliano Giovagnoli",
+        "company": "DeltaTre"
+    },
+    "mmat11": {
+        "name": "Mattia Meleleo",
+        "company": "Hetzner Cloud"
+    },
+    "mstemm": {
+        "name": "Mark Stemm",
+        "company": "Sysdig"
+    },
+    "nestorsalceda": {
+        "name": "Néstor Salceda",
+        "company": "Sysdig"
+    },
+    "radhikapc": {
+        "name": "Radhika Puthiyetath",
+        "company": "Sysdig"
+    },
+    "rajakavitha1": {
+        "name": "Rajakavitha",
+        "company": "Independent"
+    },
+    "tembleking": {
+        "name": "Fede Barcelona",
+        "company": "Sysdig"
+    },
+    "mfdii": {
+        "name": "Michael Ducy",
+        "company": "RedHat"
+    }
+}

--- a/tools/delete_local_prowjob.sh
+++ b/tools/delete_local_prowjob.sh
@@ -14,21 +14,18 @@
 
 set -o errexit
 
-# desired cluster name; default is "kind"
-KIND_CLUSTER_NAME="mkpod"
+# desired cluster name
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-"mkpod"}"
 
-kind_network='bridge'
 reg_name='kind-registry'
-reg_port='5000'
 
-# create registry container unless it already exists
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [ "${running}" == 'true' ]; then
   cid="$(docker inspect -f '{{.ID}}' "${reg_name}")"
   echo "> Stopping and deleting Kind Registry container..."
-  docker stop $cid >/dev/null
-  docker rm $cid >/dev/null
+  docker stop "${cid}" >/dev/null
+  docker rm "${cid}" >/dev/null
 fi
 
 echo "> Deleting Kind cluster..."
-kind delete cluster --name=$KIND_CLUSTER_NAME 
+kind delete cluster --name="${KIND_CLUSTER_NAME}"

--- a/tools/local_prowjob.sh
+++ b/tools/local_prowjob.sh
@@ -18,11 +18,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+DEBUG="${DEBUG:-"false"}"
+
 # We use a .local file because the update-jobs configmap will merge all yaml together into one configmap
-export CONFIG_PATH="$(pwd)/config/config.yaml"
-export JOB_CONFIG_PATH="$(pwd)/config/jobs/driverkit/driverkit-test.local"
-export IMAGE_PATH="$(pwd)/images/golang"
-DEBUG="false"
+CONFIG_PATH="${CONFIG_PATH:-"$(pwd)/config/config.yaml"}"
+JOB_CONFIG_PATH="${JOB_CONFIG_PATH:-"$(pwd)/config/jobs/driverkit/driverkit-test.local"}"
+IMAGE_PATH="${IMAGE_PATH:-"$(pwd)/images/golang"}"
+
+export CONFIG_PATH
+export JOB_CONFIG_PATH
+export IMAGE_PATH
 
 function main() {
   # Point kubectl at the mkpod cluster.
@@ -31,7 +36,7 @@ function main() {
   parseArgs "$@"
   local_registrey
   ensureInstall
-  make -C ${image_path} local-registry
+  make -C "${image_path}" local-registry
 
   # Generate PJ and Pod.
   docker run -i --rm -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job=${job}" ${job_config_flag} > "${PWD}/pj.yaml"
@@ -73,9 +78,9 @@ function parseArgs() {
   image_path="${IMAGE_PATH:-}"
   out_dir="${OUT_DIR:-/mnt/disks/prowjob-out}"
   kind_config="${KIND_CONFIG:-}"
-  node_dir="${NODE_DIR:-/mnt/disks/kind-node}"  # Any pod hostPath mounts should be under this dir to reach the true host via the kind node.
+  node_dir="${NODE_DIR:-/mnt/disks/kind-node}" # Any pod hostPath mounts should be under this dir to reach the true host via the kind node.
 
-  local new_only="  (Only used when creating a new kind cluster.)"
+  local new_only=" (Only used when creating a new kind cluster.)"
 
   if [ "${DEBUG}" = "true" ]; then
     echo "job=${job}"
@@ -191,4 +196,4 @@ function ask_confirm() {
   fi
 }
 
-main "$@" 
+main "$@"


### PR DESCRIPTION
This PR introduces:

- A ProwJob ("update-maintainers") that will periodically:
    - check all the OWNERS files present in the **falcosecurity** organization (using [leodido/maintainers-generator](https://github.com/leodido/maintainers-generator))
    - create  the current list of maintainers of all the Falco projects in a YAML file (using [leodido/maintainers-generator](https://github.com/leodido/maintainers-generator))
    - open a PR towards **falcosecurity/.github** repository on the ([maintainers.yaml](https://github.com/falcosecurity/.github/blob/master/maintainers.yaml)) file, in case there are updates
- Improvements to the scripts inside `tools/` to run ProwJob locally
- Improvements to the guide to run ProwJob locally

TODOs:

- [x] Final testing
- [x] Creation of the test-infra/update-maintainers repository on AWS ECR registry
- [x] Job to build `update-maintainers` container image