### PR TITLE
fix trying to fix  s3 lifecycle rule

### DIFF
--- a/config/clusters/storage.tf
+++ b/config/clusters/storage.tf
@@ -3,23 +3,23 @@ resource "aws_s3_bucket" "prow_storage" {
 
   acl = "private"
 
-  lifecycle_rule = [{
+  lifecycle_rule = {
     id      = "ten_day_retention_logs"
     prefix  = "logs/"
     enabled = true
     expiration = {
       days = 10
     }
-    },
-    {
+  }
+
+  lifecycle_rule = {
       id      = "ten_day_retention_pr_logs"
       prefix  = "pr-logs/"
       enabled = true
       expiration = {
         days = 10
       }
-    }
-  ]
+  }
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {

--- a/config/clusters/storage.tf
+++ b/config/clusters/storage.tf
@@ -4,21 +4,12 @@ resource "aws_s3_bucket" "prow_storage" {
   acl = "private"
 
   lifecycle_rule = {
-    id      = "ten_day_retention_logs"
-    prefix  = "logs/"
+    id      = "ten_day_retention_pr_logs"
+    prefix  = "pr-logs/"
     enabled = true
     expiration = {
       days = 10
     }
-  }
-
-  lifecycle_rule = {
-      id      = "ten_day_retention_pr_logs"
-      prefix  = "pr-logs/"
-      enabled = true
-      expiration = {
-        days = 10
-      }
   }
   server_side_encryption_configuration {
     rule {


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

`/pr-logs` has most of the log data, and it doesn't look like Terraform easily supports adding multiple lifecycle policies per bucket.