### PR TITLE
fix(images/docker-dind/Dockerfile): upgrade awscli to v2 according to usage

### DIFF
--- a/images/docker-dind/Dockerfile
+++ b/images/docker-dind/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     lsb-release \
     gettext \
-    awscli \
     groff \
     unzip \
     && apt-get clean
@@ -37,3 +36,8 @@ RUN apt-get update && \
 RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
     tee --append /etc/default/docker
 RUN mkdir /docker-graph
+
+RUN tmpdir=`mktemp -d` && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "${tmpdir}/awscliv2.zip" && \
+	unzip $tmpdir/awscliv2.zip -d $tmpdir && \
+	$tmpdir/aws/install -i /usr/local/aws-cli -b /usr/local/bin && \
+	rm -r $tmpdir


### PR DESCRIPTION
There are scripts (like [images/publish.sh](./images/publish.sh)) that reference the image built with this `Dockerfile`,
but they reference `awscli` v2 and this `Dockerfile` install version 1 via [deb package](https://packages.debian.org/buster/all/awscli), as for the Debian buster stable repository. This commit aligns its version as expected.

This PR aligns the `awscli` toolkit version as expected.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>