### PR TITLE
new: GKE prebuilt drivers

### DIFF
--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -2,5 +2,4 @@ kernelversion: 32
 kernelrelease: 4.15.0-1030-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -1,0 +1,6 @@
+kernelversion: 32
+kernelrelease: 4.15.0-1030-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 4.15.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 4.15.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 4.15.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 4.15.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -2,5 +2,4 @@ kernelversion: 36
 kernelrelease: 4.15.0-1034-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -1,0 +1,6 @@
+kernelversion: 36
+kernelrelease: 4.15.0-1034-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -2,5 +2,4 @@ kernelversion: 38
 kernelrelease: 4.15.0-1036-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -1,0 +1,6 @@
+kernelversion: 38
+kernelrelease: 4.15.0-1036-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -2,5 +2,4 @@ kernelversion: 39
 kernelrelease: 4.15.0-1037-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -1,0 +1,6 @@
+kernelversion: 39
+kernelrelease: 4.15.0-1037-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -2,5 +2,4 @@ kernelversion: 42
 kernelrelease: 4.15.0-1040-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -1,0 +1,6 @@
+kernelversion: 42
+kernelrelease: 4.15.0-1040-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -2,5 +2,4 @@ kernelversion: 43
 kernelrelease: 4.15.0-1041-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -1,0 +1,6 @@
+kernelversion: 43
+kernelrelease: 4.15.0-1041-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -1,0 +1,6 @@
+kernelversion: 44
+kernelrelease: 4.15.0-1042-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -2,5 +2,4 @@ kernelversion: 44
 kernelrelease: 4.15.0-1042-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -2,5 +2,4 @@ kernelversion: 46
 kernelrelease: 4.15.0-1044-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -1,0 +1,6 @@
+kernelversion: 46
+kernelrelease: 4.15.0-1044-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -2,5 +2,4 @@ kernelversion: 48
 kernelrelease: 4.15.0-1045-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -1,0 +1,6 @@
+kernelversion: 48
+kernelrelease: 4.15.0-1045-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -2,5 +2,4 @@ kernelversion: 49
 kernelrelease: 4.15.0-1046-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -1,0 +1,6 @@
+kernelversion: 49
+kernelrelease: 4.15.0-1046-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -1,0 +1,6 @@
+kernelversion: 51
+kernelrelease: 4.15.0-1048-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -2,5 +2,4 @@ kernelversion: 51
 kernelrelease: 4.15.0-1048-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -2,5 +2,4 @@ kernelversion: 52
 kernelrelease: 4.15.0-1049-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -1,0 +1,6 @@
+kernelversion: 52
+kernelrelease: 4.15.0-1049-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -2,5 +2,4 @@ kernelversion: 53
 kernelrelease: 4.15.0-1050-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -1,0 +1,6 @@
+kernelversion: 53
+kernelrelease: 4.15.0-1050-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -1,0 +1,6 @@
+kernelversion: 55
+kernelrelease: 4.15.0-1052-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -2,5 +2,4 @@ kernelversion: 55
 kernelrelease: 4.15.0-1052-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -2,5 +2,4 @@ kernelversion: 58
 kernelrelease: 4.15.0-1055-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -1,0 +1,6 @@
+kernelversion: 58
+kernelrelease: 4.15.0-1055-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -1,0 +1,6 @@
+kernelversion: 60
+kernelrelease: 4.15.0-1057-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -2,5 +2,4 @@ kernelversion: 60
 kernelrelease: 4.15.0-1057-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -2,5 +2,4 @@ kernelversion: 61
 kernelrelease: 4.15.0-1058-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -1,0 +1,6 @@
+kernelversion: 61
+kernelrelease: 4.15.0-1058-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -1,0 +1,6 @@
+kernelversion: 62
+kernelrelease: 4.15.0-1059-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -2,5 +2,4 @@ kernelversion: 62
 kernelrelease: 4.15.0-1059-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -1,0 +1,6 @@
+kernelversion: 66
+kernelrelease: 4.15.0-1063-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -2,5 +2,4 @@ kernelversion: 66
 kernelrelease: 4.15.0-1063-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -1,0 +1,6 @@
