### PR TITLE
feat/adding lifecycle rule for data log storage

### DIFF
--- a/config/clusters/storage.tf
+++ b/config/clusters/storage.tf
@@ -3,10 +3,23 @@ resource "aws_s3_bucket" "prow_storage" {
 
   acl = "private"
 
-  lifecycle {
-    prevent_destroy = false
-  }
-
+  lifecycle_rule = [{
+    id      = "ten_day_retention_logs"
+    prefix  = "logs/"
+    enabled = true
+    expiration = {
+      days = 10
+    }
+    },
+    {
+      id      = "ten_day_retention_pr_logs"
+      prefix  = "pr-logs/"
+      enabled = true
+      expiration = {
+        days = 10
+      }
+    }
+  ]
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -22,7 +35,6 @@ resource "aws_s3_bucket" "prow_storage" {
 
   tags = module.label.tags
 }
-
 resource "aws_kms_key" "prow_storage" {
   description             = "Prow storage master encryption key"
   deletion_window_in_days = 10


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

In an effort to cut costs, I checked s3 bucket sizes and found that `falco-prow-logs` s3 bucket is now at `84gb` in storage.

Adding rule to recycle and logs older than 10 days as we only keep prowjobs around for 2days currently.