### PR TITLE
Add eBPF probe to 5.4.149-73.259.amzn2.x86_64 kernel version

### DIFF
--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.149-73.259.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.o


### PR DESCRIPTION
This PR to create a prebuilt probe for 5.4.149-73.259.amzn2.x86_64.


