### PR TITLE
Adding latest ebpf probe building to all amazonlinux2 kernels

### DIFF
--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.101-91.76.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.101-91.76.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.101-91.76.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.101-91.76.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.101-91.76.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.104-95.84.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.104-95.84.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.104-95.84.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.104-95.84.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.104-95.84.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.106-97.85.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.106-97.85.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.106-97.85.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.106-97.85.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.106-97.85.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.109-99.92.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.109-99.92.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.109-99.92.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.109-99.92.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.109-99.92.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.114-103.97.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.114-103.97.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.114-103.97.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.114-103.97.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.114-103.97.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.114-105.126.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.114-105.126.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.114-105.126.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.114-105.126.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.114-105.126.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.121-109.96.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.121-109.96.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.121-109.96.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.121-109.96.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.121-109.96.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.123-111.109.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.123-111.109.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.123-111.109.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.123-111.109.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.123-111.109.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.128-112.105.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.128-112.105.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.128-112.105.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.128-112.105.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.128-112.105.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.133-113.105.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.133-113.105.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.133-113.105.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.133-113.105.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.133-113.105.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.133-113.112.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.133-113.112.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.133-113.112.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.133-113.112.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.133-113.112.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.138-114.102.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.138-114.102.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.138-114.102.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.138-114.102.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.138-114.102.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.143-118.123.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.143-118.123.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.143-118.123.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.143-118.123.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.143-118.123.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.146-119.123.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.146-119.123.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.146-119.123.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.146-119.123.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.146-119.123.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.146-120.181.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.146-120.181.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.146-120.181.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.146-120.181.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.146-120.181.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.152-124.171.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.152-124.171.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.152-124.171.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.152-124.171.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.152-124.171.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.152-127.182.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.152-127.182.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.152-127.182.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.152-127.182.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.152-127.182.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.154-128.181.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.154-128.181.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.154-128.181.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.154-128.181.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.154-128.181.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.158-129.185.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.158-129.185.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.158-129.185.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.158-129.185.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.158-129.185.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.165-131.185.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.165-131.185.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.165-131.185.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.165-131.185.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.165-131.185.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.165-133.209.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.165-133.209.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.165-133.209.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.165-133.209.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.165-133.209.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.171-136.231.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.171-136.231.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.171-136.231.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.171-136.231.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.171-136.231.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.173-137.228.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.173-137.228.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.173-137.228.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.173-137.228.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.173-137.228.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.173-137.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.173-137.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.173-137.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.173-137.229.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.173-137.229.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.177-139.253.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.177-139.253.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.177-139.253.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.177-139.253.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.177-139.253.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.177-139.254.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.177-139.254.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.181-140.257.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.181-140.257.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.181-140.257.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.181-140.257.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.181-140.257.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.181-142.260.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.181-142.260.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.186-146.268.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.186-146.268.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.186-146.268.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.186-146.268.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.186-146.268.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.192-147.314.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.192-147.314.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.192-147.314.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.192-147.314.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.192-147.314.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.193-149.317.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.193-149.317.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.193-149.317.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.193-149.317.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.193-149.317.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.198-152.320.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.198-152.320.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.198-152.320.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.198-152.320.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.198-152.320.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.200-155.322.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.200-155.322.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.200-155.322.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.200-155.322.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.200-155.322.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.203-156.332.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.203-156.332.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.203-156.332.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.203-156.332.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.203-156.332.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.209-160.335.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.209-160.335.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.209-160.335.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.209-160.335.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.209-160.335.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.209-160.339.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.209-160.339.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.209-160.339.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.209-160.339.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.209-160.339.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.214-160.339.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.214-160.339.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.214-160.339.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.214-160.339.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.214-160.339.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.219-161.340.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.219-161.340.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.219-161.340.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.219-161.340.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.219-161.340.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.219-164.354.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.219-164.354.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.219-164.354.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.219-164.354.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.219-164.354.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.225-168.357.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.225-168.357.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.225-168.357.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.225-168.357.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.225-168.357.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.225-169.362.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.225-169.362.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.231-173.360.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.231-173.360.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.231-173.360.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.231-173.360.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.231-173.360.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.231-173.361.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.231-173.361.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.231-173.361.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.231-173.361.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.231-173.361.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.232-176.381.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.232-176.381.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.232-176.381.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.232-176.381.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.232-176.381.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.232-177.418.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.232-177.418.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.238-182.421.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.238-182.421.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.238-182.421.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.238-182.421.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.238-182.421.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.238-182.422.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.238-182.422.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.238-182.422.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.238-182.422.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.238-182.422.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.241-184.433.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.241-184.433.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.241-184.433.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.241-184.433.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.241-184.433.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.243-185.433.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.243-185.433.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.243-185.433.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.243-185.433.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.243-185.433.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.246-186.474.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.246-186.474.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.246-186.474.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.246-186.474.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.246-186.474.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.248-189.473.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.248-189.473.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.248-189.473.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.248-189.473.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.248-189.473.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.26-54.32.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.26-54.32.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.26-54.32.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.26-54.32.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.26-54.32.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.33-59.34.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.33-59.34.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.33-59.34.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.33-59.34.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.33-59.34.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.33-59.37.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.33-59.37.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.33-59.37.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.33-59.37.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.33-59.37.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.42-61.37.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.42-61.37.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.42-61.37.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.42-61.37.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.42-61.37.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.47-63.37.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.47-63.37.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.47-63.37.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.47-63.37.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.47-63.37.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.47-64.38.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.47-64.38.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.47-64.38.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.47-64.38.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.47-64.38.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.51-66.38.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.51-66.38.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.51-66.38.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.51-66.38.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.51-66.38.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.55-68.37.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.55-68.37.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.55-68.37.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.55-68.37.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.55-68.37.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.59-68.43.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.59-68.43.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.59-68.43.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.59-68.43.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.59-68.43.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.62-70.117.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.62-70.117.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.62-70.117.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.62-70.117.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.62-70.117.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.67-71.56.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.67-71.56.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.67-71.56.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.67-71.56.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.67-71.56.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.70-72.55.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.70-72.55.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.70-72.55.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.70-72.55.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.70-72.55.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.72-73.55.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.72-73.55.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.72-73.55.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.72-73.55.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.72-73.55.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.77-80.57.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.77-80.57.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.77-80.57.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.77-80.57.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.77-80.57.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.77-81.59.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.77-81.59.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.77-81.59.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.77-81.59.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.77-81.59.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.77-86.82.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.77-86.82.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.77-86.82.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.77-86.82.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.77-86.82.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.88-88.73.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.88-88.73.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.88-88.73.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.88-88.73.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.88-88.73.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.88-88.76.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.88-88.76.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.88-88.76.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.88-88.76.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.88-88.76.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.94-89.73.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.94-89.73.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.94-89.73.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.94-89.73.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.94-89.73.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.97-90.72.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.14.97-90.72.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.14.97-90.72.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.97-90.72.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.14.97-90.72.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.62-10.57.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.62-10.57.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.62-10.57.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.62-10.57.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.62-10.57.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.70-2.243.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.70-2.243.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.70-2.243.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.70-2.243.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.70-2.243.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.75-1.56.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.75-1.56.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.75-1.56.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.75-1.56.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.75-1.56.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.76-38.79.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.76-38.79.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.76-38.79.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.76-38.79.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.76-38.79.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.77-41.59.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.77-41.59.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.77-41.59.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.77-41.59.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.77-41.59.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.81-44.57.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.81-44.57.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.81-44.57.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.81-44.57.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.81-44.57.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.85-46.56.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.85-46.56.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.85-46.56.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.85-46.56.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.85-46.56.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.85-47.59.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_4.9.85-47.59.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 4.9.85-47.59.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.85-47.59.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_4.9.85-47.59.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.68-62.173.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.68-62.173.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.10.68-62.173.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.68-62.173.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.68-62.173.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.117-58.216.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.ko 
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.117-58.216.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.129-62.227.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.129-62.227.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.129-63.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.129-63.229.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.141-67.229.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.141-67.229.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.141-67.229.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.141-67.229.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.141-67.229.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.144-69.257.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.144-69.257.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.156-83.273.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.156-83.273.amzn2.x86_64_1.yaml
@@ -3,3 +3,4 @@ kernelrelease: 5.4.156-83.273.amzn2.x86_64
 target: amazonlinux2
 output:
   module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.156-83.273.amzn2.x86_64_1.ko 
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.156-83.273.amzn2.x86_64_1.o


### PR DESCRIPTION
We have a lot of variety in our AWS environment and to cover our bases would like to build the eBPF probe for all amazonlinux2 kernels that we currently build the kernel module for. We have chosen to only do this for the latest driver used in `0.31.0`, `319368f1ad778691164d33d59945e00c5752cd27`, but can do all driver versions if this is desired.