### PR TITLE
fix(config/prow/deck.yaml): add required cookie secret path flag

### DIFF
--- a/config/prow/deck.yaml
+++ b/config/prow/deck.yaml
@@ -125,7 +125,7 @@ spec:
         - --plugin-config=/etc/plugins/plugins.yaml
         - --github-oauth-config-file=/etc/githuboauth/secret
         # - --kubeconfig=/etc/kubeconfig/config
-        # - --cookie-secret=/etc/cookie/secret
+        - --cookie-secret=/etc/cookie/secret
         # - --rerun-creates-job
         - --oauth-url=/github-login
         # - --github-token-path=/etc/github/oauth


### PR DESCRIPTION
This PR aims to resolve an issue with PR status page configuration of OAuth and cookie.
In detail, the `--cookie-secret` flag argument of Deck command was missing.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>