### PR TITLE
update(build-libs): test minimal libs build

### DIFF
--- a/config/jobs/build-libs/build-libs.yaml
+++ b/config/jobs/build-libs/build-libs.yaml
@@ -68,3 +68,25 @@ presubmits:
             cpu: 1.5
       nodeSelector:
         Archtype: "x86"
+  - name: build-libs-minimal
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    always_run: true  # Run for every PR, but master
+    spec:
+      containers:
+      - command:
+        - /build.sh
+        args:
+        - -DMINIMAL_BUILD=True
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-libs:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+      nodeSelector:
+        Archtype: "x86"


### PR DESCRIPTION
Note that BPF build is disabled because MINIMAL_BUILD does not support building bpf probe.

Signed-off-by: Federico Di Pierro <nierro92@gmail.com>