### PR TITLE
update(config): protect branch v0.27 of the falco-website

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -184,6 +184,8 @@ branch-protection:
               protect: true
             v0.26:
               protect: true
+            v0.27:
+              protect: true
           required_status_checks:
             contexts:
               - "netlify/falcosecurity/deploy-preview"


### PR DESCRIPTION
As per [website release instructions](https://github.com/falcosecurity/falco-website/blob/master/release.md#create-a-new-website-snapshot).

This PR needs to be merged in after:

- Falco 0.28 released
- falco-website snapshot for Falco 0.27 created (branch v0.27)

/hold

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>