### PR TITLE
Configure Deck to get PR status from Github

### DIFF
--- a/config/prow/deck.yaml
+++ b/config/prow/deck.yaml
@@ -123,11 +123,11 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --plugin-config=/etc/plugins/plugins.yaml
-        # - --github-oauth-config-file=/etc/githuboauth/secret
+        - --github-oauth-config-file=/etc/githuboauth/secret
         # - --kubeconfig=/etc/kubeconfig/config
         # - --cookie-secret=/etc/cookie/secret
         # - --rerun-creates-job
-        # - --oauth-url=/github-login
+        - --oauth-url=/github-login
         # - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
@@ -145,9 +145,9 @@ spec:
         # - name: oauth
         #   mountPath: /etc/github
         #   readOnly: true
-        # - name: oauth-config
-        #   mountPath: /etc/githuboauth
-        #   readOnly: true
+        - name: oauth-config
+          mountPath: /etc/githuboauth
+          readOnly: true
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
@@ -157,20 +157,20 @@ spec:
         # - name: kubeconfig
         #   mountPath: /etc/kubeconfig
         #   readOnly: true
-        # - name: cookie-secret
-        #   mountPath: /etc/cookie
-        #   readOnly: true
+        - name: cookie-secret
+          mountPath: /etc/cookie
+          readOnly: true
       volumes:
       # - name: kubeconfig
       #   secret:
       #     defaultMode: 420
       #     secretName: kubeconfig
-      # - name: oauth-config
-      #   secret:
-      #       secretName: github-oauth-config
-      # - name: cookie-secret
-      #   secret:
-      #       secretName: cookie
+      - name: oauth-config
+        secret:
+            secretName: github-oauth-config
+      - name: cookie-secret
+        secret:
+            secretName: cookie
       - name: config
         configMap:
           name: config

--- a/tools/deploy_prow.sh
+++ b/tools/deploy_prow.sh
@@ -37,6 +37,10 @@ function launchConfig(){
   kubectl create secret generic hmac-token --from-literal=hmac="$(./tools/1password.sh -d config/prow/hmac-token)" || true
   kubectl create secret generic oauth-token --from-literal=oauth="$(./tools/1password.sh -d config/prow/oauth-token)" || true
   kubectl create secret generic oauth-token --from-literal=oauth="$(./tools/1password.sh -d config/prow/oauth-token)" -n test-pods || true
+
+  # PR Status
+  kubectl create secret generic github-oauth-config --from-literal=oauth="$(./tools/1password.sh -d prow-prstatus-github-oauth-app.yaml)" || true
+  kubectl create secret generic cookie --from-literal=oauth="$(./tools/1password.sh -d prow-prstatus-cookie-encryption-key.txt)" || true
   
   # Related to OAuth setup... need to setup base url on Github for callback before we can create these
   


### PR DESCRIPTION
This PR introduces the PR status page.

This is accomplished by configuring OAuth so that Deck can access GH resources via API, on behalf of the authenticated Github identity.

Closes #23.