### PR TITLE
Fix build-plugins/build-plugin-sdk-go jobs

### DIFF
--- a/config/jobs/build-plugin-sdk-go/build-plugin-sdk-go.yaml
+++ b/config/jobs/build-plugin-sdk-go/build-plugin-sdk-go.yaml
@@ -8,11 +8,11 @@ presubmits:
     spec:
       containers:
       - command:
-        - /workspace/build.sh
+        - /code/github.com/falcosecurity/plugins/build.sh
         env:
         - name: AWS_REGION
           value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/golang:latest
+        image: golang:1.15
         imagePullPolicy: Always
         resources:
           requests:

--- a/config/jobs/build-plugins/build-plugins.yaml
+++ b/config/jobs/build-plugins/build-plugins.yaml
@@ -8,11 +8,11 @@ presubmits:
     spec:
       containers:
       - command:
-        - /workspace/build.sh
+        - /code/github.com/falcosecurity/plugins/build.sh
         env:
         - name: AWS_REGION
           value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/golang:latest
+        image: golang:1.15
         imagePullPolicy: Always
         resources:
           requests:


### PR DESCRIPTION
Instead of using the local golang image, use golang:1.15. This matches
what's in go.mod for the plugins.

Also fix the command to use the the mount location for the code, as
a workingDir is set for the k8s job.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>