### PR TITLE
update(build-plugins): automatically generate plugins readme and auto-check plugin registry

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -620,7 +620,6 @@ tide:
         - do-not-merge/hold
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
         - needs-rebase
       reviewApprovedRequired: true
     - repos:

--- a/config/jobs/build-plugins/build-plugins.yaml
+++ b/config/jobs/build-plugins/build-plugins.yaml
@@ -64,3 +64,26 @@ postsubmits:
             memory: 3Gi
       nodeSelector:
         Archtype: "x86"
+  - name: build-plugins-update-readme-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: "^registry.yaml"
+    spec:
+      serviceAccountName: build-plugins
+      containers:
+      - command:
+        - /update-readme.sh
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-plugins:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 1Gi
+      nodeSelector:
+        Archtype: "x86"

--- a/config/jobs/build-plugins/build-plugins.yaml
+++ b/config/jobs/build-plugins/build-plugins.yaml
@@ -9,8 +9,8 @@ presubmits:
     spec:
       containers:
       - command:
-        - /home/prow/go/src/github.com/falcosecurity/plugins/build.sh
-        image: golang:1.17
+        - /build.sh
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-plugins:latest
         imagePullPolicy: Always
         resources:
           requests:

--- a/config/jobs/build-plugins/build-plugins.yaml
+++ b/config/jobs/build-plugins/build-plugins.yaml
@@ -66,24 +66,45 @@ postsubmits:
         Archtype: "x86"
   - name: build-plugins-update-readme-postsubmit
     decorate: true
+    extra_refs:
+    # Check out the falcosecurity/plugins repo
+    # This will be the working directory
+    - org: falcosecurity
+      repo: plugins
+      base_ref: master
+      workdir: true
     skip_report: false
     agent: kubernetes
     branches:
       - ^master$
     run_if_changed: "^registry.yaml"
     spec:
-      serviceAccountName: build-plugins
       containers:
-      - command:
-        - /update-readme.sh
-        env:
-        - name: AWS_REGION
-          value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-plugins:latest
+      # See images/build-plugins
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-plugins:latest
         imagePullPolicy: Always
-        resources:
-          requests:
-            cpu: 500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 1Gi
+        command:
+        - /update-readme.sh
+        args:
+        - /etc/github-token/oauth
+        env:
+        - name: GH_PROXY
+          value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+        - name: gpg-signing-key
+          mountPath: /root/gpg-signing-key/
+          readOnly: true
+      volumes:
+      - name: github
+        secret:
+          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+          secretName: oauth-token
+      - name: gpg-signing-key
+        secret:
+          secretName: poiana-gpg-signing-key
+          defaultMode: 0400
       nodeSelector:
         Archtype: "x86"

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -826,7 +826,6 @@ plugins:
     - lifecycle
     - lgtm
     - mergecommitblocker
-    - release-note
     - require-matching-label
     - retitle
     - size

--- a/images/build-plugins/Dockerfile
+++ b/images/build-plugins/Dockerfile
@@ -1,3 +1,8 @@
+FROM golang:1.17 AS pullrequestcreator
+
+RUN git clone https://github.com/kubernetes/test-infra
+RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
+
 FROM golang:1.17
 
 LABEL usage="docker run -i -t -v /path/to/source:/workspace test-infra/build-plugins"
@@ -11,6 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean
 
 RUN pip install awscli
+
+COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin
 
 COPY build-and-publish.sh /
 RUN chmod +x /build-and-publish.sh

--- a/images/build-plugins/Dockerfile
+++ b/images/build-plugins/Dockerfile
@@ -18,6 +18,9 @@ RUN chmod +x /build-and-publish.sh
 COPY update-readme.sh /
 RUN chmod +x /update-readme.sh
 
+COPY build.sh /
+RUN chmod +x /build.sh
+
 WORKDIR /workspace
 
 ENTRYPOINT ["/build-and-publish.sh"]

--- a/images/build-plugins/Dockerfile
+++ b/images/build-plugins/Dockerfile
@@ -15,6 +15,9 @@ RUN pip install awscli
 COPY build-and-publish.sh /
 RUN chmod +x /build-and-publish.sh
 
+COPY update-readme.sh /
+RUN chmod +x /update-readme.sh
+
 WORKDIR /workspace
 
 ENTRYPOINT ["/build-and-publish.sh"]

--- a/images/build-plugins/build.sh
+++ b/images/build-plugins/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 The Falco Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+make

--- a/images/build-plugins/update-readme.sh
+++ b/images/build-plugins/update-readme.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 The Falco Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+make update-readme

