### PR TITLE
update(images/update-maintainers): re-add jasondellaluce

### DIFF
--- a/images/update-maintainers/persons.json
+++ b/images/update-maintainers/persons.json
@@ -118,5 +118,9 @@
     "pabloopez" : {
         "name": "Pablo Zaldivar",
         "company": "Sysdig"
+    },
+    "jasondellaluce" : {
+        "name": "Jason Dellaluce",
+        "company": "Sysdig"
     }
 }


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

Re-adding myself to the maintainers list. I was already added since https://github.com/falcosecurity/test-infra/pull/567, but my name was apparently removed by mistake in https://github.com/falcosecurity/test-infra/pull/568.