### PR TITLE
fixing terrascan, and tightning SG rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             tar -xf terrascan.tar.gz
             install terrascan /usr/local/bin
             terrascan scan -d config/clusters -v \
-              --skip-rules 'AWS.VPC.Logging.Medium.0470,AC-AW-CA-LC-H-0439,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007,AWS.CloudTrail.Logging.Low.009,AWS.S3Bucket.LM.MEDIUM.0078,AWS.DynamoDb.Logging.Medium.007'
+              --skip-rules 'AWS.VPC.Logging.Medium.0470,AC-AW-CA-LC-H-0439,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007,AWS.CloudTrail.Logging.Low.009,AWS.S3Bucket.LM.MEDIUM.0078,AWS.DynamoDb.Logging.Medium.007,AC_AWS_0320'
   "test-infra/deploy/terraform":
     requires:
       - test-infra/scan/terraform

--- a/config/clusters/security_groups.tf
+++ b/config/clusters/security_groups.tf
@@ -9,7 +9,7 @@ resource "aws_security_group" "worker_group_mgmt_one" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "10.0.0.0/8",
+      "10.0.0.0/16",
     ]
   }
 }
@@ -25,9 +25,7 @@ resource "aws_security_group" "all_worker_mgmt" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "10.0.0.0/8",
-      "172.16.0.0/12",
-      "192.168.0.0/16",
+      "10.0.0.0/16",
     ]
   }
 }


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

Another Terrascan addition. We can't really scope these SG's to any /32 since we don't use a bastion host at the moment. Would rather install SSM agent daemon and remove this in the future for SSH access.


When reviewing the rules noticed they were scoped for other network ranges not in use so fixed that.