### PR TITLE
Configure Prow (@poiana) for falcosecurity/libs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,7 +31,7 @@ plank:
   pod_pending_timeout: 60m
   default_decoration_configs:
     '*':
-      timeout: 24h # Up to 12 hours for driverkit builder jobs
+      timeout: 24h # Up to 24 hours for driverkit builder jobs
       grace_period: 10m
       utility_images:
         clonerefs: "gcr.io/k8s-prow/clonerefs:v20210211-72696ce111"
@@ -191,6 +191,10 @@ branch-protection:
           branches:
             master:
               protect: true
+        libs:
+          branches:
+            master:
+              protect: true
         pdig:
           branches:
             master:
@@ -239,6 +243,7 @@ tide:
     falcosecurity/falcoctl: rebase
     falcosecurity/falco-website: rebase
     falcosecurity/kilt: rebase
+    falcosecurity/libs: rebase
     falcosecurity/pdig: rebase
     falcosecurity/template-repository: rebase
     falcosecurity/test-infra: rebase
@@ -507,6 +512,19 @@ tide:
         - needs-rebase
     - repos:
         - falcosecurity/kilt
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
+        - needs-rebase
+    - repos:
+        - falcosecurity/libs
       labels:
         - approved
         - lgtm

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -192,6 +192,8 @@ branch-protection:
             master:
               protect: true
         libs:
+          required_pull_request_reviews:
+            required_approving_review_count: 2
           branches:
             master:
               protect: true

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -20,6 +20,7 @@ approve:
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
       - falcosecurity/kilt
+      - falcosecurity/libs
       - falcosecurity/pdig
       - falcosecurity/template-repository
       - falcosecurity/test-infra
@@ -72,6 +73,7 @@ lgtm:
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
       - falcosecurity/kilt
+      - falcosecurity/libs
       - falcosecurity/pdig
       - falcosecurity/template-repository
       - falcosecurity/test-infra
@@ -236,6 +238,14 @@ require_matching_label:
     missing_comment: |
       There is not a label identifying the kind of this issue.
       Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: libs
+    issues: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this issue.
+      Please specify it either using `/kind <group>` or manually from the side menu.
 
 retitle:
   allow_closed_issues: true
@@ -250,7 +260,7 @@ size:
 triggers:
 - repos:
   - falcosecurity
-  join_org_url: "https://github.com/falcosecurity/falco/blob/master/GOVERNANCE.md#process-for-becoming-a-maintainer"
+  join_org_url: "https://github.com/falcosecurity/.github/blob/master/GOVERNANCE.md"
   only_org_members: true
 
 plugins:
@@ -664,6 +674,28 @@ plugins:
     - verify-owners
     - welcome
     - wip
+  falcosecurity/libs:
+    - approve
+    - assign
+    - blunderbuss
+    - branchcleaner
+    - cat
+    - dco
+    - dog
+    - goose
+    - help
+    - hold
+    - label
+    - lifecycle
+    - lgtm
+    - mergecommitblocker
+    - release-note
+    - require-matching-label
+    - retitle
+    - size
+    - verify-owners
+    - welcome
+    - wip
   falcosecurity/pdig:
     - approve
     - assign
@@ -716,7 +748,7 @@ plugins:
     - hold  # Support /hold to delay merge
     - lifecycle # Allow /lifecycle stale
     - lgtm # Allow /lgtm
-    - retitle 
+    - retitle
     - size # Auto-label size of PR
     - trigger  # Allow people to configure CI jobs to /test
     - verify-owners # Validates OWNERS file changes in PRs.
@@ -805,6 +837,10 @@ external_plugins:
       events:
         - pull_request
   falcosecurity/kilt:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/libs:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
This PR adds @poiana (stop the drama!) to the [libs](https://github.com/falcosecurity/libs) repository.

Plugins:

  - approve
  - assign
  - blunderbuss
  - branchcleaner
  - cat
  - dco
  - dog
  - goose
  - help
  - hold
  - label
  - lifecycle
  - lgtm
  - mergecommitblocker
  - release-note
  - require-matching-label
  - retitle
  - size
  - verify-owners
  - welcome
  - wip

Labels:

- At least a "kind/*" label

Protected branches:

- master

Merging strategy:

- rebase

PR checks & auto-merge (tide):

- must be "approved"
- must have a "lgtm" review
- commits must be signed-off (DCO)
- must NOT have "do-not-merge/*" labels
- must NOT have "needs-rebase" label