### PR TITLE
fix(images): fixed build-libs list of deps to build using system deps.

### DIFF
--- a/images/build-libs/Dockerfile
+++ b/images/build-libs/Dockerfile
@@ -18,6 +18,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtool \
     libelf-dev \
     wget \
+    libb64-dev \
+    libc-ares-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libtbb-dev \
+    libjq-dev \
+    libjsoncpp-dev \
+    libgrpc++-dev \
+    protobuf-compiler-grpc \
+    libgtest-dev \
     linux-headers-${ARCH} \
     && apt-get clean
 


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

Recently, https://github.com/falcosecurity/test-infra/pull/633 was merged, and now build-libs jobs actually tries to build libs using system deps.
This PR properly installs system deps in used image.