### PR TITLE
Fix the update-jobs image and ProwJob

### DIFF
--- a/images/update-jobs/Makefile
+++ b/images/update-jobs/Makefile
@@ -1,14 +1,19 @@
-IMG_NAME = test-infra/update-jobs
+SHELL := /bin/bash
+
+IMG_SLUG := test-infra
+IMG_NAME = update-jobs
+IMG_TAG ?= latest
+
 ACCOUNT=292999226676
 DOCKER_PUSH_REPOSITORY=dkr.ecr.eu-west-1.amazonaws.com
-TAG?=latest
-IMAGE=$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_NAME)
 
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME):$(IMG_TAG)"
 
 build-push: build-image push-image
 
 build-image:
-	docker build -t $(IMG_NAME) .
+	docker build -t "$(IMG_SLUG)/$(IMG_NAME)" .
+
 push-image:
-	docker tag $(IMG_NAME) $(IMAGE):$(TAG)
-	docker push $(IMAGE):$(TAG)
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" $(IMAGE)
+	docker push $(IMAGE)

--- a/images/update-jobs/update-jobs.sh
+++ b/images/update-jobs/update-jobs.sh
@@ -2,18 +2,14 @@
 set -eo pipefail
 set -o errexit
 
-DISABLE_MD_LINTING=1
-DISABLE_MD_LINK_CHECK=1
-export GO111MODULE=off
-
 export PULL_PULL_SHA=$PULL_PULL_SHA
 
 echo "******************************************************"
-echo "DryRun of updating job configs for github PR hash $PULL_PULL_SHA"
+echo "DryRun of updating job configs for GitHub PR hash $PULL_PULL_SHA"
 echo "******************************************************"
 
 # Using prowjob elements:
-# decorate: true 
+# decorate: true
 # Will pull in the PR git HASH into the image via the Initupload Sidecar
 
 export GOPATH="/home/prow/go"
@@ -21,7 +17,11 @@ export KUBECONFIG="/root/.kube/config"
 
 cd /home/prow/go/src/github.com/falcosecurity/test-infra/prow/update-jobs
 
-go get -u github.com/golang/dep/cmd/dep
+echo "******************************************************"
+echo "Building update-jobs"
+echo "******************************************************"
+
+make build
 
 echo "******************************************************"
 echo "Adding EKS value to kubeconfig"
@@ -30,12 +30,10 @@ echo "******************************************************"
 aws eks --region eu-west-1 update-kubeconfig --name falco-prow-test-infra
 
 echo "******************************************************"
-echo "Updating Go Dep and running job update"
+echo "Running job update"
 echo "******************************************************"
 
-dep ensure
-
-go run main.go --kubeconfig $KUBECONFIG --jobs-config-path /home/prow/go/src/github.com/falcosecurity/test-infra/config/jobs
+bin/update-jobs --kubeconfig $KUBECONFIG --jobs-config-path /home/prow/go/src/github.com/falcosecurity/test-infra/config/jobs
 
 echo "******************************************************"
 echo "Updated-jobs image"


### PR DESCRIPTION
Fixes #285 

The `update-jobs` go tool uses go modules now. The image needs to be updated accordingly.