### PR TITLE
fix: Add configs for CentOS 8.0, 8.1, 8.2 and 8.3

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.0.3.el8_1.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-147.0.3.el8_1.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.3.1.el8_1.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-147.3.1.el8_1.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.5.1.el8_1.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-147.5.1.el8_1.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.8.1.el8_1.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-147.8.1.el8_1.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.el8.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-147.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.el8.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-147.el8.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.1.2.el8_2.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-193.1.2.el8_2.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.14.2.el8_2.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-193.14.2.el8_2.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.19.1.el8_2.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-193.19.1.el8_2.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.28.1.el8_2.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-193.28.1.el8_2.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.6.3.el8_2.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-193.6.3.el8_2.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.el8.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-193.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.el8.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-193.el8.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.22.1.el8_3.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-240.22.1.el8_3.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.1.2.el8_0.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-80.1.2.el8_0.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.1.el8_0.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-80.11.1.el8_0.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.2.el8_0.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-80.11.2.el8_0.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.4.2.el8_0.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-80.4.2.el8_0.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.1.el8_0.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-80.7.1.el8_0.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.2.el8_0.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-80.7.2.el8_0.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.el8.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/centos_4.18.0-80.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.el8.x86_64
+target: centos
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_centos_4.18.0-80.el8.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.0.3.el8_1.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-147.0.3.el8_1.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.3.1.el8_1.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-147.3.1.el8_1.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.5.1.el8_1.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-147.5.1.el8_1.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.8.1.el8_1.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-147.8.1.el8_1.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.el8.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-147.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.el8.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-147.el8.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.1.2.el8_2.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-193.1.2.el8_2.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.14.2.el8_2.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-193.14.2.el8_2.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.19.1.el8_2.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-193.19.1.el8_2.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.28.1.el8_2.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-193.28.1.el8_2.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.6.3.el8_2.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-193.6.3.el8_2.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.el8.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-193.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.el8.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-193.el8.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.1.1.el8_3.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.1.1.el8_3.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.1.1.el8_3.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-240.1.1.el8_3.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.10.1.el8_3.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.10.1.el8_3.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.10.1.el8_3.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-240.10.1.el8_3.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.15.1.el8_3.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.15.1.el8_3.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.15.1.el8_3.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-240.15.1.el8_3.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.22.1.el8_3.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-240.22.1.el8_3.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.el8.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-240.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.el8.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-240.el8.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.10.2.el8_4.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.10.2.el8_4.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-305.10.2.el8_4.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-305.10.2.el8_4.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.12.1.el8_4.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.12.1.el8_4.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-305.12.1.el8_4.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-305.12.1.el8_4.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.17.1.el8_4.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.17.1.el8_4.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-305.17.1.el8_4.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-305.17.1.el8_4.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.19.1.el8_4.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.19.1.el8_4.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-305.19.1.el8_4.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-305.19.1.el8_4.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.7.1.el8_4.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-305.7.1.el8_4.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-305.7.1.el8_4.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-305.7.1.el8_4.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-348.2.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-348.2.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8_5.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-348.2.1.el8_5.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-348.7.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-348.7.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8_5.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-348.7.1.el8_5.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-348.el8.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-348.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-348.el8.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.1.2.el8_0.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-80.1.2.el8_0.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.1.el8_0.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-80.11.1.el8_0.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.2.el8_0.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-80.11.2.el8_0.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.4.2.el8_0.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-80.4.2.el8_0.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.1.el8_0.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-80.7.1.el8_0.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.2.el8_0.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-80.7.2.el8_0.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.el8.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/centos_4.18.0-80.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.el8.x86_64
+target: centos
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_centos_4.18.0-80.el8.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.0.3.el8_1.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-147.0.3.el8_1.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.3.1.el8_1.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-147.3.1.el8_1.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.5.1.el8_1.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-147.5.1.el8_1.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.8.1.el8_1.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-147.8.1.el8_1.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.el8.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-147.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.el8.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-147.el8.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.1.2.el8_2.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-193.1.2.el8_2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.14.2.el8_2.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-193.14.2.el8_2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.19.1.el8_2.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-193.19.1.el8_2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.28.1.el8_2.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-193.28.1.el8_2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.6.3.el8_2.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-193.6.3.el8_2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.el8.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-193.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.el8.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-193.el8.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.22.1.el8_3.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-240.22.1.el8_3.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.1.2.el8_0.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-80.1.2.el8_0.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.1.el8_0.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-80.11.1.el8_0.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.2.el8_0.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-80.11.2.el8_0.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.4.2.el8_0.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-80.4.2.el8_0.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.1.el8_0.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-80.7.1.el8_0.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.2.el8_0.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-80.7.2.el8_0.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.el8.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-80.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.el8.x86_64
+target: centos
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_centos_4.18.0-80.el8.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.0.3.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.0.3.el8_1.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-147.0.3.el8_1.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.3.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.3.1.el8_1.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-147.3.1.el8_1.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.5.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.5.1.el8_1.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-147.5.1.el8_1.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.8.1.el8_1.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.8.1.el8_1.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-147.8.1.el8_1.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.el8.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-147.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-147.el8.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-147.el8.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.1.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.1.2.el8_2.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-193.1.2.el8_2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.14.2.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.14.2.el8_2.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-193.14.2.el8_2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.19.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.19.1.el8_2.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-193.19.1.el8_2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.28.1.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.28.1.el8_2.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-193.28.1.el8_2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.6.3.el8_2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.6.3.el8_2.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-193.6.3.el8_2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.el8.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-193.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-193.el8.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-193.el8.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-240.22.1.el8_3.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-240.22.1.el8_3.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-240.22.1.el8_3.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.1.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.1.2.el8_0.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-80.1.2.el8_0.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.11.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.1.el8_0.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-80.11.1.el8_0.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.11.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.11.2.el8_0.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-80.11.2.el8_0.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.4.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.4.2.el8_0.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-80.4.2.el8_0.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.7.1.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.1.el8_0.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-80.7.1.el8_0.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.7.2.el8_0.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.7.2.el8_0.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-80.7.2.el8_0.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.el8.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/centos_4.18.0-80.el8.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-80.el8.x86_64
+target: centos
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_centos_4.18.0-80.el8.x86_64_1.ko


### PR DESCRIPTION
Adds configs for remaining CentOS 8 kernels.

Signed-off-by: David Windsor <dwindsor@secureworks.com>