### PR TITLE
fix(config): katacoda-scenarios does not use `do-not-merge/release-note-label-needed label` label

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -561,7 +561,6 @@ tide:
         - do-not-merge/hold
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
         - needs-rebase
       reviewApprovedRequired: true
     - repos:


### PR DESCRIPTION
This commit fixes the following warning reported by the `check-prow-config` job:

```json
{
  "component": "unset",
  "file": "prow/cmd/checkconfig/main.go:90",
  "func": "main.reportWarning",
  "level": "warning",
  "msg": "the following orgs or repos forbid the do-not-merge/release-note-label-needed label for merging but do not enable the release-note plugin: [repo: falcosecurity/katacoda-scenarios]",
  "severity": "warning",
  "time": "2021-11-23T21:11:57Z"
}
```

See https://github.com/falcosecurity/test-infra/pull/559#pullrequestreview-814653036

/cc @maxgio92 