### PR TITLE
fix(config/jobs): add pod utils to arm-build jobs

### DIFF
--- a/config/jobs/arm-build/arm-build.yaml
+++ b/config/jobs/arm-build/arm-build.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: arm-build-falco
+  decorate: true
   cron: "0 15 * * 1"
   spec:
     containers:
@@ -25,6 +26,7 @@ periodics:
       value: "arm"
       effect: "NoSchedule"
 - name: arm-build-falco-grpc
+  decorate: true
   cron: "0 15 * * 2"
   # interval: 1h
   spec:


### PR DESCRIPTION
This commit fixes the following warning reported by `check-prow-config` job:

```json
{
  "component": "unset",
  "file": "prow/cmd/checkconfig/main.go:90",
  "func": "main.reportWarning",
  "level": "warning",
  "msg": "the following jobs use the kubernetes provider but do not use the pod utilities: [arm-build-falco arm-build-falco-grpc]",
  "severity": "warning",
  "time": "2021-11-23T21:11:57Z"
}
```

See https://github.com/falcosecurity/test-infra/pull/559#pullrequestreview-814653036

/cc @maxgio92 