### PR TITLE
update(test-infra/config): add target URL for tide

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -214,6 +214,7 @@ pod_namespace: test-pods
 prowjob_namespace: default
 
 tide:
+  target_url: https://prow.falco.org/tide
   context_options:
     skip-unknown-contexts: true
     from-branch-protection: true


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

As per [docs](https://github.com/kubernetes/test-infra/blob/2abb7ff26579325f6a335990003f665755c96d7a/prow/cmd/tide/config.md#general-configuration) we need an URL for tide status contexts.