### PR TITLE
feat(config): configure tide to wait for review approved

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -266,6 +266,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/advocacy
       labels:
@@ -278,6 +279,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/charts
       labels:
@@ -290,6 +292,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/client-go
       labels:
@@ -303,6 +306,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/event-generator
       labels:
@@ -315,6 +319,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falco
       labels:
@@ -328,6 +333,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/client-py
       labels:
@@ -341,6 +347,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/client-rs
       labels:
@@ -354,6 +361,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/cloud-native-security-hub
       labels:
@@ -367,6 +375,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/cloud-native-security-hub-frontend
       labels:
@@ -380,6 +389,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/cloud-native-security-hub-backend
       labels:
@@ -393,6 +403,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/community
       labels:
@@ -405,6 +416,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/driverkit
       labels:
@@ -417,6 +429,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/evolution
       labels:
@@ -429,6 +442,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falco
       labels:
@@ -442,6 +456,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falcosidekick
       labels:
@@ -454,6 +469,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falcosidekick-ui
       labels:
@@ -466,6 +482,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falcoctl
       labels:
@@ -479,6 +496,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falco
       labels:
@@ -492,6 +510,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falco-exporter
       labels:
@@ -504,6 +523,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/falco-website
       labels:
@@ -516,6 +536,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/kilt
       labels:
@@ -529,6 +550,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/libs
       labels:
@@ -542,6 +564,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/pdig
       labels:
@@ -554,6 +577,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/test-infra
       labels:
@@ -566,6 +590,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true
     - repos:
         - falcosecurity/template-repository
       labels:
@@ -578,3 +603,4 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - needs-rebase
+      reviewApprovedRequired: true


### PR DESCRIPTION
This PR configures tide to wait for review being approved.

With this configuration of tide each PR in the query must have at least one
approved GitHub pull request review present for merge, to be put in the
PRs pool.

Note: this should respect what is set in
`required_pull_request_reviews.required_approving_review_count` branch
protection`s configuration.

This prevents from an inconsistency between `tide` and Github.
This inconsistency can be generated when `tide` queries for PRs without
considering Github review approvals.
So, when the query criteria match for tide, there still can be reviews
to be approved, and branch protection preventing from merge.
In this scenario `tide` could repeatedly try to merge the PR on Github
until exceeding the Github specific API rate limit.

This happened for example is [this](https://github.com/falcosecurity/falco/pull/1688#issuecomment-889888003) PR, but also in others in the past.

Docs: https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/config.md#queries

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>