### PR TITLE
fix(script): correctly escapes newline character

### DIFF
--- a/images/build-plugins/update-readme.sh
+++ b/images/build-plugins/update-readme.sh
@@ -74,7 +74,7 @@ create_pr() {
         "HEAD:${branch}"
 
     echo "> creating pull-request to merge ${user}:${branch} into master..." >&2
-    body="Updating README.md (automatically generated with build/registry). Made using the [build-plugins-update-readme-postsubmit](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/build-plugins/build-plugins.yaml) ProwJob. Do not edit this PR.\n\n/kind documentation\n\n/area documentation"
+    body=$'Updating README.md (automatically generated with build/registry). Made using the [build-plugins-update-readme-postsubmit](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/build-plugins/build-plugins.yaml) ProwJob. Do not edit this PR.\n\n/kind documentation\n\n/area documentation'
 
     pr-creator \
         --github-endpoint="${GH_PROXY}" \


### PR DESCRIPTION
Signed-off-by: Andrea Bonanno <andrea@bonanno.cloud>

This PR applies a fix to escape and properly print `/n` characters in `update-readme.sh`