### PR TITLE
Add support for v20210526 Amazon EKS AMIs

### DIFF
--- a/driverkit/config/13ec67ebd23417273275296813066e07cb85bc91/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
+++ b/driverkit/config/13ec67ebd23417273275296813066e07cb85bc91/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.117-58.216.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/13ec67ebd23417273275296813066e07cb85bc91/falco_amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.ko

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.117-58.216.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.ko

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.117-58.216.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.ko

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.117-58.216.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.ko


### PR DESCRIPTION
Amazon released new EKS AMIs in the v20210526 tag using kernels
5.4.117-58.216.amzn2.x86_64 (for 1.19 and above) and
4.14.232-176.381.amzn2.x86_64 (for 1.18 and below). This PR is based on
previous PRs to this repo to resolve falco-driver-loader failing to
download drivers for these new AMIs.

https://github.com/awslabs/amazon-eks-ami/releases/tag/v20210526