### PR TITLE
Update driverkit to 0.3.0 (build-drivers-* prowjob)

### DIFF
--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -1,7 +1,7 @@
 FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.2.0/driverkit_0.2.0_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.2.0_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.3.0/driverkit_0.3.0_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.3.0_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 

--- a/images/build-drivers/Makefile
+++ b/images/build-drivers/Makefile
@@ -9,9 +9,11 @@ build-push: build-image push-image
 
 build-image:
 	docker build -t $(IMG_NAME) .
+
 push-image:
 	docker tag $(IMG_NAME) $(IMAGE):$(TAG)
 	docker push $(IMAGE):$(TAG)
+
 local-registry:
 	aws ecr get-login-password \
 		| docker login \

--- a/images/build-drivers/build-drivers.sh
+++ b/images/build-drivers/build-drivers.sh
@@ -26,9 +26,6 @@ function start_docker() {
     echo "Done setting up docker in docker."
 }
 
-DISABLE_MD_LINTING=1
-DISABLE_MD_LINK_CHECK=1
-
 export PULL_PULL_SHA=$PULL_PULL_SHA
 
 echo "******************************************************"
@@ -48,7 +45,7 @@ echo "******************************************************"
 start_docker
 
 cd driverkit/
-make -e TARGET_DISTRO=$@ specific_target
+make -e TARGET_DISTRO="$1" specific_target
 
 make publish_s3
 


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

This PR updates the `falcosecurity/test-infra/build-drivers` container image that the `build-drivers-*` ProwJobs use to ship a bunch of prebuilt Falco drivers.

Such container image will now use [driverkit 0.3.0](https://github.com/falcosecurity/driverkit/releases/tag/v0.3.0) (mainly for shipping some prebuilt Falco drivers for GKE kernels).