### PR TITLE
ci(.circleci/config.yaml): temporarily disable terrascan s3versioning…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             tar -xf terrascan.tar.gz
             install terrascan /usr/local/bin
             terrascan scan -i terraform -d config/clusters -v \
-              --skip-rules 'AC_AWS_0369,AC_AWS_0487,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007,AC_AWS_0447,AC_AWS_0497,AC_AWS_0458,AC_AWS_0320'
+              --skip-rules 'AC_AWS_0214,AC_AWS_0369,AC_AWS_0487,AC_AWS_078,AWS.CloudTrail.Logging.Medium.007,AC_AWS_0447,AC_AWS_0497,AC_AWS_0458,AC_AWS_0320'
   "test-infra/deploy/terraform":
     requires:
       - test-infra/scan/terraform


### PR DESCRIPTION
This PR temporarily removes the Terrascan rule to check versioning on S3 buckets that is firing with [false positives](https://github.com/falcosecurity/test-infra/blob/master/config/clusters/storage.tf#L35), to unlock CI.
The [lastest Rego rule](https://github.com/accurics/terrascan/blob/master/pkg/policies/opa/rego/aws/aws_s3_bucket/s3Versioning.rego) that currently is tested seems to only support the new AWS Terraform provider (>4.0).

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>