--- a/images/build-plugins/update-readme.sh
+++ b/images/build-plugins/update-readme.sh
@@ -11,4 +11,120 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-make update-readme
+GH_PROXY="${GH_PROXY:-"http://ghproxy"}"
+GH_ORG="${GH_ORG:-"falcosecurity"}"
+GH_REPO="${GH_REPO:-"plugins"}"
+BOT_NAME="${BOT_NAME:-"poiana"}"
+BOT_MAIL="${BOT_MAIL:-"51138685+poiana@users.noreply.github.com"}"
+BOT_GPG_KEY_PATH="${BOT_GPG_KEY_PATH:-"/root/gpg-signing-key/poiana.asc"}"
+BOT_GPG_PUBLIC_KEY="${BOT_GPG_PUBLIC_KEY:-"EC9875C7B990D55F3B44D6E45F284448FF941C8F"}"
+
+export GIT_COMMITTER_NAME=${BOT_NAME}
+export GIT_COMMITTER_EMAIL=${BOT_MAIL}
+export GIT_AUTHOR_NAME=${BOT_NAME}
+export GIT_AUTHOR_EMAIL=${BOT_MAIL}
+
+
+# Sets git user configs, otherwise errors out.
+# $1: git user name
+# $2: git user email
+ensure_git_config() {
+    echo "> configuring git user (name=$1, email=$2)..." >&2
+    git config --global user.name "$1"
+    git config --global user.email "$2"
+
+    git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    return 1
+}
+
+# Configures GPG key, otherwise errors out.
+# $1: GPG key location
+# $2: GPG ASCII armored public key
+ensure_gpg_key() {
+    echo "> configuring git with gpg key=$1..." >&2
+    gpg --import "$1"
+    git config --global commit.gpgsign true
+    git config --global user.signingkey "$2"
+
+    git config --global commit.gpgsign &>/dev/null && git config --global user.signingkey &>/dev/null && return 0
+    echo "ERROR: git gpg key location, public key ID unset. No defaults provided" >&2
+    return 1
+}
+
+# Creates a pull-request in case there are changes to commit and to push.
+# $1: path of the file containing the token
+create_pr() {
+    nchanges=$(git status --porcelain=v1 2> /dev/null | wc -l)
+    if [ "${nchanges}" -eq "0" ]; then
+        echo "> moving on since there are no changes..." >&2
+        return 0;
+    fi
+
+    echo "> creating commit..." >&2
+    title="docs(README.md): update plugin registry table"
+    git add .
+    git commit -s -m "${title}"
+
+    user=$(get_user_from_token "$1")
+    branch="docs/update-readme-registry-table"
+    echo "> pushing commit as ${user} on branch ${branch}..." >&2
+    git push -f \
+        "https://${user}:$(cat "$1")@github.com/${GH_ORG}/${GH_REPO}" \
+        "HEAD:${branch}"
+
+    echo "> creating pull-request to merge ${user}:${branch} into master..." >&2
+    body="Updating README.md (automatically generated with build/registry). Made using the [build-plugins-update-readme-postsubmit](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/build-plugins/build-plugins.yaml) ProwJob. Do not edit this PR.\n\n/kind documentation\n\n/area documentation"
+
+    pr-creator \
+        --github-endpoint="${GH_PROXY}" \
+        --github-token-path="$1" \
+        --org="${GH_ORG}" --repo="${GH_REPO}" --branch=master \
+        --title="${title}" --match-title="${title}" \
+        --body="${body}" \
+        --local --source="${branch}" \
+        --allow-mods --confirm
+}
+
+# $1: path of the file containing the token
+get_user_from_token() {
+    curl --silent -H "Authorization: token $(cat "$1")" "https://api.github.com/user" | grep -Po '"login": "\K.*?(?=")'
+}
+
+# $1: the program to check
+function check_program {
+    if hash "$1" 2>/dev/null; then
+        type -P "$1" >&/dev/null
+    else
+        echo "> aborting because $1 is required..." >&2
+       return 1
+    fi
+}
+
+# Meant to be run in the https://github.com/falcosecurity/plugins repository.
+# $1: path of the file containing the token
+main() {
+    # Checks
+    check_program "gpg"
+    check_program "git"
+    check_program "curl"
+    check_program "pr-creator"
+    check_program "awk"
+
+    # Settings
+    ensure_git_config "${BOT_NAME}" "${BOT_MAIL}"
+    ensure_gpg_key "${BOT_GPG_KEY_PATH}" "${BOT_GPG_PUBLIC_KEY}"
+
+    # Generate README.md
+    make update-readme
+
+    # Create PR (in case there are changes)
+    create_pr "$1"
+}
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <path to github token>" >&2
+    exit 1
+fi
+
+main "$@"


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>

This adds the following in the `build-plugins` jobs:
- An additional check at presubmit that verifies the correctness of the `registry.yaml` plugin registry
- A post-submit job to automatically generate the `README.md` file everytime the plugin registry gets updated