### PR TITLE
Adding support for kernel 4.14.252-195.483.amzn2.x86_64

### DIFF
--- a/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
+++ b/driverkit/config/2aa88dcf6243982697811df4c1b484bcbe9488a2/amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.14.252-195.483.amzn2.x86_64
+target: amazonlinux
+output:
+  module: output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko


### PR DESCRIPTION
to fix following error:

Trying to download a prebuilt falco module from https://download.falco.org/driver/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_amazonlinux2_4.14.252-195.483.amzn2.x86_64_1.ko
curl: (22) The requested URL returned error: 404
Unable to find a prebuilt falco module

Signed-off-by: Stuxend <friquet@gmail.com>