### PR TITLE
adding ecr login to Makefile for base image pull

### DIFF
--- a/images/build-drivers/Makefile
+++ b/images/build-drivers/Makefile
@@ -1,24 +1,29 @@
-IMG_NAME = test-infra/build-drivers
-ACCOUNT=292999226676
-DOCKER_PUSH_REPOSITORY=dkr.ecr.eu-west-1.amazonaws.com
-TAG?=latest
-IMAGE=$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_NAME)
+SHELL := /bin/bash
 
+IMG_SLUG := test-infra
+IMG_NAME := build-drivers
+IMG_TAG ?= latest
+
+ACCOUNT := 292999226676
+DOCKER_PUSH_REPOSITORY = dkr.ecr.eu-west-1.amazonaws.com
+
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME):$(IMG_TAG)"
 
 build-push: build-image push-image
 
-build-image:
-	docker build -t $(IMG_NAME) .
-
-push-image:
-	docker tag $(IMG_NAME) $(IMAGE):$(TAG)
-	docker push $(IMAGE):$(TAG)
-
-local-registry:
+login:
 	aws ecr get-login-password \
 		| docker login \
 		--username AWS \
 		--password-stdin $(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)
-	docker pull $(IMAGE):$(TAG)
-	docker tag $(IMAGE):$(TAG) localhost:5000/build-drivers
-	docker push localhost:5000/build-drivers
+
+build-image: login
+	docker build --no-cache -t "$(IMG_SLUG)/$(IMG_NAME)" .
+
+push-image: login
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" $(IMAGE)
+	docker push $(IMAGE)
+
+local-registry:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" localhost:5000/$(IMG_NAME)
+	docker push localhost:5000/$(IMG_NAME)


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

Trying to fix https://github.com/falcosecurity/test-infra/pull/595

Most of our other builds use base images such as `golang` or `debian` so we didn't notice a lack of ECR login in the makefiles. Since this one uses a custom built image we needed an ECR login prior to build. 