### PR TITLE
add amazonlinux2_4.14.252-195.483 and amazonlinux2_5.10.75-79.358

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.252-195.483.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.o

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.75-79.358.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.ko
+  probe:  output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.o 

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.252-195.483.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.75-79.358.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.ko
+  probe:  output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.o 

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.252-195.483.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko
+  probe:  output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.o 

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.75-79.358.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.ko
+  probe:  output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.o 


### PR DESCRIPTION
Signed-off-by: Miguel Veliz <mveliz@frame.io>

add amazonlinux2_4.14.252-195.483 and amazonlinux2_5.10.75-79.358 kernel and probe support.

Error:
Trying to download a prebuilt eBPF probe from https://download.falco.org/driver/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.o curl: (22) The requested URL returned error: 404 Unable to find a prebuilt falco eBPF probe

And

Trying to download a prebuilt eBPF probe from https://download.falco.org/driver/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.75-79.358.amzn2.x86_64_1.o curl: (22) The requested URL returned error: 404 Unable to find a prebuilt falco eBPF probe