### PR TITLE
fix(build-plugins): remove extra_refs from build-plugins-update-readme-postsubmit

### DIFF
--- a/config/jobs/build-plugins/build-plugins.yaml
+++ b/config/jobs/build-plugins/build-plugins.yaml
@@ -66,13 +66,6 @@ postsubmits:
         Archtype: "x86"
   - name: build-plugins-update-readme-postsubmit
     decorate: true
-    extra_refs:
-    # Check out the falcosecurity/plugins repo
-    # This will be the working directory
-    - org: falcosecurity
-      repo: plugins
-      base_ref: master
-      workdir: true
     skip_report: false
     agent: kubernetes
     branches:


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

This attempt fixing the `build-plugins` postsubmit for readme autogeneration.

The issue has been detected in this job: https://prow.falco.org/view/s3/falco-prow-logs/logs/build-plugins-update-readme-postsubmit/1483775166877011968