### PR TITLE
update driverkit

### DIFF
--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -2,8 +2,8 @@ FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.4.0/driverkit_0.4.0_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.4.0_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.5.0/driverkit_0.5.0_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.5.0_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 


### PR DESCRIPTION
We just released a new version of driverkit which fixes issues we have for debian kernels > 5.x. This PR update the according docker image for using this new release.

https://github.com/falcosecurity/driverkit/releases/tag/v0.5.0

Signed-off-by: Issif <issif+github@gadz.org>