+kernelversion: 67
+kernelrelease: 4.15.0-1064-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -2,5 +2,4 @@ kernelversion: 67
 kernelrelease: 4.15.0-1064-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -1,0 +1,6 @@
+kernelversion: 69
+kernelrelease: 4.15.0-1066-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -2,5 +2,4 @@ kernelversion: 69
 kernelrelease: 4.15.0-1066-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -1,0 +1,6 @@
+kernelversion: 70
+kernelrelease: 4.15.0-1067-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -2,5 +2,4 @@ kernelversion: 70
 kernelrelease: 4.15.0-1067-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -2,5 +2,4 @@ kernelversion: 72
 kernelrelease: 4.15.0-1069-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -1,0 +1,6 @@
+kernelversion: 72
+kernelrelease: 4.15.0-1069-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -1,0 +1,6 @@
+kernelversion: 73
+kernelrelease: 4.15.0-1070-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -2,5 +2,4 @@ kernelversion: 73
 kernelrelease: 4.15.0-1070-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -2,5 +2,4 @@ kernelversion: 76
 kernelrelease: 4.15.0-1072-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -1,0 +1,6 @@
+kernelversion: 76
+kernelrelease: 4.15.0-1072-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -2,5 +2,4 @@ kernelversion: 78
 kernelrelease: 4.15.0-1073-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -1,0 +1,6 @@
+kernelversion: 78
+kernelrelease: 4.15.0-1073-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -2,5 +2,4 @@ kernelversion: 81
 kernelrelease: 4.15.0-1076-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -1,0 +1,6 @@
+kernelversion: 81
+kernelrelease: 4.15.0-1076-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -1,0 +1,6 @@
+kernelversion: 82
+kernelrelease: 4.15.0-1077-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -2,5 +2,4 @@ kernelversion: 82
 kernelrelease: 4.15.0-1077-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -1,0 +1,6 @@
+kernelversion: 25
+kernelrelease: 5.4.0-1025-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -2,5 +2,4 @@ kernelversion: 25
 kernelrelease: 5.4.0-1025-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -1,0 +1,6 @@
+kernelversion: 28
+kernelrelease: 5.4.0-1027-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -2,5 +2,4 @@ kernelversion: 28
 kernelrelease: 5.4.0-1027-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -2,5 +2,4 @@ kernelversion: 31
 kernelrelease: 5.4.0-1029-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -1,0 +1,6 @@
+kernelversion: 31
+kernelrelease: 5.4.0-1029-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 5.4.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 5.4.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 5.4.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 5.4.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -1,0 +1,6 @@
+kernelversion: 37
+kernelrelease: 5.4.0-1035-gke
+target: ubuntu-generic
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1035-gke_37.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -2,5 +2,4 @@ kernelversion: 37
 kernelrelease: 5.4.0-1035-gke
 target: ubuntu-generic
 output:
-  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
   probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.4.0-1035-gke_37.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -2,5 +2,4 @@ kernelversion: 32
 kernelrelease: 4.15.0-1030-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -1,0 +1,6 @@
+kernelversion: 32
+kernelrelease: 4.15.0-1030-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 4.15.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 4.15.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 4.15.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 4.15.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -2,5 +2,4 @@ kernelversion: 36
 kernelrelease: 4.15.0-1034-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -1,0 +1,6 @@
+kernelversion: 36
+kernelrelease: 4.15.0-1034-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -1,0 +1,6 @@
+kernelversion: 38
+kernelrelease: 4.15.0-1036-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -2,5 +2,4 @@ kernelversion: 38
 kernelrelease: 4.15.0-1036-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -2,5 +2,4 @@ kernelversion: 39
 kernelrelease: 4.15.0-1037-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -1,0 +1,6 @@
+kernelversion: 39
+kernelrelease: 4.15.0-1037-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -1,0 +1,6 @@
+kernelversion: 42
+kernelrelease: 4.15.0-1040-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -2,5 +2,4 @@ kernelversion: 42
 kernelrelease: 4.15.0-1040-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -2,5 +2,4 @@ kernelversion: 43
 kernelrelease: 4.15.0-1041-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -1,0 +1,6 @@
