### PR TITLE
update(config): initial `falcosidekick-ui` prow configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -158,6 +158,11 @@ branch-protection:
           branches:
             master:
               protect: true
+        falcosidekick-ui:
+          # todo(leogr): add required_status_checks once CI setup has been done
+          branches:
+            master:
+              protect: true
         falco-exporter:
           branches:
             master:
@@ -224,6 +229,7 @@ tide:
     falcosecurity/event-generator: rebase
     falcosecurity/falco: rebase
     falcosecurity/falcosidekick: rebase
+    falcosecurity/falcosidekick-ui: rebase
     falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
     falcosecurity/falco-website: rebase
@@ -422,6 +428,18 @@ tide:
         - needs-rebase
     - repos:
         - falcosecurity/falcosidekick
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - falcosecurity/falcosidekick-ui
       labels:
         - approved
         - lgtm

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -16,6 +16,7 @@ approve:
       - falcosecurity/falco
       - falcosecurity/falcoctl
       - falcosecurity/falcosidekick
+      - falcosecurity/falcosidekick-ui
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
       - falcosecurity/kilt
@@ -67,6 +68,7 @@ lgtm:
       - falcosecurity/falco
       - falcosecurity/falcoctl
       - falcosecurity/falcosidekick
+      - falcosecurity/falcosidekick-ui
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
       - falcosecurity/kilt
@@ -189,6 +191,14 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: falcosidekick
+    prs: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this PR.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: falcosidekick-ui
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -548,6 +558,28 @@ plugins:
     - verify-owners
     - welcome
     - wip
+  falcosecurity/falcosidekick-ui:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - dog
+    - golint
+    - goose
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - mergecommitblocker
+    - require-matching-label
+    - retitle
+    - size
+    - verify-owners
+    - welcome
+    - wip
   falcosecurity/falco-exporter:
     - approve
     - assign
@@ -753,6 +785,10 @@ external_plugins:
       events:
         - issue_comment
   falcosecurity/falcosidekick:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/falcosidekick-ui:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
As per the approved incubation request https://github.com/falcosecurity/evolution/issues/47, this PR adds the initial prow configuration for https://github.com/falcosecurity/falcosidekick-ui

/cc @leodido 