### PR TITLE
update(images/build-drivers): switch to use driverkit v0.4.0

### DIFF
--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -1,7 +1,7 @@
 FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.3.0/driverkit_0.3.0_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.3.0_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.4.0/driverkit_0.4.0_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.4.0_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 


### PR DESCRIPTION
Co-authored-by: Michele Zuccala <michele@zuccala.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

I and @zuc just released driverkit v0.4.0 (read the CHANGELOG [here](https://github.com/falcosecurity/driverkit/releases/tag/v0.4.0), notably the support for AmazonLinux 2 `5.*` kernels).

This PR updates the `build-drivers-*` ProwJobs image in order to use this new version.