### PR TITLE
Add support for CentOS 8.5 configs

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-348.2.1.el8.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-348.2.1.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-348.2.1.el8.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-348.7.1.el8.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-348.7.1.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-348.7.1.el8.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-348.el8.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-348.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-348.el8.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-348.2.1.el8.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-348.2.1.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-348.2.1.el8.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-348.7.1.el8.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-348.7.1.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-348.7.1.el8.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-348.el8.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-348.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-348.el8.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-348.2.1.el8.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-348.2.1.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-348.2.1.el8.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-348.7.1.el8.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-348.7.1.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-348.7.1.el8.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-348.el8.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-348.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-348.el8.x86_64_1.ko


### PR DESCRIPTION
CentOS 8.5 was released on 2021-11-16.

Add the CentOS 8.5 configs to driverkit.

Signed-off-by: David Windsor <dwindsor@secureworks.com>