### PR TITLE
Add ECR repositories for falcosidekick and falcosidekick-ui

### DIFF
--- a/config/distribution/.terraform.lock.hcl
+++ b/config/distribution/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.53.0"
+  constraints = ">= 3.0.0, ~> 3.0"
+  hashes = [
+    "h1:oRCCzfwGCDNyuhIJ8kCg0N7h4W2WESm37o2GIt0ETpQ=",
+    "zh:35a77c79170b0cf3fb7eb835f3ce0b715aeeceda0a259e96e49fed5a30cf6646",
+    "zh:519d5470a932b1ec9a0fe08876c5e0f0f84f8e506b652c051e4ab708be081e89",
+    "zh:58cfa5b454602d57c47acd15c2ad166a012574742cdbcf950787ce79b6510218",
+    "zh:5fc3c0162335a730701c0175809250233f45f1021da8fa52c73635e4c08372d8",
+    "zh:6790f9d6261eb4bd5cdd7cd9125f103befce2ba127f9ba46eef83585b86e1d11",
+    "zh:76e1776c3bf9568d520f78419ec143c081f653b8df4fb22577a8c4a35d3315f9",
+    "zh:ca8ed88d0385e45c35223ace59b1bf77d81cd2154d5416e63a3dddaf0def30e6",
+    "zh:d002562c4a89a9f1f6cd8d854fad3c66839626fc260e5dde5267f6d34dbd97a4",
+    "zh:da5e47fb769e90a2f16c90fd0ba95d62da3d76eb006823664a5c6e96188731b0",
+    "zh:dfe7f33ec252ea550e090975a5f10940c27302bebb5559957957937b069646ea",
+    "zh:fa91574605ddce726e8a4e421297009a9dabe023106e139ac46da49c8285f2fe",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "2.1.0"
+  hashes = [
+    "h1:HmUcHqc59VeHReHD2SEhnLVQPUKHKTipJ8Jxq67GiDU=",
+    "zh:03d82dc0887d755b8406697b1d27506bc9f86f93b3e9b4d26e0679d96b802826",
+    "zh:0704d02926393ddc0cfad0b87c3d51eafeeae5f9e27cc71e193c141079244a22",
+    "zh:095ea350ea94973e043dad2394f10bca4a4bf41be775ba59d19961d39141d150",
+    "zh:0b71ac44e87d6964ace82979fc3cbb09eb876ed8f954449481bcaa969ba29cb7",
+    "zh:0e255a170db598bd1142c396cefc59712ad6d4e1b0e08a840356a371e7b73bc4",
+    "zh:67c8091cfad226218c472c04881edf236db8f2dc149dc5ada878a1cd3c1de171",
+    "zh:75df05e25d14b5101d4bc6624ac4a01bb17af0263c9e8a740e739f8938b86ee3",
+    "zh:b4e36b2c4f33fdc44bf55fa1c9bb6864b5b77822f444bd56f0be7e9476674d0e",
+    "zh:b9b36b01d2ec4771838743517bc5f24ea27976634987c6d5529ac4223e44365d",
+    "zh:ca264a916e42e221fddb98d640148b12e42116046454b39ede99a77fc52f59f4",
+    "zh:fe373b2fb2cc94777a91ecd7ac5372e699748c455f44f6ea27e494de9e5e6f92",
+  ]
+}

--- a/config/distribution/README.md
+++ b/config/distribution/README.md
@@ -1,9 +1,15 @@
-# Falco artifacts on S3
+# Falco distribution artifacts
 
