### PR TITLE
ci: use terrascan rule id instead of reference id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             curl -L "$(curl -s https://api.github.com/repos/accurics/terrascan/releases/latest | grep -o -E "https://.+?_Linux_x86_64.tar.gz")" > terrascan.tar.gz
             tar -xf terrascan.tar.gz
             install terrascan /usr/local/bin
-            terrascan scan -d config/clusters -v \
+            terrascan scan -i terraform -d config/clusters -v \
               --skip-rules 'AC_AWS_0369,AC_AWS_0487,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007,AC_AWS_0447,AC_AWS_0497,AC_AWS_0458,AC_AWS_0320'
   "test-infra/deploy/terraform":
     requires:


### PR DESCRIPTION
This PR fixes `terrascan` steps to scan security vulnerabilities on the open infra.
In detail, the use of rule reference ids is deprecated. This PR references now rule ids instead.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>