### PR TITLE
Generate Kustomizations for Falco ecosystem components

### DIFF
--- a/images/update-falco-k8s-manifests/Dockerfile
+++ b/images/update-falco-k8s-manifests/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && apt-get clean
 
-RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+RUN curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+RUN curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
 
 COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin
 COPY entrypoint.sh /

--- a/images/update-falco-k8s-manifests/entrypoint.sh
+++ b/images/update-falco-k8s-manifests/entrypoint.sh
@@ -42,7 +42,9 @@ generate_deployment_files() {
 
     echo "> generating template files"
     # inspired by https://github.com/helm/helm/issues/4680#issuecomment-613201032
-    helm template "${chart_name}" "falcosecurity/${chart_name}" --dry-run | awk -vout=$1 -F": " '
+    helm template --dry-run \
+      "${chart_name}" "falcosecurity/${chart_name}" \
+      | awk -vout=$1 -F": " '
         $0~/^# Source: / {
             file=out"/"$2;
             if (!(file in filemap)) {
@@ -55,7 +57,11 @@ generate_deployment_files() {
             if (file) {
                 print $0 >> file;
             }
-        }' && return 0
+        }' && \
+        { pushd ${1}/${chart_name} && \
+          kustomize create --autodetect --recursive && \
+          popd ; } && \
+        return 0
     echo "ERROR: Unable to generate deployment files from helm template" >&2
     return 1
 }

--- a/images/update-falco-k8s-manifests/entrypoint.sh
+++ b/images/update-falco-k8s-manifests/entrypoint.sh
@@ -42,7 +42,7 @@ generate_deployment_files() {
 
     echo "> generating template files"
     # inspired by https://github.com/helm/helm/issues/4680#issuecomment-613201032
-    helm template --dry-run \
+    helm template --skip-tests --dry-run \
       "${chart_name}" "falcosecurity/${chart_name}" \
       | awk -vout=$1 -F": " '
         $0~/^# Source: / {


### PR DESCRIPTION
This PR updates the `update-falco-k8s-manifests` `ProwJob` image to include a base `Kustomization` file for components of which Kubernetes manifests are generated, in order to provide a version-zero support for users that use Kustomize to manage Kubernetes configurations.

So, in the end for who wants to manage his configurations with Kustomize will (from [evolution](https://github.com/falcosecurity/evolution) root folder):
```
kubectl apply -k deploy/kubernetes/falco
```
and who doesn't:
```
kubectl apply -f deploy/kubernetes/falco/templates
```