### PR TITLE
fixing rbac for update-jobs

### DIFF
--- a/config/prow/update-jobs.yaml
+++ b/config/prow/update-jobs.yaml
@@ -28,13 +28,12 @@ roleRef:
   kind: Role
   name: update-jobs
 subjects:
-- apiGroup: ''
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: update-jobs
-  namespace: default
+  namespace: test-pods
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: update-jobs
-  namespace: default
+  namespace: test-pods


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

RBAC wasn't working from the re-write.

`time="2021-02-02T15:00:04Z" 
level=fatal msg="while updating jobs: configmaps \"job-config\" is forbidden: User \"system:serviceaccount:test-pods:update-jobs\" cannot update resource \"configmaps\" in API group \"\" in the namespace \"default\""`

Changed RBAC to work properly, and periodic test looks like it passed using new RBAC.  https://prow.falco.org/view/s3/falco-prow-logs/logs/update-jobs-periodic/1356633460638224384