### PR TITLE
fix(config/clusters/storage.tf): s3 bucket lifecycle aws provider syntax

### DIFF
--- a/config/clusters/storage.tf
+++ b/config/clusters/storage.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "prow_storage" {
     id      = "ten_day_retention_logs"
     prefix  = "logs/"
     enabled = true
-    expiration = {
+    expiration {
       days = 10
     }
   }
@@ -16,7 +16,7 @@ resource "aws_s3_bucket" "prow_storage" {
     id      = "ten_day_retention_pr_logs"
     prefix  = "pr-logs/"
     enabled = true
-    expiration = {
+    expiration {
       days = 10
     }
   }


### PR DESCRIPTION
This PR should further fix and unblock other syntax errors that now are blocking the CI/CD of the infrastructure.
/cc @jonahjon