### PR TITLE
Pinning image version for CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
     requires:
       - test-infra/deploy/terraform
     docker:
-      - image: amazon/aws-cli:latest
+      - image: amazon/aws-cli:2.2.37
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

New image doesn't work in CircleCI https://app.circleci.com/pipelines/github/falcosecurity/test-infra/1141/workflows/7dfdc83d-d69b-4a40-9498-8bb29a5f25eb/jobs/3989

Pinning to a more recent version until they fix latest.