### PR TITLE
Add eBPF probe support for CentOS 5.4.0-80.90.2.el7.x86_64

### DIFF
--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_5.4.0-80.90.2.el7.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_5.4.0-80.90.2.el7.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.0-80.90.2.el7.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_5.4.0-80.90.2.el7.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_5.4.0-80.90.2.el7.x86_64_1.o


### PR DESCRIPTION
Signed-off-by: Troy Pang <beactivepang@gmail.com>