### PR TITLE
Add amazonlinux2_4.14.246-187.474.amzn2.x86_64 BPF

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.246-187.474.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.ko
+  probe:  output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.246-187.474.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.ko
+  probe:  output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.246-187.474.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.ko
+  probe:  output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.246-187.474.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.ko
+  probe:  output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_4.14.246-187.474.amzn2.x86_64_1.o


### PR DESCRIPTION
This kernel already had a module defined, but no probe artifact. It compiles and runs the eBPF probe locally just fine, as far as I can tell.


