### PR TITLE
Adds amazonlinux2_5.4.162-86.275.amzn2.x86_64_1

### DIFF
--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.162-86.275.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.162-86.275.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.162-86.275.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.162-86.275.amzn2.x86_64_1.ko
+  probe:  output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.162-86.275.amzn2.x86_64_1.o


### PR DESCRIPTION
```
• Looking for a falco module locally (kernel 5.4.162-86.275.amzn2.x86_64)
• Trying to download a prebuilt falco module from https://download.falco.org/driver/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.162-86.275.amzn2.x86_64_1.ko
curl: (22) The requested URL returned error: 404 
Unable to find a prebuilt falco module
```