### PR TITLE
Update checkconfig entrypoint binary name

### DIFF
--- a/config/jobs/check-prow-config/check-prow-config.yaml
+++ b/config/jobs/check-prow-config/check-prow-config.yaml
@@ -10,7 +10,7 @@ presubmits:
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20220225-e131bfaf16
             command:
-              - /checkconfig
+              - checkconfig
             args:
             - --config-path=config/config.yaml
             - --job-config-path=config/jobs
@@ -29,7 +29,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220225-e131bfaf16
       command:
-      - /checkconfig
+      - checkconfig
       args:
       - --config-path=config/config.yaml
       - --job-config-path=config/jobs


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

Since https://github.com/kubernetes/test-infra/pull/25384 got merged (and because we update docker tags in #638), this is now needed in order for `checkconfig` to work correctly.

/cc @leogr
/cc @maxgio92 