+kernelversion: 43
+kernelrelease: 4.15.0-1041-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -1,0 +1,6 @@
+kernelversion: 44
+kernelrelease: 4.15.0-1042-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -2,5 +2,4 @@ kernelversion: 44
 kernelrelease: 4.15.0-1042-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -2,5 +2,4 @@ kernelversion: 46
 kernelrelease: 4.15.0-1044-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -1,0 +1,6 @@
+kernelversion: 46
+kernelrelease: 4.15.0-1044-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -2,5 +2,4 @@ kernelversion: 48
 kernelrelease: 4.15.0-1045-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -1,0 +1,6 @@
+kernelversion: 48
+kernelrelease: 4.15.0-1045-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -2,5 +2,4 @@ kernelversion: 49
 kernelrelease: 4.15.0-1046-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -1,0 +1,6 @@
+kernelversion: 49
+kernelrelease: 4.15.0-1046-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -1,0 +1,6 @@
+kernelversion: 51
+kernelrelease: 4.15.0-1048-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -2,5 +2,4 @@ kernelversion: 51
 kernelrelease: 4.15.0-1048-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -2,5 +2,4 @@ kernelversion: 52
 kernelrelease: 4.15.0-1049-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -1,0 +1,6 @@
+kernelversion: 52
+kernelrelease: 4.15.0-1049-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -1,0 +1,6 @@
+kernelversion: 53
+kernelrelease: 4.15.0-1050-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -2,5 +2,4 @@ kernelversion: 53
 kernelrelease: 4.15.0-1050-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -2,5 +2,4 @@ kernelversion: 55
 kernelrelease: 4.15.0-1052-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -1,0 +1,6 @@
+kernelversion: 55
+kernelrelease: 4.15.0-1052-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -2,5 +2,4 @@ kernelversion: 58
 kernelrelease: 4.15.0-1055-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -1,0 +1,6 @@
+kernelversion: 58
+kernelrelease: 4.15.0-1055-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -2,5 +2,4 @@ kernelversion: 60
 kernelrelease: 4.15.0-1057-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -1,0 +1,6 @@
+kernelversion: 60
+kernelrelease: 4.15.0-1057-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -1,0 +1,6 @@
+kernelversion: 61
+kernelrelease: 4.15.0-1058-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -2,5 +2,4 @@ kernelversion: 61
 kernelrelease: 4.15.0-1058-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -1,0 +1,6 @@
+kernelversion: 62
+kernelrelease: 4.15.0-1059-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -2,5 +2,4 @@ kernelversion: 62
 kernelrelease: 4.15.0-1059-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -1,0 +1,6 @@
+kernelversion: 66
+kernelrelease: 4.15.0-1063-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -2,5 +2,4 @@ kernelversion: 66
 kernelrelease: 4.15.0-1063-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -2,5 +2,4 @@ kernelversion: 67
 kernelrelease: 4.15.0-1064-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -1,0 +1,6 @@
+kernelversion: 67
+kernelrelease: 4.15.0-1064-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -2,5 +2,4 @@ kernelversion: 69
 kernelrelease: 4.15.0-1066-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -1,0 +1,6 @@
+kernelversion: 69
+kernelrelease: 4.15.0-1066-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -1,0 +1,6 @@
+kernelversion: 70
+kernelrelease: 4.15.0-1067-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -2,5 +2,4 @@ kernelversion: 70
 kernelrelease: 4.15.0-1067-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -2,5 +2,4 @@ kernelversion: 72
 kernelrelease: 4.15.0-1069-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -1,0 +1,6 @@
+kernelversion: 72
+kernelrelease: 4.15.0-1069-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -2,5 +2,4 @@ kernelversion: 73
 kernelrelease: 4.15.0-1070-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -1,0 +1,6 @@
