### PR TITLE
fix issues when driverkit is missing

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -1,6 +1,9 @@
 SHELL := /bin/bash
 
-DRIVERKIT ?= $(-shell which driverkit)
+DRIVERKIT := $(shell command -v driverkit)
+ifeq ($(DRIVERKIT),)
+DRIVERKIT := "/bin/driverkit"
+endif
 
 CONFIGS := $(wildcard config/*/*.yaml)
 VERSIONS := $(patsubst config/%,%,$(sort $(dir $(wildcard config/*/))))


### PR DESCRIPTION
This PR changes the way to check if `driverkit` is installed, and set up a default value. We faced this error in last pipelines when driverkit is not found:

```
DRIVERKIT= S3_DRIVERS_BUCKET="falco-distribution" S3_DRIVERS_KEY_PREFIX="driver" SKIP_EXISTING=true utils/build config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.256-197.484.amzn2.x86_64_1.yaml

unknown shorthand flag: 'c' in -c
```

If `DRIVERKIT` is empty, it creates a command `docker -c` and not `/path/driverkit docker -c`, however `-c` is not a valid argument for docker, this is why we get `unknown shorthand flag: 'c' in -c`.

