### PR TITLE
Fix/build drivers approval

### DIFF
--- a/config/jobs/build-drivers/build-drivers.yaml
+++ b/config/jobs/build-drivers/build-drivers.yaml
@@ -174,6 +174,8 @@ periodics:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -197,6 +199,8 @@ periodics:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -220,6 +224,8 @@ periodics:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -243,6 +249,8 @@ periodics:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -266,6 +274,8 @@ periodics:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -289,9 +299,181 @@ periodics:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
           privileged: true
+      nodeSelector:
+        Archtype: "x86"
+postsubmits:
+  falcosecurity/test-infra:
+  - name: build-drivers-amazonlinux-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9]{40,}/amazonlinux_.*'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - amazonlinux
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-drivers-amazonlinux2-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9]{40,}/amazonlinux2_.*'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - amazonlinux2
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-drivers-centos-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9]{40,}/centos_.*'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - centos
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-drivers-debian-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9]{40,}/debian_.*'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - debian
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-drivers-ubuntu-aws-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9]{40,}/ubuntu-aws_.*'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-aws
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-drivers-ubuntu-generic-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9]{40,}/ubuntu-generic_.*'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-generic
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
       nodeSelector:
         Archtype: "x86"

--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -1,5 +1,7 @@
 FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
+ENV PUBLISH_S3="false"
+
 RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.4.0/driverkit_0.4.0_linux_amd64.tar.gz \
     && tar -xvf driverkit_0.4.0_linux_amd64.tar.gz \
     && chmod +x driverkit \

--- a/images/build-drivers/build-drivers.sh
+++ b/images/build-drivers/build-drivers.sh
@@ -26,6 +26,7 @@ function start_docker() {
     echo "Done setting up docker in docker."
 }
 
+PUBLISH_S3="${PUBLISH_S3:-false}"
 export PULL_PULL_SHA=$PULL_PULL_SHA
 
 echo "******************************************************"
@@ -47,7 +48,7 @@ start_docker
 cd driverkit/
 make -e TARGET_DISTRO="$1" specific_target
 
-make publish_s3
+test "${PUBLISH_S3}" == "true" && make publish_s3
 
 echo "******************************************************"
 echo "Ran DriverKit tests"


### PR DESCRIPTION
This PR should introduce driverkit configuration approval before being published.
In detail the `build-driver` script publishes only when explicitely specified by setting `PUBLISH_S3` environment variable to `"true"`.
Also, the `presubmit` jobs do no longer publish the prebuilt driver, instead new `postsubmit` jobs will do the work.
The `periodic` ones will continue to publish the drivers as they run based on `master` branch.