+kernelversion: 73
+kernelrelease: 4.15.0-1070-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -1,0 +1,6 @@
+kernelversion: 76
+kernelrelease: 4.15.0-1072-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -2,5 +2,4 @@ kernelversion: 76
 kernelrelease: 4.15.0-1072-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -2,5 +2,4 @@ kernelversion: 78
 kernelrelease: 4.15.0-1073-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -1,0 +1,6 @@
+kernelversion: 78
+kernelrelease: 4.15.0-1073-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -2,5 +2,4 @@ kernelversion: 81
 kernelrelease: 4.15.0-1076-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -1,0 +1,6 @@
+kernelversion: 81
+kernelrelease: 4.15.0-1076-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -2,5 +2,4 @@ kernelversion: 82
 kernelrelease: 4.15.0-1077-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -1,0 +1,6 @@
+kernelversion: 82
+kernelrelease: 4.15.0-1077-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -1,0 +1,6 @@
+kernelversion: 25
+kernelrelease: 5.4.0-1025-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -2,5 +2,4 @@ kernelversion: 25
 kernelrelease: 5.4.0-1025-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -2,5 +2,4 @@ kernelversion: 28
 kernelrelease: 5.4.0-1027-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -1,0 +1,6 @@
+kernelversion: 28
+kernelrelease: 5.4.0-1027-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -1,0 +1,6 @@
+kernelversion: 31
+kernelrelease: 5.4.0-1029-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -2,5 +2,4 @@ kernelversion: 31
 kernelrelease: 5.4.0-1029-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 5.4.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 5.4.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 5.4.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 5.4.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -2,5 +2,4 @@ kernelversion: 37
 kernelrelease: 5.4.0-1035-gke
 target: ubuntu-generic
 output:
-  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
   probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1035-gke_37.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -1,0 +1,6 @@
+kernelversion: 37
+kernelrelease: 5.4.0-1035-gke
+target: ubuntu-generic
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-generic_5.4.0-1035-gke_37.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -2,5 +2,4 @@ kernelversion: 32
 kernelrelease: 4.15.0-1030-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -1,0 +1,6 @@
+kernelversion: 32
+kernelrelease: 4.15.0-1030-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 4.15.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 4.15.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 4.15.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 4.15.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -1,0 +1,6 @@
+kernelversion: 36
+kernelrelease: 4.15.0-1034-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -2,5 +2,4 @@ kernelversion: 36
 kernelrelease: 4.15.0-1034-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -1,0 +1,6 @@
+kernelversion: 38
+kernelrelease: 4.15.0-1036-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -2,5 +2,4 @@ kernelversion: 38
 kernelrelease: 4.15.0-1036-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -2,5 +2,4 @@ kernelversion: 39
 kernelrelease: 4.15.0-1037-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -1,0 +1,6 @@
+kernelversion: 39
+kernelrelease: 4.15.0-1037-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -2,5 +2,4 @@ kernelversion: 42
 kernelrelease: 4.15.0-1040-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -1,0 +1,6 @@
+kernelversion: 42
+kernelrelease: 4.15.0-1040-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -1,0 +1,6 @@
+kernelversion: 43
+kernelrelease: 4.15.0-1041-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -2,5 +2,4 @@ kernelversion: 43
 kernelrelease: 4.15.0-1041-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -2,5 +2,4 @@ kernelversion: 44
 kernelrelease: 4.15.0-1042-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -1,0 +1,6 @@
+kernelversion: 44
+kernelrelease: 4.15.0-1042-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -1,0 +1,6 @@
+kernelversion: 46
+kernelrelease: 4.15.0-1044-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -2,5 +2,4 @@ kernelversion: 46
 kernelrelease: 4.15.0-1044-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -2,5 +2,4 @@ kernelversion: 48
 kernelrelease: 4.15.0-1045-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -1,0 +1,6 @@
+kernelversion: 48
+kernelrelease: 4.15.0-1045-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -1,0 +1,6 @@
+kernelversion: 49
+kernelrelease: 4.15.0-1046-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -2,5 +2,4 @@ kernelversion: 49
 kernelrelease: 4.15.0-1046-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -2,5 +2,4 @@ kernelversion: 51
 kernelrelease: 4.15.0-1048-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -1,0 +1,6 @@
