### PR TITLE
update: add automake dep to build-libs dockerfile

### DIFF
--- a/images/build-libs/Dockerfile
+++ b/images/build-libs/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:buster
 
 LABEL usage="docker run -i -t -v /path/to/source:/workspace test-infra/build-libs [cmake options]"
 
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libncurses-dev \
     pkg-config \
     autoconf \ 
+    automake \
     libtool \
     libelf-dev \
     wget \


### PR DESCRIPTION
Moreover, pin debian:buster, following what was already done for falco: https://github.com/falcosecurity/falco/pull/1719/files

Note: automake is an explicit dep listed in our documentation: https://falco.org/docs/getting-started/source/;
moreover, automake installs autoconf as dep, but i decided to keep both.  

Finally, this should fix a build issue: https://github.com/falcosecurity/libs/pull/115, where `aclocal` executable was not found.

```
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

Co-authored-by: Leonardo Grasso <me@leonardograsso.com>
```