### PR TITLE
Add build-libs AWS ECR Repository

### DIFF
--- a/tools/create_ecr.sh
+++ b/tools/create_ecr.sh
@@ -8,3 +8,4 @@ aws ecr create-repository --repository-name test-infra/build-drivers || true
 aws ecr create-repository --repository-name test-infra/docker-dind || true
 aws ecr create-repository --repository-name test-infra/autobump || true
 aws ecr create-repository --repository-name test-infra/arm-build || true
+aws ecr create-repository --repository-name test-infra/build-libs || true


### PR DESCRIPTION
An entry for creation of the `build-libs` OCI image repository on AWS ECR is added with this PR.