### PR TITLE
fix(images/autobump): fix broken regex in autobump script

### DIFF
--- a/config/jobs/arm-build/arm-build.yaml
+++ b/config/jobs/arm-build/arm-build.yaml
@@ -3,10 +3,10 @@ periodics:
   decorate: true
   decoration_config:
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20220128-eb56385920-arm64"
-      initupload: "gcr.io/k8s-prow/initupload:v20220128-eb56385920-arm64"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20220128-eb56385920-arm64"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20220128-eb56385920-arm64"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20220225-e131bfaf16-arm64"
+      initupload: "gcr.io/k8s-prow/initupload:v20220225-e131bfaf16-arm64"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20220225-e131bfaf16-arm64"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20220225-e131bfaf16-arm64"
   cron: "0 15 * * 1"
   spec:
     containers:

--- a/config/jobs/autobump/autobump.yaml
+++ b/config/jobs/autobump/autobump.yaml
@@ -47,14 +47,14 @@ periodics:
     # bump.sh args
       # Directory containing k8s deployment YAMLs for Prow components.
       - name: COMPONENT_FILE_DIR
-        value: config/prow
+        value: config/prow/
       # Repo relative path of the core Prow config file (config.yaml).
       - name: CONFIG_PATH
         value: config/config.yaml
       # Repo relative path of the ProwJob config file or directory.
       # Omit this if ProwJobs are only defined in config.yaml (or are not configured at all).
       - name: JOB_CONFIG_PATH
-        value: config/jobs/check-prow-config/check-prow-config.yaml
+        value: config/jobs/
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
     volumes:

--- a/config/jobs/lifecycle-bot/periodic-close.yaml
+++ b/config/jobs/lifecycle-bot/periodic-close.yaml
@@ -7,7 +7,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-prow/commenter:v20210806-c95403cd67
+        - image: gcr.io/k8s-prow/commenter:v20220225-e131bfaf16
           command:
             - /app/robots/commenter/app.binary
           args:

--- a/config/jobs/lifecycle-bot/periodic-rotten.yaml
+++ b/config/jobs/lifecycle-bot/periodic-rotten.yaml
@@ -7,7 +7,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-prow/commenter:v20210806-c95403cd67
+        - image: gcr.io/k8s-prow/commenter:v20220225-e131bfaf16
           command:
             - /app/robots/commenter/app.binary
           args:

--- a/config/jobs/lifecycle-bot/periodic-stale.yaml
+++ b/config/jobs/lifecycle-bot/periodic-stale.yaml
@@ -7,7 +7,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-prow/commenter:v20210806-c95403cd67
+        - image: gcr.io/k8s-prow/commenter:v20220225-e131bfaf16
           command:
             - /app/robots/commenter/app.binary
           args:

--- a/images/autobump/bump.sh
+++ b/images/autobump/bump.sh
@@ -87,7 +87,7 @@ main() {
   done
   local token="$(gcloud auth print-access-token)"
   # Update image tags in the identified files. This supports both normal image and -arm64 images
-  local matcher="gcr.io\/k8s-prow\/\([[:alnum:]_-]\+\):v[a-f0-9-]\+\(-arm64\)\?$"
+  local matcher="gcr.io\/k8s-prow\/\([[:alnum:]_-]\+\):v[a-f0-9-]\+\(-arm64\)\{0,1\}"
   local replacer="s/${matcher}/gcr.io\/k8s-prow\/\1:${new_version}\2/I"
   for file in "${bumpfiles[@]}"; do
     ${SED} -i "${replacer}" "${file}"


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

#626 introduced 2 problems:
- we lost ability to bump pod utilities (see #638 -> #641)
- we didn't start updating `-arm64` images because standard `sed` only understands POSIX Basic Regular Expressions (BRE) but not Extended Regular Expressions (ERE), and the `?` (on which #626 relied on) is a metacharacter in EREs, but not in BREs ¯\\_(ツ)_/¯

Additionally, this PR fixes #634.

/cc @maxgio92 