### PR TITLE
fix(arm-build): try to fix arm64 build job

### DIFF
--- a/config/jobs/arm-build/arm-build.yaml
+++ b/config/jobs/arm-build/arm-build.yaml
@@ -1,6 +1,12 @@
 periodics:
 - name: arm-build-falco
   decorate: true
+  decoration_config:
+    utility_images:
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20220128-eb56385920-arm64"
+      initupload: "gcr.io/k8s-prow/initupload:v20220128-eb56385920-arm64"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20220128-eb56385920-arm64"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20220128-eb56385920-arm64"
   cron: "0 15 * * 1"
   spec:
     containers:


### PR DESCRIPTION
```
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

Co-authored-by: Michele Zuccala <michele@zuccala.com>
```

Override default decoration config using arm64 images for utilities.

If this works, next steps:
* update autobump script to manage "-arm64" suffix
* add build-libs job to test on arm64