### PR TITLE
Import container image repositories to Terraform state

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -1,0 +1,27 @@
+resource "aws_ecr_repository" "update_jobs" {
+  name = "test-infra/update-jobs"
+}
+
+resource "aws_ecr_repository" "golang" {
+  name = "test-infra/golang"
+}
+
+resource "aws_ecr_repository" "build_drivers" {
+  name = "test-infra/build-drivers"
+}
+
+resource "aws_ecr_repository" "docker_dind" {
+  name = "test-infra/docker-dind"
+}
+
+resource "aws_ecr_repository" "autobump" {
+  name = "test-infra/autobump"
+}
+
+resource "aws_ecr_repository" "arm_build" {
+  name = "test-infra/arm-build"
+}
+
+resource "aws_ecr_repository" "build_libs" {
+  name = "test-infra/build-libs"
+}

--- a/tools/deploy_terraform.sh
+++ b/tools/deploy_terraform.sh
@@ -47,8 +47,8 @@ function importEcrRepositoriesToTerraformState() {
   for ecr_repository in $ecr_repositories; do
     echo
     echo "> AWS ECR Repository name: ${ecr_repository}"
-    TF_RESOURCE="${ecr_repository/test-infra\//}"
-    TF_RESOURCE="${tf_resource/-/_}"
+    tf_resource="${ecr_repository/test-infra\//}"
+    tf_resource="${tf_resource/-/_}"
     echo "  TF Resource Name: ${tf_resource}"
 
     terraform import aws_ecr_repository.${tf_resource} ${ecr_repository}


### PR DESCRIPTION
This PR will:
- declare the AWS ECR repositories used for the infra containers as code
- import the existing ones to the Terraform state, right before applying the code, of which plan should have desired state matching the actual one.

[Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#import)