### PR TITLE
updating cluster autoscaler

### DIFF
--- a/config/prow/cluster-autoscaler.yaml
+++ b/config/prow/cluster-autoscaler.yaml
@@ -79,7 +79,6 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
     verbs: ["delete", "get", "update", "watch"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -138,15 +137,15 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.17.3
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
           name: cluster-autoscaler
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
           command:
             - ./cluster-autoscaler
             - --v=4


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

Cluster Autoscaler was older, and has throttling issues leading to crashes.... updating to new version.