### PR TITLE
amazonlinux2_5.4.110-54.189 config

### DIFF
--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.110-54.189.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.110-54.189.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.110-54.189.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.110-54.189.amzn2.x86_64_1.ko


### PR DESCRIPTION
Signed-off-by: ismail yenigul <ismailyenigul@gmail.com>
fix for  latest EKS worker instance kernel
```
2021-05-19T18:09:38.018964835Z * Setting up /usr/src links from host
2021-05-19T18:09:38.030239959Z * Running falco-driver-loader for: falco version=0.28.1, driver version=5c0b863ddade7a45568c0ac97d037422c9efb750
2021-05-19T18:09:38.031509119Z * Running falco-driver-loader with: driver=module, compile=yes, download=yes
2021-05-19T18:09:38.031836055Z * Unloading falco module, if present
2021-05-19T18:09:38.042065677Z * Trying to load a system falco module, if present
2021-05-19T18:09:38.044166061Z * Looking for a falco module locally (kernel 5.4.110-54.189.amzn2.x86_64)
2021-05-19T18:09:38.046529944Z * Trying to download a prebuilt falco module from https://download.falco.org/driver/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.110-54.189.amzn2.x86_64_1.ko
2021-05-19T18:09:38.080601716Z curl: (22) The requested URL returned error: 404 
2021-05-19T18:09:38.081574268Z Unable to find a prebuilt falco module
2021-05-19T18:09:38.088747515Z * Trying to dkms install falco module with GCC /usr/bin/gcc
2021-05-19T18:09:38.171477598Z DIRECTIVE: MAKE="'/tmp/falco-dkms-make'"
2021-05-19T18:09:38.184260394Z * Running dkms build failed, couldn't find /var/lib/dkms/falco/5c0b863ddade7a45568c0ac97d037422c9efb750/build/make.log (with GCC /usr/bin/gcc)
2021-05-19T18:09:38.184285780Z * Trying to dkms install falco module with GCC /usr/bin/gcc-8
2021-05-19T18:09:38.261489248Z DIRECTIVE: MAKE="'/tmp/falco-dkms-make'"
2021-05-19T18:09:38.283381790Z * Running dkms build failed, couldn't find /var/lib/dkms/falco/5c0b863ddade7a45568c0ac97d037422c9efb750/build/make.log (with GCC /usr/bin/gcc-8)
2021-05-19T18:09:38.283407003Z * Trying to dkms install falco module with GCC /usr/bin/gcc-6
2021-05-19T18:09:38.375197679Z DIRECTIVE: MAKE="'/tmp/falco-dkms-make'"
2021-05-19T18:09:38.387765073Z * Running dkms build failed, couldn't find /var/lib/dkms/falco/5c0b863ddade7a45568c0ac97d037422c9efb750/build/make.log (with GCC /usr/bin/gcc-6)
2021-05-19T18:09:38.387800745Z * Trying to dkms install falco module with GCC /usr/bin/gcc-5
2021-05-19T18:09:38.489115707Z DIRECTIVE: MAKE="'/tmp/falco-dkms-make'"
2021-05-19T18:09:38.502000198Z * Running dkms build failed, couldn't find /var/lib/dkms/falco/5c0b863ddade7a45568c0ac97d037422c9efb750/build/make.log (with GCC /usr/bin/gcc-5)
2021-05-19T18:09:38.502054822Z Consider compiling your own falco driver and loading it or getting in touch with the Falco community
2021-05-19T18:09:38.513453466Z Wed May 19 18:09:38 2021: Falco version 0.28.1 (driver version 5c0b863ddade7a45568c0ac97d037422c9efb750)
2021-05-19T18:09:38.513482102Z Wed May 19 18:09:38 2021: Falco initialized with configuration file /etc/falco/falco.yaml
2021-05-19T18:09:38.513484979Z Wed May 19 18:09:38 2021: Loading rules from file /etc/falco/falco_rules.yaml:
2021-05-19T18:09:38.700384560Z Wed May 19 18:09:38 2021: Loading rules from file /etc/falco/falco_rules.local.yaml:
2021-05-19T18:09:38.837374038Z Wed May 19 18:09:38 2021: Loading rules from file /etc/falco/k8s_audit_rules.yaml:
2021-05-19T18:09:39.045783057Z Wed May 19 18:09:39 2021: Loading rules from file /etc/falco/rules.d/my-custom.yaml:
2021-05-19T18:09:39.257271451Z Wed May 19 18:09:39 2021: Unable to load the driver.
2021-05-19T18:09:39.257641766Z Wed May 19 18:09:39 2021: Runtime error: error opening device /host/dev/falco0. Make sure you have root credentials and that the falco module is loaded.. Exiting.
```