### PR TITLE
update(images): upgrade base image to golang:1.17

### DIFF
--- a/images/autobump/Dockerfile
+++ b/images/autobump/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS pullrequestcreator
+FROM golang:1.17 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go

--- a/images/update-falco-k8s-manifests/Dockerfile
+++ b/images/update-falco-k8s-manifests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS pullrequestcreator
+FROM golang:1.17 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go

--- a/images/update-maintainers/Dockerfile
+++ b/images/update-maintainers/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.14 AS pullrequestcreator
+FROM golang:1.17 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
 
-FROM golang:1.14 AS maintainersgenerator
+FROM golang:1.17 AS maintainersgenerator
 
 RUN wget -qO- "https://api.github.com/repos/leodido/maintainers-generator/releases/latest" | grep -Po '"browser_download_url": "\K.*?(?=")' | xargs wget -qO- | tar -xvz
 


### PR DESCRIPTION
Image builders with golang:1.14 are currently failing:
```
../../ghproxy/ghcache/ghcache.go:277:36: undefined: os.ReadDir
note: module requires Go 1.16
```

This PR upgrade the golang version to fix the issue.

/cc @maxgio92 
/cc @leodido 