### PR TITLE
tweaking lgtm to reduce test-retriggering

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -23,13 +23,13 @@ approve:
       - falcosecurity/template-repository
       - falcosecurity/test-infra
     lgtm_acts_as_approve: true
-    require_self_approval: true
+    require_self_approval: false
     commandHelpLink: https://prow.falco.org/command-help
   - repos:
       - falcosecurity/falco
       - falcosecurity/libs
     lgtm_acts_as_approve: true
-    require_self_approval: true
+    require_self_approval: false
     commandHelpLink: https://prow.falco.org/command-help
     ignore_review_state: true
     
@@ -85,6 +85,7 @@ lgtm:
       - falcosecurity/test-infra
     review_acts_as_lgtm: true
     store_tree_hash: true
+    trusted_team_for_sticky_lgtm: test-infra-maintainers
 
 repo_milestone:
   # Default/fallback milestone maintainers


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

2 Changes

1. `require_self_approval: true` -> `require_self_approval: false`
     RequireSelfApproval requires PR authors to explicitly approve their PRs.  This is redundant since PR authors approve the changes in the PR by default.

2.      `trusted_team_for_sticky_lgtm: test-infra-maintainers` 

 This should eliminates the need to re-lgtm minor fixes/updates.