### PR TITLE
Add jobs to push falco-exporter and falco-sidekick plain manifests from Helm charts

### DIFF
--- a/config/jobs/update-falco-k8s-manifests/update-falco-k8s-manifests.yaml
+++ b/config/jobs/update-falco-k8s-manifests/update-falco-k8s-manifests.yaml
@@ -21,6 +21,92 @@ periodics:
         env:
         - name: GH_PROXY
           value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+        - name: HELM_CHART_NAME
+          value: falco
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+        - name: gpg-signing-key
+          mountPath: /root/gpg-signing-key/
+          readOnly: true
+      volumes:
+      - name: github
+        secret:
+          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+          secretName: oauth-token
+      - name: gpg-signing-key
+        secret:
+          secretName: poiana-gpg-signing-key
+          defaultMode: 0400
+      nodeSelector:
+        Archtype: "x86"
+  - name: update-falco-exporter-k8s-manifests
+    cron: "0 7 * * *" # Run everyday at 7:00
+    decorate: true
+    extra_refs:
+    # Check out the falcosecurity/evolution repo
+    # This will be the working directory
+    - org: falcosecurity
+      repo: evolution
+      base_ref: master
+      workdir: true
+    spec:
+      containers:
+      # See images/update-falco-k8s-manifests
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-falco-k8s-manifests
+        imagePullPolicy: Always
+        command:
+        - /entrypoint.sh
+        args:
+        - /etc/github-token/oauth
+        env:
+        - name: GH_PROXY
+          value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+        - name: HELM_CHART_NAME
+          value: falco-exporter
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+        - name: gpg-signing-key
+          mountPath: /root/gpg-signing-key/
+          readOnly: true
+      volumes:
+      - name: github
+        secret:
+          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+          secretName: oauth-token
+      - name: gpg-signing-key
+        secret:
+          secretName: poiana-gpg-signing-key
+          defaultMode: 0400
+      nodeSelector:
+        Archtype: "x86"
+  - name: update-falco-sidekick-k8s-manifests
+    cron: "0 7 * * *" # Run everyday at 7:00
+    decorate: true
+    extra_refs:
+    # Check out the falcosecurity/evolution repo
+    # This will be the working directory
+    - org: falcosecurity
+      repo: evolution
+      base_ref: master
+      workdir: true
+    spec:
+      containers:
+      # See images/update-falco-k8s-manifests
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-falco-k8s-manifests
+        imagePullPolicy: Always
+        command:
+        - /entrypoint.sh
+        args:
+        - /etc/github-token/oauth
+        env:
+        - name: GH_PROXY
+          value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+        - name: HELM_CHART_NAME
+          value: falcosidekick
         volumeMounts:
         - name: github
           mountPath: /etc/github-token


### PR DESCRIPTION
This PR enable the image `update-falco-k8s-manifests` to `template` every Helm chart from `falcosecurity` Helm repository and push them to `evolution` repo.
It also adds two new jobs to generate and push manifests for `falco-exporter` and `falco-sidekick`. 