### PR TITLE
amazonlinux2 5.10.68-62.173 Amzn2 Falco Kernel.

### DIFF
--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.68-62.173.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.68-62.173.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.68-62.173.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.68-62.173.amzn2.x86_64_1.ko
+  


### PR DESCRIPTION
Kernel probe for amazon linux2 5.10.68