### PR TITLE
bug - fixing tide mis-match approval bug for falco and libs repos

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -13,21 +13,26 @@ approve:
       - falcosecurity/evolution
       - falcosecurity/driverkit
       - falcosecurity/event-generator
-      - falcosecurity/falco
       - falcosecurity/falcoctl
       - falcosecurity/falcosidekick
       - falcosecurity/falcosidekick-ui
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
       - falcosecurity/kilt
-      - falcosecurity/libs
       - falcosecurity/pdig
       - falcosecurity/template-repository
       - falcosecurity/test-infra
     lgtm_acts_as_approve: true
     require_self_approval: true
     commandHelpLink: https://prow.falco.org/command-help
-
+  - repos:
+      - falcosecurity/falco
+      - falcosecurity/libs
+    lgtm_acts_as_approve: true
+    require_self_approval: true
+    commandHelpLink: https://prow.falco.org/command-help
+    ignore_review_state: true
+    
 blunderbuss:
   max_request_count: 2
   use_status_availability: true


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

Currently we are encountering an issue. The issue is that Tide is seeing an approval tag being applied to a PR in `falco` when it's gets a Github approval. However the repo requires 2 approvals so Tide is trying to merge the PR but branchprotector is stopping it, causing an endless cycle of merge attempts.

This is because in the `config.yml` we require 2 approvals for both the `falco` and the `libs` repo's.

```
     falco:
          required_pull_request_reviews:
            required_approving_review_count: 2
```

This fix would only allow the approve label to be applied via an approver typing `/approve` when it has the required 2 reviews, and not by a single github review. 

Link to config in docs https://github.com/kubernetes/test-infra/blob/40c5a1d1b758201872804ec32ebad03845cffd47/prow/plugins/plugin-config-documented.yaml#L11

Picture of the problem it's causing.

<img width="1431" alt="Screen Shot 2021-04-21 at 5 51 42 PM" src="https://user-images.githubusercontent.com/34656423/115630847-5b130a00-a2ca-11eb-9232-108e4fa463d5.png">

