### PR TITLE
fix(config/clusters/storage.tf): s3 bucket lifecycle aws provider syntax

### DIFF
--- a/config/clusters/storage.tf
+++ b/config/clusters/storage.tf
@@ -3,23 +3,24 @@ resource "aws_s3_bucket" "prow_storage" {
 
   acl = "private"
 
-  lifecycle_rule = [{
+  lifecycle_rule {
     id      = "ten_day_retention_logs"
     prefix  = "logs/"
     enabled = true
     expiration = {
       days = 10
     }
-    },
-    {
-      id      = "ten_day_retention_pr_logs"
-      prefix  = "pr-logs/"
-      enabled = true
-      expiration = {
-        days = 10
-      }
+  }
+
+  lifecycle_rule {
+    id      = "ten_day_retention_pr_logs"
+    prefix  = "pr-logs/"
+    enabled = true
+    expiration = {
+      days = 10
     }
-  ]
+  }
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -35,6 +36,7 @@ resource "aws_s3_bucket" "prow_storage" {
 
   tags = module.label.tags
 }
+
 resource "aws_kms_key" "prow_storage" {
   description             = "Prow storage master encryption key"
   deletion_window_in_days = 10


### PR DESCRIPTION
This PR should fix and unblock syntax errors that now are blocking the CI/CD of the infrastructure.
/cc @jonahjon WDYT?