### PR TITLE
Create ubuntu-aws_5.4.0-1059-aws_62 and ubuntu-aws_5.4.0-1058-aws_61

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/ubuntu-aws_5.4.0-1057-aws_61.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/ubuntu-aws_5.4.0-1057-aws_61.yaml
@@ -1,0 +1,6 @@
+kernelversion: 61
+kernelrelease: 5.4.0-1058-aws
+target: ubuntu-aws
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_ubuntu-aws_5.4.0-1058-aws_61.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_ubuntu-aws_5.4.0-1058-aws_61.o

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/ubuntu-aws_5.4.0-1057-aws_62.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/ubuntu-aws_5.4.0-1057-aws_62.yaml
@@ -1,0 +1,6 @@
+kernelversion: 62
+kernelrelease: 5.4.0-1059-aws
+target: ubuntu-aws
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_ubuntu-aws_5.4.0-1059-aws_62.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_ubuntu-aws_5.4.0-1059-aws_62.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/ubuntu-aws_5.4.0-1058-aws_61.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/ubuntu-aws_5.4.0-1058-aws_61.yaml
@@ -1,0 +1,6 @@
+kernelversion: 61
+kernelrelease: 5.4.0-1058-aws
+target: ubuntu-aws
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_ubuntu-aws_5.4.0-1058-aws_61.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_ubuntu-aws_5.4.0-1058-aws_61.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/ubuntu-aws_5.4.0-1059-aws_62.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/ubuntu-aws_5.4.0-1059-aws_62.yaml
@@ -1,0 +1,6 @@
+kernelversion: 62
+kernelrelease: 5.4.0-1059-aws
+target: ubuntu-aws
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_ubuntu-aws_5.4.0-1059-aws_62.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_ubuntu-aws_5.4.0-1059-aws_62.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-aws_5.4.0-1058-aws_61.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-aws_5.4.0-1058-aws_61.yaml
@@ -1,0 +1,6 @@
+kernelversion: 61
+kernelrelease: 5.4.0-1058-aws
+target: ubuntu-aws
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-aws_5.4.0-1058-aws_61.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-aws_5.4.0-1058-aws_61.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-aws_5.4.0-1059-aws_62.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/ubuntu-aws_5.4.0-1059-aws_62.yaml
@@ -1,0 +1,6 @@
+kernelversion: 62
+kernelrelease: 5.4.0-1059-aws
+target: ubuntu-aws
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-aws_5.4.0-1059-aws_62.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_ubuntu-aws_5.4.0-1059-aws_62.o


### PR DESCRIPTION
This addresses issue #560 and adds version 61 so it's not skipped.

Signed-off-by: Travis Lowe yogisec7@gmail.com