### PR TITLE
Create amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.yaml

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 5.4.144-69.257.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.ko


### PR DESCRIPTION
This is to resolve falco pod fails in EKS in the new kernel 5.4.144-69.257.amzn2.x86_64 with following error.
* Trying to download a prebuilt falco module from https://download.falco.org/driver/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.ko
curl: (22) The requested URL returned error: 404