### PR TITLE
Build eBPF modules for amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.129-63.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.o

--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.129-63.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.ko
+  probe: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.129-63.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.o

--- a/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/85c88952b018fdbce2464222c3303229f5bfcfad/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.129-63.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.ko
+  probe: output/85c88952b018fdbce2464222c3303229f5bfcfad/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.o

--- a/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.129-63.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.ko
+  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.o


### PR DESCRIPTION
Forgot to add eBPF probe in previous [PR](https://github.com/falcosecurity/test-infra/pull/502/files)