### PR TITLE
Set correct entrypoint for k8s images used in jobs

### DIFF
--- a/config/jobs/lifecycle-bot/periodic-close.yaml
+++ b/config/jobs/lifecycle-bot/periodic-close.yaml
@@ -9,7 +9,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20220225-e131bfaf16
           command:
-            - /app/robots/commenter/app.binary
+            - commenter
           args:
             - |-
               --query=org:falcosecurity

--- a/config/jobs/lifecycle-bot/periodic-rotten.yaml
+++ b/config/jobs/lifecycle-bot/periodic-rotten.yaml
@@ -9,7 +9,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20220225-e131bfaf16
           command:
-            - /app/robots/commenter/app.binary
+            - commenter
           args:
             - |-
               --query=org:falcosecurity

--- a/config/jobs/lifecycle-bot/periodic-stale.yaml
+++ b/config/jobs/lifecycle-bot/periodic-stale.yaml
@@ -9,7 +9,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20220225-e131bfaf16
           command:
-            - /app/robots/commenter/app.binary
+            - commenter
           args:
             - |-
               --query=org:falcosecurity

--- a/config/jobs/peribolos/peribolos.yaml
+++ b/config/jobs/peribolos/peribolos.yaml
@@ -11,7 +11,7 @@ presubmits:
         containers:
           - image: gcr.io/k8s-prow/peribolos:v20220225-e131bfaf16
             command:
-              - /ko-app/peribolos
+              - peribolos
             args:
               - --config-path=config/org.yaml
               - --fix-org
@@ -47,7 +47,7 @@ postsubmits:
         containers:
           - image: gcr.io/k8s-prow/peribolos:v20220225-e131bfaf16
             command:
-              - /ko-app/peribolos
+              - peribolos
             args:
               - --confirm
               - --config-path=config/org.yaml
@@ -86,7 +86,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/peribolos:v20220225-e131bfaf16
           command:
-            - /ko-app/peribolos
+            - peribolos
           args:
             - --confirm
             - --config-path=config/org.yaml


### PR DESCRIPTION
This PR:
- addresses issues like [this one](https://prow.falco.org/view/s3/falco-prow-logs/logs/periodic-stale/1501238969222828032) for `commenter` image
- prevents similar issues from happening in the future for `peribolos` image

/cc @maxgio92 
/cc @jonahjon 

Signed-off-by: Michele Zuccala <michele@zuccala.com>