### PR TITLE
Bump prow from v20201228-15d664642a to v20210108-eac8059329

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,10 +34,10 @@ plank:
       timeout: 24h # Up to 12 hours for driverkit builder jobs
       grace_period: 10m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20201228-15d664642a"
-        initupload: "gcr.io/k8s-prow/initupload:v20201228-15d664642a"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20201228-15d664642a"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20201228-15d664642a"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210108-eac8059329"
+        initupload: "gcr.io/k8s-prow/initupload:v20210108-eac8059329"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210108-eac8059329"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210108-eac8059329"
       gcs_configuration:
         bucket: s3://falco-prow-logs
         path_strategy: explicit

--- a/config/jobs/check-prow-config/check-prow-config.yaml
+++ b/config/jobs/check-prow-config/check-prow-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       always_run: true
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20201228-15d664642a
+          - image: gcr.io/k8s-prow/checkconfig:v20210108-eac8059329
             command:
               - /checkconfig
             args:
@@ -25,7 +25,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20201228-15d664642a
+    - image: gcr.io/k8s-prow/checkconfig:v20210108-eac8059329
       command:
       - /checkconfig
       args:

--- a/config/prow/branchprotector.yaml
+++ b/config/prow/branchprotector.yaml
@@ -51,7 +51,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20201228-15d664642a
+            image: gcr.io/k8s-prow/branchprotector:v20210108-eac8059329
             imagePullPolicy: Always
             args:
             - --config-path=/etc/config/config.yaml

--- a/config/prow/crier.yaml
+++ b/config/prow/crier.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20201228-15d664642a
+        image: gcr.io/k8s-prow/crier:v20210108-eac8059329
         env:
         - name: AWS_REGION
           value: eu-west-1

--- a/config/prow/deck.yaml
+++ b/config/prow/deck.yaml
@@ -111,7 +111,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20201228-15d664642a
+        image: gcr.io/k8s-prow/deck:v20210108-eac8059329
         env:
         - name: AWS_REGION #required for splyglass bucket looku
           value: eu-west-1

--- a/config/prow/ghproxy.yaml
+++ b/config/prow/ghproxy.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20201228-15d664642a
+        image: gcr.io/k8s-prow/ghproxy:v20210108-eac8059329
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/hook.yaml
+++ b/config/prow/hook.yaml
@@ -68,7 +68,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20201228-15d664642a
+        image: gcr.io/k8s-prow/hook:v20210108-eac8059329
         imagePullPolicy: Always
         args:
         - --github-endpoint=http://ghproxy

--- a/config/prow/horologium.yaml
+++ b/config/prow/horologium.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20201228-15d664642a
+        image: gcr.io/k8s-prow/horologium:v20210108-eac8059329
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/needs-rebase.yaml
+++ b/config/prow/needs-rebase.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20201228-15d664642a
+        image: gcr.io/k8s-prow/needs-rebase:v20210108-eac8059329
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/plank.yaml
+++ b/config/prow/plank.yaml
@@ -85,7 +85,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20201228-15d664642a
+        image: gcr.io/k8s-prow/plank:v20210108-eac8059329
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/config/prow/prow-controller-manager.yaml
+++ b/config/prow/prow-controller-manager.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "prow-controller-manager"
       containers:
         - name: prow-controller-manager
-          image: gcr.io/k8s-prow/prow-controller-manager:v20201228-15d664642a
+          image: gcr.io/k8s-prow/prow-controller-manager:v20210108-eac8059329
           env:
           - name: AWS_REGION
             value: eu-west-1

--- a/config/prow/sinker.yaml
+++ b/config/prow/sinker.yaml
@@ -116,7 +116,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20201228-15d664642a
+        image: gcr.io/k8s-prow/sinker:v20210108-eac8059329
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/statusreconciler.yaml
+++ b/config/prow/statusreconciler.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20201228-15d664642a
+        image: gcr.io/k8s-prow/status-reconciler:v20210108-eac8059329
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/config/prow/tide.yaml
+++ b/config/prow/tide.yaml
@@ -70,7 +70,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20201228-15d664642a
+        image: gcr.io/k8s-prow/tide:v20210108-eac8059329
         env:
         - name: AWS_REGION
           value: eu-west-1


### PR DESCRIPTION
Included changes: https://github.com/kubernetes/test-infra/compare/15d664642a...eac8059329