### PR TITLE
new(driver): Add debian 5.8 for Linode Kubernetes

### DIFF
--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-1-cloud-amd64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/debian_5.8.0-1-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-1-cloud-amd64
+target: debian
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-1-cloud-amd64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_debian_5.8.0-1-cloud-amd64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/debian_5.8.0-1-cloud-amd64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/debian_5.8.0-1-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-1-cloud-amd64
+target: debian
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_debian_5.8.0-1-cloud-amd64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_debian_5.8.0-1-cloud-amd64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-1-cloud-amd64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/debian_5.8.0-1-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-1-cloud-amd64
+target: debian
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-1-cloud-amd64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_debian_5.8.0-1-cloud-amd64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-1-cloud-amd64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/debian_5.8.0-1-cloud-amd64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.8.0-1-cloud-amd64
+target: debian
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-1-cloud-amd64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_debian_5.8.0-1-cloud-amd64_1.o


### PR DESCRIPTION
A user reported on slack that kernel 5.8.0-1-cloud-amd64 on debian 9 is
in use on Linode. No headers were found on the host.

Signed-off-by: Spencer Krum <nibz@spencerkrum.com>