### PR TITLE
Add the most recent EKS AMI

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.129-62.227.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.ko


### PR DESCRIPTION
Our EKS Nodes updated to this new AMI - amazon-eks-node-1.20-v20210720 - which goes looking for driver version 5.4.129-62.227.amzn2.x86_64_1

This PR adds that driver version