### PR TITLE
Pin update-jobs stable image until tests on latest pass

### DIFF
--- a/config/jobs/update-jobs/update-jobs.yaml
+++ b/config/jobs/update-jobs/update-jobs.yaml
@@ -13,5 +13,5 @@ postsubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-jobs:latest
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-jobs:stable
         imagePullPolicy: Always


### PR DESCRIPTION
Latest images are pushed on PR presubmit and jobs pick always latest version of them.

In example `update-jobs` lastest image is published from #292 but with neither the PR being accepted nor required new `prowjob` configurations put in place.

The stable version of `update-jobs` (the version before the #292 latest) container image has been tagged `stable` and `1.0.0`.