### PR TITLE
Use multiarch AWS EBS CSI driver kustomization

### DIFF
--- a/tools/deploy_prow.sh
+++ b/tools/deploy_prow.sh
@@ -24,7 +24,7 @@ function updateKubeConfig() {
 
 function launchConfig(){
   #ALB Ingress and ebs CSI driver
-  kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/arm64/?ref=v0.9.0"
+  kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/arm64/?ref=release-0.9"
 
   kubectl create configmap plugins --from-file=plugins.yaml=./config/plugins.yaml || true
   kubectl create configmap config --from-file "./config/config.yaml" || true


### PR DESCRIPTION
This PR will inherit benefit from [PR](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/731) merged to driver repository.
In detail, all the driver components will now use multiarch container images. 

In the meantime I asked to push a new semantic versioning tag like `v0.9.1`. 