### PR TITLE
update(driverkit/config): add config files for driver version 3aa7a83

### DIFF
--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.246-186.474.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.246-186.474.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+
+kernelversion: 1
+kernelrelease: 4.14.246-186.474.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.246-186.474.amzn2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.248-189.473.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.248-189.473.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+
+kernelversion: 1
+kernelrelease: 4.14.248-189.473.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.248-189.473.amzn2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+
+kernelversion: 1
+kernelrelease: 5.4.129-62.227.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+
+kernelversion: 1
+kernelrelease: 5.4.129-63.229.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.141-67.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.141-67.229.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+
+kernelversion: 1
+kernelrelease: 5.4.141-67.229.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.141-67.229.amzn2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+
+kernelversion: 1
+kernelrelease: 5.4.144-69.257.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+
+kernelversion: 1
+kernelrelease: 5.4.149-73.259.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.ko


### PR DESCRIPTION
This PR aims to add EKS optimized AMI kernel versions to the list of Falco drivers to be built. 
The config files added have been generated using the [EKS documentation](https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/eks-linux-ami-versions.md#amazon-eks-optimized-amazon-linux-ami) provided by AWS, and the [list of kernel built by AWS](https://github.com/amazonlinux/linux).

Signed-off-by: Alexis Descamps <alexis.descamps@qonto.com>