### PR TITLE
Add amazonlinux2_4.14.252-195.483 kernel support

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.252-195.483.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.252-195.483.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.252-195.483.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko


### PR DESCRIPTION
Adding support for kernel 4.14.252-195.483.amzn2.x86_64 to fix the following error:

`Trying to download a prebuilt falco module from https://download.falco.org/driver/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko`
`curl: (22) The requested URL returned error: 404`
`Unable to find a prebuilt falco module`

Signed-off-by: Luciano Carranza <luchoc@gmail.com>