### PR TITLE
Set proper logo URL for deck

### DIFF
--- a/config/prow/deck.yaml
+++ b/config/prow/deck.yaml
@@ -152,7 +152,7 @@ spec:
           mountPath: /etc/plugins
           readOnly: true
         - name: branding
-          mountPath: /static/extensions
+          mountPath: /var/run/ko/static/extensions
           readOnly: true
         # - name: kubeconfig
         #   mountPath: /etc/kubeconfig


### PR DESCRIPTION
Because of https://github.com/kubernetes/test-infra/pull/25119, deck static files path has changed.
This PR adapts our deck configuration accordingly.

See also https://github.com/kubernetes/test-infra/commit/d2cda07fef895e934499c9277ae4b995c4da962b#diff-d6f8aa32a45789914825e80f5abd962ee6051bb07b57460cd0a660eb86116c49R201-R202

/cc @maxgio92 
/cc @jonahjon 

Signed-off-by: Michele Zuccala <michele@zuccala.com>