+kernelversion: 51
+kernelrelease: 4.15.0-1048-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -1,0 +1,6 @@
+kernelversion: 52
+kernelrelease: 4.15.0-1049-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -2,5 +2,4 @@ kernelversion: 52
 kernelrelease: 4.15.0-1049-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -2,5 +2,4 @@ kernelversion: 53
 kernelrelease: 4.15.0-1050-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -1,0 +1,6 @@
+kernelversion: 53
+kernelrelease: 4.15.0-1050-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -2,5 +2,4 @@ kernelversion: 55
 kernelrelease: 4.15.0-1052-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -1,0 +1,6 @@
+kernelversion: 55
+kernelrelease: 4.15.0-1052-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -2,5 +2,4 @@ kernelversion: 58
 kernelrelease: 4.15.0-1055-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -1,0 +1,6 @@
+kernelversion: 58
+kernelrelease: 4.15.0-1055-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -2,5 +2,4 @@ kernelversion: 60
 kernelrelease: 4.15.0-1057-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -1,0 +1,6 @@
+kernelversion: 60
+kernelrelease: 4.15.0-1057-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -1,0 +1,6 @@
+kernelversion: 61
+kernelrelease: 4.15.0-1058-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -2,5 +2,4 @@ kernelversion: 61
 kernelrelease: 4.15.0-1058-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -2,5 +2,4 @@ kernelversion: 62
 kernelrelease: 4.15.0-1059-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -1,0 +1,6 @@
+kernelversion: 62
+kernelrelease: 4.15.0-1059-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -1,0 +1,6 @@
+kernelversion: 66
+kernelrelease: 4.15.0-1063-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -2,5 +2,4 @@ kernelversion: 66
 kernelrelease: 4.15.0-1063-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -1,0 +1,6 @@
+kernelversion: 67
+kernelrelease: 4.15.0-1064-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -2,5 +2,4 @@ kernelversion: 67
 kernelrelease: 4.15.0-1064-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -1,0 +1,6 @@
+kernelversion: 69
+kernelrelease: 4.15.0-1066-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -2,5 +2,4 @@ kernelversion: 69
 kernelrelease: 4.15.0-1066-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -2,5 +2,4 @@ kernelversion: 70
 kernelrelease: 4.15.0-1067-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -1,0 +1,6 @@
+kernelversion: 70
+kernelrelease: 4.15.0-1067-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -2,5 +2,4 @@ kernelversion: 72
 kernelrelease: 4.15.0-1069-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -1,0 +1,6 @@
+kernelversion: 72
+kernelrelease: 4.15.0-1069-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -2,5 +2,4 @@ kernelversion: 73
 kernelrelease: 4.15.0-1070-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -1,0 +1,6 @@
+kernelversion: 73
+kernelrelease: 4.15.0-1070-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -2,5 +2,4 @@ kernelversion: 76
 kernelrelease: 4.15.0-1072-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -1,0 +1,6 @@
+kernelversion: 76
+kernelrelease: 4.15.0-1072-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -1,0 +1,6 @@
+kernelversion: 78
+kernelrelease: 4.15.0-1073-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -2,5 +2,4 @@ kernelversion: 78
 kernelrelease: 4.15.0-1073-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -1,0 +1,6 @@
+kernelversion: 81
+kernelrelease: 4.15.0-1076-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -2,5 +2,4 @@ kernelversion: 81
 kernelrelease: 4.15.0-1076-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -2,5 +2,4 @@ kernelversion: 82
 kernelrelease: 4.15.0-1077-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -1,0 +1,6 @@
+kernelversion: 82
+kernelrelease: 4.15.0-1077-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -2,5 +2,4 @@ kernelversion: 25
 kernelrelease: 5.4.0-1025-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -1,0 +1,6 @@
+kernelversion: 25
+kernelrelease: 5.4.0-1025-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -1,0 +1,6 @@
+kernelversion: 28
+kernelrelease: 5.4.0-1027-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -2,5 +2,4 @@ kernelversion: 28
 kernelrelease: 5.4.0-1027-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -2,5 +2,4 @@ kernelversion: 31
 kernelrelease: 5.4.0-1029-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -1,0 +1,6 @@
