### PR TITLE
ci: prevent critical resources from destroy

### DIFF
--- a/config/distribution/containers.tf
+++ b/config/distribution/containers.tf
@@ -13,6 +13,10 @@ resource "aws_ecrpublic_repository" "falcosidekick" {
     architectures     = ["x86-64"]
     operating_systems = ["Linux"]
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 data "http" "falcosidekick_ui_readme" {
@@ -29,5 +33,9 @@ resource "aws_ecrpublic_repository" "falcosidekick_ui" {
     about_text        = substr(data.http.falcosidekick_ui_readme.body, 0, 10240)
     architectures     = ["x86-64"]
     operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }

--- a/config/distribution/distribution.tf
+++ b/config/distribution/distribution.tf
@@ -41,6 +41,10 @@ EOF
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_s3_bucket_object" "distribution_index" {
@@ -76,6 +80,7 @@ resource "aws_s3_bucket" "logging_bucket" {
     Name = var.logging_bucket_name
   }
 }
+
 resource "aws_acm_certificate" "cert" {
   domain_name       = var.distribution_name_alias
   validation_method = "DNS"
@@ -135,5 +140,9 @@ resource "aws_cloudfront_distribution" "distribution" {
   viewer_certificate {
     acm_certificate_arn = aws_acm_certificate.cert.arn
     ssl_support_method  = "sni-only"
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }


### PR DESCRIPTION
This PR introduces Terraform [protection from destroy](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#prevent_destroy) on the critical resources of the [`distribution`](https://github.com/falcosecurity/test-infra/tree/master/config/distribution) infrastructure.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>

/cc @jonahjon 