### PR TITLE
WIP Build drivers bug fix

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -31,7 +31,7 @@ define gen_build_targets
 $(1): $(3)
 	utils/checkfiles $(3)
 	@mkdir -p output/$(2)
-	@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 && echo $(3) >> output/failing.log
+	@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 && { echo $(3) >> output/failing.log; exit 1; }
 endef
 $(foreach CONFIG,$(CONFIGS),\
 	$(eval INNER := $(patsubst config/%,%,$(CONFIG)))\

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -31,7 +31,7 @@ define gen_build_targets
 $(1): $(3)
 	utils/checkfiles $(3)
 	@mkdir -p output/$(2)
-	@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 && { echo $(3) >> output/failing.log; exit 1; }
+	@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 || { echo $(3) >> output/failing.log; exit 1; }
 endef
 $(foreach CONFIG,$(CONFIGS),\
 	$(eval INNER := $(patsubst config/%,%,$(CONFIG)))\

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -31,7 +31,7 @@ define gen_build_targets
 $(1): $(3)
 	utils/checkfiles $(3)
 	@mkdir -p output/$(2)
-	@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 || echo $(3) >> output/failing.log
+	@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 && echo $(3) >> output/failing.log
 endef
 $(foreach CONFIG,$(CONFIGS),\
 	$(eval INNER := $(patsubst config/%,%,$(CONFIG)))\


### PR DESCRIPTION
There is currently a bug for the build drivers that will have a job finish as "success" even when there is a failure. Luckily the publish job doesn't trigger, but this doesn't allow the re-testing mechanism we would expect.

https://github.com/falcosecurity/test-infra/issues/451

Trying to adjust the makefile and the line where it fails to actually emit a trap failure, and adding a fake driverkit entry to cause a failure. 

Previous
`@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 || echo $(3) >> output/failing.log`

Adding the `&&` so it will exit on failures.
`@${DRIVERKIT} docker -c $(3) --driverversion $(2) --timeout 1000 && { echo $(3) >> output/failing.log; exit 1; }`