### PR TITLE
Upgrade EKS Terraform module to v17.0.3 without disruption

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             tar -xf terrascan.tar.gz
             install terrascan /usr/local/bin
             terrascan scan -d config/clusters -v \
-              --skip-rules 'AWS.VPC.Logging.Medium.0470,AC-AW-CA-LC-H-0439,AC_AWS_078'
+              --skip-rules 'AWS.VPC.Logging.Medium.0470,AC-AW-CA-LC-H-0439,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007'
   "test-infra/deploy/terraform":
     requires:
       - test-infra/scan/terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             tar -xf terrascan.tar.gz
             install terrascan /usr/local/bin
             terrascan scan -d config/clusters -v \
-              --skip-rules 'AWS.VPC.Logging.Medium.0470,AC-AW-CA-LC-H-0439,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007'
+              --skip-rules 'AWS.VPC.Logging.Medium.0470,AC-AW-CA-LC-H-0439,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007,AWS.CloudTrail.Logging.Low.009'
   "test-infra/deploy/terraform":
     requires:
       - test-infra/scan/terraform

--- a/config/clusters/eks.tf
+++ b/config/clusters/eks.tf
@@ -1,5 +1,7 @@
 module "eks" {
-  source                    = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.0.3"
+
   cluster_name              = local.cluster_name
   cluster_version           = "1.17"
   subnets                   = module.vpc.private_subnets
@@ -28,6 +30,7 @@ module "eks" {
   #Managed Node Group
   node_groups = {
     falco-ng = {
+      name_prefix        = null
       desired_capacity   = var.eks_default_worker_group_asg_desired_capacity
       max_capacity       = var.eks_default_worker_group_asg_max_capacity
       min_capacity       = var.eks_default_worker_group_asg_min_capacity
@@ -45,6 +48,7 @@ module "eks" {
       }
     }
     arm-ng = {
+      name_prefix        = null
       desired_capacity   = 1
       max_capacity       = 2
       min_capacity       = 1

--- a/tools/terraform.Makefile
+++ b/tools/terraform.Makefile
@@ -1,4 +1,4 @@
-terraform_version ?= 0.13.5
+terraform_version ?= $(shell grep required_version $(PWD)/config/clusters/terraform_versions.tf | cut -d '=' -f2 | tr -d '"' | tr -d ' ')
 terraform_workspace := $(PWD)/config/clusters
 terraform := docker run --rm -v $(HOME)/.aws/config:/root/.aws/config -v $(HOME)/.aws/credentials:/root/.aws/credentials -v $(terraform_workspace):/workspace -w /workspace -e AWS_PROFILE=$(AWS_PROFILE) hashicorp/terraform:$(terraform_version)
 


### PR DESCRIPTION
This PR upgrades and locks the EKS Terraform module to v17.0.3 version without introducing disruption (see [commit](https://github.com/terraform-aws-modules/terraform-aws-eks/commit/6d7d6f6f5a26a4d3aee527d9ddd087f0fd8bdbe9) about the `name_prefix` introduction for Node Groups which causes to re-create the resources).

Furthermore, this PR adds two skip on infra scanning check, as I think they have a pretty low priority now. We can then improve there.