+kernelversion: 31
+kernelrelease: 5.4.0-1029-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 5.4.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 5.4.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 5.4.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 5.4.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -1,0 +1,6 @@
+kernelversion: 37
+kernelrelease: 5.4.0-1035-gke
+target: ubuntu-generic
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1035-gke_37.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -2,5 +2,4 @@ kernelversion: 37
 kernelrelease: 5.4.0-1035-gke
 target: ubuntu-generic
 output:
-  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
   probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_ubuntu-generic_5.4.0-1035-gke_37.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -2,5 +2,4 @@ kernelversion: 32
 kernelrelease: 4.15.0-1030-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1030-gke_32.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1030-gke_32.yaml
@@ -1,0 +1,6 @@
+kernelversion: 32
+kernelrelease: 4.15.0-1030-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1030-gke_32.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1030-gke_32.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 4.15.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1032-gke_34.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 4.15.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1032-gke_34.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1032-gke_34.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 4.15.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1033-gke_35.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 4.15.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1033-gke_35.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1033-gke_35.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -2,5 +2,4 @@ kernelversion: 36
 kernelrelease: 4.15.0-1034-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1034-gke_36.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1034-gke_36.yaml
@@ -1,0 +1,6 @@
+kernelversion: 36
+kernelrelease: 4.15.0-1034-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1034-gke_36.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1034-gke_36.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -2,5 +2,4 @@ kernelversion: 38
 kernelrelease: 4.15.0-1036-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1036-gke_38.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1036-gke_38.yaml
@@ -1,0 +1,6 @@
+kernelversion: 38
+kernelrelease: 4.15.0-1036-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1036-gke_38.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1036-gke_38.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -2,5 +2,4 @@ kernelversion: 39
 kernelrelease: 4.15.0-1037-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1037-gke_39.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1037-gke_39.yaml
@@ -1,0 +1,6 @@
+kernelversion: 39
+kernelrelease: 4.15.0-1037-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1037-gke_39.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1037-gke_39.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -2,5 +2,4 @@ kernelversion: 42
 kernelrelease: 4.15.0-1040-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1040-gke_42.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1040-gke_42.yaml
@@ -1,0 +1,6 @@
+kernelversion: 42
+kernelrelease: 4.15.0-1040-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1040-gke_42.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1040-gke_42.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -2,5 +2,4 @@ kernelversion: 43
 kernelrelease: 4.15.0-1041-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1041-gke_43.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1041-gke_43.yaml
@@ -1,0 +1,6 @@
+kernelversion: 43
+kernelrelease: 4.15.0-1041-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1041-gke_43.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1041-gke_43.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -2,5 +2,4 @@ kernelversion: 44
 kernelrelease: 4.15.0-1042-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1042-gke_44.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1042-gke_44.yaml
@@ -1,0 +1,6 @@
+kernelversion: 44
+kernelrelease: 4.15.0-1042-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1042-gke_44.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1042-gke_44.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -2,5 +2,4 @@ kernelversion: 46
 kernelrelease: 4.15.0-1044-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1044-gke_46.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1044-gke_46.yaml
@@ -1,0 +1,6 @@
+kernelversion: 46
+kernelrelease: 4.15.0-1044-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1044-gke_46.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -2,5 +2,4 @@ kernelversion: 48
 kernelrelease: 4.15.0-1045-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1045-gke_48.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1045-gke_48.yaml
@@ -1,0 +1,6 @@
+kernelversion: 48
+kernelrelease: 4.15.0-1045-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1045-gke_48.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1045-gke_48.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -2,5 +2,4 @@ kernelversion: 49
 kernelrelease: 4.15.0-1046-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1046-gke_49.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1046-gke_49.yaml
@@ -1,0 +1,6 @@
+kernelversion: 49
+kernelrelease: 4.15.0-1046-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1046-gke_49.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1046-gke_49.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -2,5 +2,4 @@ kernelversion: 51
 kernelrelease: 4.15.0-1048-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1048-gke_51.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1048-gke_51.yaml
