### PR TITLE
wip: ci(.circleci/config.yml): downgrade terrascan to avoid bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Scan terraform code # terrascan -d does not currently support remote TF modules. See: https://github.com/accurics/terrascan/issues/332
           command: |
             apk add curl tar
-            curl -L "$(curl -s https://api.github.com/repos/accurics/terrascan/releases/latest | grep -o -E "https://.+?_Linux_x86_64.tar.gz")" > terrascan.tar.gz
+            curl -sL https://github.com/accurics/terrascan/releases/download/v1.11.0/terrascan_1.11.0_Linux_x86_64.tar.gz -o terrascan.tar.gz
             tar -xf terrascan.tar.gz
             install terrascan /usr/local/bin
             terrascan scan -i terraform -d config/clusters -v \


### PR DESCRIPTION
The related rego policies on AWS S3 versioning are triggered for false positives.
Bug fixes have been committed to master, but not still released, needed a 1.13.2.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>