### PR TITLE
Bump Prow clusters' AWS Terraform provider version

### DIFF
--- a/config/clusters/TERRAFORM.md
+++ b/config/clusters/TERRAFORM.md
@@ -3,8 +3,9 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.2 |
-| terraform | >= 0.12 |
-| aws | >= 2.28.1 |
+| terraform | 0.13.5 |
+| aws | ~> 3.40.0 |
+| kubernetes | ~> 2.0.1 |
 | local | ~> 1.2 |
 | null | ~> 2.1 |
 | random | ~> 2.1 |
@@ -14,7 +15,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.28.1 |
+| aws | ~> 3.40.0 |
 
 ## Inputs
 
@@ -24,12 +25,12 @@
 | app\_namespace | n/a | `any` | n/a | yes |
 | app\_stage | n/a | `any` | n/a | yes |
 | eks\_default\_worker\_group\_additional\_userdata | Uerdata to append to the default userdata of the default EKS worker group | `number` | `1` | no |
-| eks\_default\_worker\_group\_asg\_desired\_capacity | The Autoscaling Group size of the default EKS worker group | `number` | `1` | no |
-| eks\_default\_worker\_group\_asg\_max\_capacity | The Autoscaling Group size of the default EKS worker group | `number` | `3` | no |
-| eks\_default\_worker\_group\_asg\_min\_capacity | The Autoscaling Group size of the default EKS worker group | `number` | `1` | no |
+| eks\_default\_worker\_group\_asg\_desired\_capacity | The Autoscaling Group size of the default EKS worker group | `number` | `4` | no |
+| eks\_default\_worker\_group\_asg\_max\_capacity | The Autoscaling Group size of the default EKS worker group | `number` | `10` | no |
+| eks\_default\_worker\_group\_asg\_min\_capacity | The Autoscaling Group size of the default EKS worker group | `number` | `3` | no |
 | eks\_default\_worker\_group\_instance\_type | The instance type of the default EKS worker group | `string` | `"m5.large"` | no |
 | eks\_default\_worker\_group\_name | The name of the default EKS worker group | `string` | `"default-worker-group"` | no |
-| eks\_users | Additional IAM users to add to the aws-auth configmap. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/jonah.jones",<br>    "username": "jonah.jones"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/fontanalorenz@gmail.com",<br>    "username": "fontanalorenz@gmail.com"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/leodidonato@gmail.com",<br>    "username": "leodidonato@gmail.com"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/leonardo.grasso",<br>    "username": "leonardo.grasso"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/massimiliano.giovagnoli",<br>    "username": "massimiliano.giovagnoli"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/spencer.krum",<br>    "username": "spencer.krum"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/circleci",<br>    "username": "circleci"<br>  }<br>]</pre> | no |
+| eks\_users | Additional IAM users to add to the aws-auth configmap. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/jonah.jones",<br>    "username": "jonah.jones"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/fontanalorenz@gmail.com",<br>    "username": "fontanalorenz@gmail.com"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/leodidonato@gmail.com",<br>    "username": "leodidonato@gmail.com"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/leonardo.grasso",<br>    "username": "leonardo.grasso"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/massimiliano.giovagnoli",<br>    "username": "massimiliano.giovagnoli"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/spencer.krum",<br>    "username": "spencer.krum"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/thomas.labarussias",<br>    "username": "thomas.labarussias"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/circleci",<br>    "username": "circleci"<br>  },<br>  {<br>    "groups": [<br>      "system:masters"<br>    ],<br>    "userarn": "arn:aws:iam::292999226676:user/michele@zuccala.com",<br>    "username": "michele@zuccala.com"<br>  }<br>]</pre> | no |
 | region | AWS region | `string` | `"eu-west-1"` | no |
 | vpc\_cidr\_block | The CIDR block of the main VPC | `string` | `"10.0.0.0/16"` | no |
 | vpc\_enable\_dns\_hostnames | A boolean flag to enable/disable DNS hostnames in the main VPC | `bool` | `true` | no |
@@ -49,3 +50,4 @@
 | eks\_cluster\_security\_group\_id | Security group ids attached to the cluster control plane. |
 | region | AWS region |
 | vpc\_id | The VPC id where the cluster is provisioned to |
+

--- a/config/clusters/terraform_versions.tf
+++ b/config/clusters/terraform_versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.0.1"
+      version = "~> 2.0.1"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.39.0"
+      version = "~> 3.40.0"
     }
   }
 }


### PR DESCRIPTION
This PR bumps the AWS Terraform provider version from 3.39.0 to 3.40.0, allowing increment of new patch versions.
Furthermore, this PR allows incrementing also the patch version of the Kubernetes Terraform provider. 
More on Terraform [version constraints](https://www.terraform.io/docs/language/expressions/version-constraints.html#version-constraint-syntax).