-This repo contains an infrastructure implementation to host Falco distribution artifacts
-on Amazon S3.
+This repo contains an infrastructure implementation to host Falco official support and incubating projects distribution artifacts.
+Read more [here](https://github.com/falcosecurity/evolution#adoption-model) about the Falco projects adoption model.
 
-Proposal related to this document [here](https://github.com/falcosecurity/falco/blob/master/proposals/20201025-drivers-storage-s3.md).
+The Artifacts Scope follows [this proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20200506-artifacts-scope-part-2.md).
+
+Instead, you can find [here](https://github.com/falcosecurity/falco/blob/master/proposals/20201025-drivers-storage-s3.md) the proposal document related to the specific storage for the Falco Drivers artifacts.
+
+## Usage
+
+### Requirements
 
 After installing the AWS CLI. Configure it to use your credentials.
 
@@ -17,7 +23,7 @@ Default output format [None]: json
 
 This enables Terraform access to the configuration file and performs operations on your behalf with these security credentials.
 
-## Normal operations
+### Normal operations
 
 If you are making changes to the terraform configuration here, your AWS account
 will need to be able to read the `falco-distribution-state-bucket` S3 and read the
@@ -30,7 +36,7 @@ terraform init
 terraform apply
 ```
 
-## First initialization
+### First initialization
 
 **Warning**: only do this if this distribution infrastructure is not
 yet on your cluster. If it is, you will damage the state.
@@ -69,5 +75,4 @@ terraform apply
 ```
 
 From now on you can manage the distribution infra using the "Normal operations" section.
-
 

--- a/config/distribution/containers.tf
+++ b/config/distribution/containers.tf
@@ -1,0 +1,33 @@
+data "http" "falcosidekick_readme" {
+  url = "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/README.md"
+}
+
+resource "aws_ecrpublic_repository" "falcosidekick" {
+  provider = aws.us
+
+  repository_name = "falcosidekick"
+
+  catalog_data {
+    description       = "A simple daemon to help you with falco's outputs"
+    about_text        = substr(data.http.falcosidekick_readme.body, 0, 10240)
+    architectures     = ["x86-64"]
+    operating_systems = ["Linux"]
+  }
+}
+
+data "http" "falcosidekick_ui_readme" {
+  url = "https://raw.githubusercontent.com/falcosecurity/falcosidekick-ui/master/README.md"
+}
+
+resource "aws_ecrpublic_repository" "falcosidekick_ui" {
+  provider = aws.us
+
+  repository_name = "falcosidekick-ui"
+
+  catalog_data {
+    description       = "A simple WebUI with latest events from Falco"
+    about_text        = substr(data.http.falcosidekick_ui_readme.body, 0, 10240)
+    architectures     = ["x86-64"]
+    operating_systems = ["Linux"]
+  }
+}

--- a/config/distribution/distribution.tf
+++ b/config/distribution/distribution.tf
@@ -54,7 +54,23 @@ resource "aws_s3_bucket_object" "distribution_index" {
 
 resource "aws_s3_bucket" "logging_bucket" {
   bucket = var.logging_bucket_name
-  acl    = "private"
+  #acl    = "private"
+
+  grant {
+    id = "6e179ab6a522e9123d39ace0dace05f83ca531f9e778367bb90199a80786c709"
+    permissions = [
+      "FULL_CONTROL",
+    ]
+    type = "CanonicalUser"
+  }
+
+  grant {
+    id = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+    permissions = [
+      "FULL_CONTROL",
+    ]
+    type = "CanonicalUser"
+  }
 
   tags = {
     Name = var.logging_bucket_name

--- a/config/distribution/terraform_providers.tf
+++ b/config/distribution/terraform_providers.tf
@@ -1,21 +1,10 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
-  }
-}
-
 provider "aws" {
-  version                 = ">= 3.0"
   region                  = "eu-west-1"
   shared_credentials_file = "~/.aws/credentials"
   profile                 = "default"
 }
 
 provider "aws" {
-  version                 = ">= 3.0"
   alias                   = "us"
   region                  = "us-east-1"
   shared_credentials_file = "~/.aws/credentials"

--- a/config/distribution/terraform_versions.tf
+++ b/config/distribution/terraform_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "0.14.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR
- extend the scope of the Falco [distribution infrastructure](https://github.com/falcosecurity/test-infra/tree/master/config/distribution) to artifacts from incubating projects
- delcares two new ECR repositories for [`falcosidekick`](https://github.com/falcosecurity/falcosidekick) and [`falcosidekick-ui`](https://github.com/falcosecurity/falcosidekick-ui).

This enables Falco Sidekick and Falco Sidekick UI to distribute OCI artifacts from AWS ECR in addition to Docker Hub.

/cc @jonahjon 