### PR TITLE
update(config/jobs/build-libs): add build job with no bundled deps

### DIFF
--- a/config/jobs/build-libs/build-libs.yaml
+++ b/config/jobs/build-libs/build-libs.yaml
@@ -1,5 +1,29 @@
 presubmits:
   falcosecurity/libs:
+  - name: build-libs
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    always_run: true  # Run for every PR, but master
+    spec:
+      containers:
+      - command:
+        - /build.sh
+        args:
+        - -DBUILD_BPF=On
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-libs:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+      nodeSelector:
+        Archtype: "x86"
   - name: build-libs-bundled-deps
     decorate: true
     skip_report: false

--- a/config/jobs/build-libs/build-libs.yaml
+++ b/config/jobs/build-libs/build-libs.yaml
@@ -16,8 +16,6 @@ presubmits:
           value: eu-west-1
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-libs:latest
         imagePullPolicy: Always
-        securityContext:
-          privileged: true
         resources:
           requests:
             memory: 3Gi
@@ -41,8 +39,6 @@ presubmits:
           value: eu-west-1
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-libs:latest
         imagePullPolicy: Always
-        securityContext:
-          privileged: true
         resources:
           requests:
             memory: 3Gi


### PR DESCRIPTION
Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

Add another test job similar to the previous one, but without the `-DUSE_BUNDLED_DEPS` build option.
Follow up #319, #321, and #322 

/cc @leodido 
/cc @maxgio92 