### PR TITLE
Add image and ProwJob to open recurring Github Issues

### DIFF
--- a/config/jobs/recurring-ghissues/prow-eks-upgrade.yaml
+++ b/config/jobs/recurring-ghissues/prow-eks-upgrade.yaml
@@ -30,5 +30,12 @@ periodics:
             secretKeyRef:
               name: oauth-token
               key: oauth
+        command:
+        - /usr/local/bin/entrypoint.sh
+        args:
+        - ghissue
+        - create
+        - "--byline=false"
+        - issue.txt
       nodeSelector:
         Archtype: "x86"

--- a/config/jobs/recurring-ghissues/prow-eks-upgrade.yaml
+++ b/config/jobs/recurring-ghissues/prow-eks-upgrade.yaml
@@ -1,7 +1,7 @@
 periodics:
   - name: prow-eks-upgrade-reminder
     #cron: "0 7 1 */4 *" # Run every 4 month, the first day of the month, at 7am
-    cron: "0 7 18 6 *"
+    cron: "0 7 17 6 *"
     decorate: true
     spec:
       containers:

--- a/config/jobs/recurring-ghissues/prow-eks-upgrade.yaml
+++ b/config/jobs/recurring-ghissues/prow-eks-upgrade.yaml
@@ -1,0 +1,34 @@
+periodics:
+  - name: prow-eks-upgrade-reminder
+    #cron: "0 7 1 */4 *" # Run every 4 month, the first day of the month, at 7am
+    cron: "0 7 18 6 *"
+    decorate: true
+    spec:
+      containers:
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/ghissue:latest
+        imagePullPolicy: Always
+        env:
+        - name: GH_REPO
+          value: test-infra
+        - name: GH_ISSUE_TITLE
+          value: "Upgrade EKS cluster to latest stable version"
+        - name: GH_ISSUE_BODY
+          value: |
+            This is a reminder to upgrade the Prow EKS cluster to the latest stable version available.
+
+            These are the main components to keep up to date:
+            * EKS Control plane Version
+            * EKS Data plane version
+            * EKS optimized AMI ID
+            * VPC CNI image tag/version
+            * EKS Kubelet version
+            * CoreDNS tag/version
+        - name: GH_ISSUE_TAGS
+          value: "maintenance,eks"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: oauth-token
+              key: oauth
+      nodeSelector:
+        Archtype: "x86"

--- a/images/ghissue/Dockerfile
+++ b/images/ghissue/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.16.5-alpine
+
+ENV GH_ORG=falcosecurity
+ENV GH_REPO=test-infra
+ENV GH_ISSUE_TAGS=
+ENV GH_ISSUE_ASSIGNEE=
+
+USER 1000
+
+RUN mkdir /tmp/workspace
+WORKDIR /tmp/workspace
+
+RUN XDG_CACHE_HOME=.cache go get -u github.com/hcgatewood/ghissue
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["ghissue","create","--byline=false","issue.txt"]

--- a/images/ghissue/Makefile
+++ b/images/ghissue/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+IMG_SLUG := test-infra
+IMG_NAME := $(notdir $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST))))))
+IMG_TAG ?= latest
+
+ACCOUNT := 292999226676
+DOCKER_PUSH_REPOSITORY = dkr.ecr.eu-west-1.amazonaws.com
+
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME):$(IMG_TAG)"
+
+build-push: build-image push-image
+
+build-image:
+	docker build --no-cache -t "$(IMG_SLUG)/$(IMG_NAME)" .
+
+push-image:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" $(IMAGE)
+	docker push $(IMAGE)
+
+local-registry:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" localhost:5000/$(IMG_NAME)
+	docker push localhost:5000/$(IMG_NAME)

--- a/images/ghissue/entrypoint.sh
+++ b/images/ghissue/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF > issue.txt
+${GH_ORG}/${GH_REPO}
+---
+${GH_ISSUE_TITLE} | ${GH_ISSUE_TAGS} | ${GH_ISSUE_ASSIGNEE}
+${GH_ISSUE_BODY}
+EOF
+
+exec $@


### PR DESCRIPTION
This PR adds:
- a CI image to open Github issues thanks to [hcgatewood/ghissue](https://github.com/hcgatewood/ghissue)
- a periodic ProwJob that should open an issue to remind the Prow EKS cluster maintenance (like #370)

The `ghissue` container requires from the env:
- `GITHUB_TOKEN`
- `GH_ISSUE_TITLE`
- `GH_ISSUE_BODY`

and accepts from the env:
- `GH_ISSUE_TAGS`
- `GH_ISSUE_ASSIGNEE`
- `GH_ISSUE_ORG` (by default `falcosecurity`)
- `GH_ISSUE_REPO` (by default `test-infra`)

The periodic ProwJob is configured to run now June the 18th at 7 AM (as a first test). The right cron expression is now commented. 