@@ -1,0 +1,6 @@
+kernelversion: 51
+kernelrelease: 4.15.0-1048-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1048-gke_51.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1048-gke_51.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -1,0 +1,6 @@
+kernelversion: 52
+kernelrelease: 4.15.0-1049-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1049-gke_52.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1049-gke_52.yaml
@@ -2,5 +2,4 @@ kernelversion: 52
 kernelrelease: 4.15.0-1049-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1049-gke_52.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1049-gke_52.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -2,5 +2,4 @@ kernelversion: 53
 kernelrelease: 4.15.0-1050-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1050-gke_53.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1050-gke_53.yaml
@@ -1,0 +1,6 @@
+kernelversion: 53
+kernelrelease: 4.15.0-1050-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1050-gke_53.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1050-gke_53.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -1,0 +1,6 @@
+kernelversion: 55
+kernelrelease: 4.15.0-1052-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1052-gke_55.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1052-gke_55.yaml
@@ -2,5 +2,4 @@ kernelversion: 55
 kernelrelease: 4.15.0-1052-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1052-gke_55.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1052-gke_55.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -1,0 +1,6 @@
+kernelversion: 58
+kernelrelease: 4.15.0-1055-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1055-gke_58.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1055-gke_58.yaml
@@ -2,5 +2,4 @@ kernelversion: 58
 kernelrelease: 4.15.0-1055-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1055-gke_58.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1055-gke_58.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -2,5 +2,4 @@ kernelversion: 60
 kernelrelease: 4.15.0-1057-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1057-gke_60.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1057-gke_60.yaml
@@ -1,0 +1,6 @@
+kernelversion: 60
+kernelrelease: 4.15.0-1057-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1057-gke_60.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1057-gke_60.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -2,5 +2,4 @@ kernelversion: 61
 kernelrelease: 4.15.0-1058-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1058-gke_61.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1058-gke_61.yaml
@@ -1,0 +1,6 @@
+kernelversion: 61
+kernelrelease: 4.15.0-1058-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1058-gke_61.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1058-gke_61.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -2,5 +2,4 @@ kernelversion: 62
 kernelrelease: 4.15.0-1059-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1059-gke_62.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1059-gke_62.yaml
@@ -1,0 +1,6 @@
+kernelversion: 62
+kernelrelease: 4.15.0-1059-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1059-gke_62.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1059-gke_62.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -1,0 +1,6 @@
+kernelversion: 66
+kernelrelease: 4.15.0-1063-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1063-gke_66.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1063-gke_66.yaml
@@ -2,5 +2,4 @@ kernelversion: 66
 kernelrelease: 4.15.0-1063-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1063-gke_66.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1063-gke_66.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -1,0 +1,6 @@
+kernelversion: 67
+kernelrelease: 4.15.0-1064-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1064-gke_67.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1064-gke_67.yaml
@@ -2,5 +2,4 @@ kernelversion: 67
 kernelrelease: 4.15.0-1064-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1064-gke_67.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1064-gke_67.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -2,5 +2,4 @@ kernelversion: 69
 kernelrelease: 4.15.0-1066-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1066-gke_69.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1066-gke_69.yaml
@@ -1,0 +1,6 @@
+kernelversion: 69
+kernelrelease: 4.15.0-1066-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1066-gke_69.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1066-gke_69.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -1,0 +1,6 @@
+kernelversion: 70
+kernelrelease: 4.15.0-1067-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1067-gke_70.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1067-gke_70.yaml
@@ -2,5 +2,4 @@ kernelversion: 70
 kernelrelease: 4.15.0-1067-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1067-gke_70.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1067-gke_70.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -2,5 +2,4 @@ kernelversion: 72
 kernelrelease: 4.15.0-1069-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1069-gke_72.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1069-gke_72.yaml
