### PR TITLE
Adding ebpf support for AmazonLinux 2 5.4.149-73.259

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.149-73.259.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.149-73.259.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.o


### PR DESCRIPTION
Ensuring the ebpf probe is built for this version of AmazonLinux 2. Was getting the following error:
```
* Trying to download a prebuilt eBPF probe from https://download.falco.org/driver/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.o
curl: (22) The requested URL returned error: 404
Unable to find a prebuilt falco eBPF probe
* Trying to compile the eBPF probe (falco_amazonlinux2_5.4.149-73.259.amzn2.x86_64_1.o)
```