### PR TITLE
Fix Kustomize path in images/update-falco-k8s-manifests/dockerfile

### DIFF
--- a/images/update-falco-k8s-manifests/Dockerfile
+++ b/images/update-falco-k8s-manifests/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean
 
 RUN curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-RUN curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
+RUN curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s /usr/local/bin
 
 COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin
 COPY entrypoint.sh /


### PR DESCRIPTION
This PR fixes the path where Kustomize is installed to.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>