@@ -1,0 +1,6 @@
+kernelversion: 72
+kernelrelease: 4.15.0-1069-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1069-gke_72.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1069-gke_72.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -1,0 +1,6 @@
+kernelversion: 73
+kernelrelease: 4.15.0-1070-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1070-gke_73.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1070-gke_73.yaml
@@ -2,5 +2,4 @@ kernelversion: 73
 kernelrelease: 4.15.0-1070-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1070-gke_73.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1070-gke_73.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -1,0 +1,6 @@
+kernelversion: 76
+kernelrelease: 4.15.0-1072-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1072-gke_76.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1072-gke_76.yaml
@@ -2,5 +2,4 @@ kernelversion: 76
 kernelrelease: 4.15.0-1072-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1072-gke_76.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1072-gke_76.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -2,5 +2,4 @@ kernelversion: 78
 kernelrelease: 4.15.0-1073-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1073-gke_78.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1073-gke_78.yaml
@@ -1,0 +1,6 @@
+kernelversion: 78
+kernelrelease: 4.15.0-1073-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1073-gke_78.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1073-gke_78.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -2,5 +2,4 @@ kernelversion: 81
 kernelrelease: 4.15.0-1076-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1076-gke_81.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1076-gke_81.yaml
@@ -1,0 +1,6 @@
+kernelversion: 81
+kernelrelease: 4.15.0-1076-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1076-gke_81.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1076-gke_81.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -1,0 +1,6 @@
+kernelversion: 82
+kernelrelease: 4.15.0-1077-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1077-gke_82.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_4.15.0-1077-gke_82.yaml
@@ -2,5 +2,4 @@ kernelversion: 82
 kernelrelease: 4.15.0-1077-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1077-gke_82.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1077-gke_82.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -2,5 +2,4 @@ kernelversion: 25
 kernelrelease: 5.4.0-1025-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1025-gke_25.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1025-gke_25.yaml
@@ -1,0 +1,6 @@
+kernelversion: 25
+kernelrelease: 5.4.0-1025-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1025-gke_25.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1025-gke_25.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -1,0 +1,6 @@
+kernelversion: 28
+kernelrelease: 5.4.0-1027-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1027-gke_28.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1027-gke_28.yaml
@@ -2,5 +2,4 @@ kernelversion: 28
 kernelrelease: 5.4.0-1027-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1027-gke_28.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1027-gke_28.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -2,5 +2,4 @@ kernelversion: 31
 kernelrelease: 5.4.0-1029-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1029-gke_31.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1029-gke_31.yaml
@@ -1,0 +1,6 @@
+kernelversion: 31
+kernelrelease: 5.4.0-1029-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1029-gke_31.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1029-gke_31.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -2,5 +2,4 @@ kernelversion: 34
 kernelrelease: 5.4.0-1032-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1032-gke_34.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1032-gke_34.yaml
@@ -1,0 +1,6 @@
+kernelversion: 34
+kernelrelease: 5.4.0-1032-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1032-gke_34.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1032-gke_34.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -2,5 +2,4 @@ kernelversion: 35
 kernelrelease: 5.4.0-1033-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1033-gke_35.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1033-gke_35.yaml
@@ -1,0 +1,6 @@
+kernelversion: 35
+kernelrelease: 5.4.0-1033-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1033-gke_35.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1033-gke_35.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -2,5 +2,4 @@ kernelversion: 37
 kernelrelease: 5.4.0-1035-gke
 target: ubuntu-generic
 output:
-  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
   probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1035-gke_37.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1035-gke_37.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/ubuntu-generic_5.4.0-1035-gke_37.yaml
@@ -1,0 +1,6 @@
+kernelversion: 37
+kernelrelease: 5.4.0-1035-gke
+target: ubuntu-generic
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_5.4.0-1035-gke_37.o


### PR DESCRIPTION
Thanks to https://github.com/falcosecurity/driverkit/pull/83 and to https://github.com/falcosecurity/driverkit/pull/84 we can now ship prebuilt drivers for GKE kernels (ubuntu-generic builder).

This PR adds the corresponding **DBG**/driverkit configuration files.

Blocked by https://github.com/falcosecurity/test-infra/pull/287