### PR TITLE
Simplify prow config and plugins files

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -71,11 +71,7 @@ branch-protection:
           - dco
       repos:
         .github:
-          branches:
-            master:
-              protect: true
-        advocacy:
-          branches:
+          branches: &default_branch_protection
             master:
               protect: true
         charts:
@@ -85,8 +81,7 @@ branch-protection:
               - "ci/circleci: lint-scripts"
               - "ci/circleci: install-charts"
           branches:
-            master:
-              protect: true
+            << : *default_branch_protection
             gh-pages:
               protect: true
               enforce_admins: false # do not enforce all configured restrictions for admins, since our bot needs to push while the CI workflow is running
@@ -94,48 +89,22 @@ branch-protection:
                 require_code_owner_reviews: false
                 required_approving_review_count: 0
         client-go:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
           required_status_checks:
             contexts:
               - "ci/circleci: test"
         client-py:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         client-rs:
-          branches:
-            master:
-              protect: true
-        cloud-native-security-hub:
-          branches:
-            master:
-              protect: true
-        cloud-native-security-hub-frontend:
-          branches:
-            master:
-              protect: true
-        cloud-native-security-hub-backend:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         community:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         driverkit:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         evolution:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         event-generator:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         falco:
           required_pull_request_reviews:
             required_approving_review_count: 2
@@ -145,8 +114,7 @@ branch-protection:
               - "ci/circleci: centos7"
               - "ci/circleci: musl"
           branches:
-            master:
-              protect: true
+            << : *default_branch_protection
             "release/0.28.1":
               protect: true
         falcosidekick:
@@ -155,37 +123,26 @@ branch-protection:
               - "ci/circleci: lint"
               - "ci/circleci: test"
               - "ci/circleci: build-image"
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         falcosidekick-ui:
           required_status_checks:
             contexts:
               - "ci/circleci: lint"
               - "ci/circleci: test"
               - "ci/circleci: build-image"
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         falco-aws-terraform:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         falco-exporter:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
           required_status_checks:
             contexts:
               - "ci/circleci: test"
         falcoctl:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         falco-website:
           branches:
-            master:
-              protect: true
+            << : *default_branch_protection
             v0.26:
               protect: true
             v0.27:
@@ -200,39 +157,27 @@ branch-protection:
             contexts:
               - "netlify/falcosecurity/deploy-preview"
         katacoda-scenarios:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         kilt:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         libs:
           required_pull_request_reviews:
             required_approving_review_count: 2
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         pdig:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
         plugins:
           branches:
             main:
               protect: true
-        plugin-sdk-go:
-          branches:
-            master:
-              protect: true
         plugin-sdk-cpp:
-          branches:
-            master:
-              protect: true      
+          branches: *default_branch_protection
+        plugin-sdk-go:
+          branches: *default_branch_protection
+        template-repository:
+          branches: *default_branch_protection
         test-infra:
-          branches:
-            master:
-              protect: true
+          branches: *default_branch_protection
           required_status_checks:
             contexts:
               - "check-prow-config"
@@ -249,65 +194,27 @@ tide:
     skip-unknown-contexts: true
     from-branch-protection: true
   merge_method:
-    falcosecurity/.github: rebase
-    falcosecurity/advocacy: rebase
-    falcosecurity/charts: rebase
-    falcosecurity/client-go: rebase
-    falcosecurity/client-py: rebase
-    falcosecurity/client-rs: rebase
-    falcosecurity/cloud-native-security-hub: rebase
-    falcosecurity/cloud-native-security-hub-frontend: rebase
-    falcosecurity/cloud-native-security-hub-backend: rebase
-    falcosecurity/community: rebase
-    falcosecurity/driverkit: rebase
-    falcosecurity/evolution: rebase
-    falcosecurity/event-generator: rebase
-    falcosecurity/falco: rebase
-    falcosecurity/falcosidekick: rebase
-    falcosecurity/falcosidekick-ui: rebase
-    falcosecurity/falco-aws-terraform: rebase
-    falcosecurity/falco-exporter: rebase
-    falcosecurity/falcoctl: rebase
-    falcosecurity/falco-website: rebase
-    falcosecurity/katacoda-scenarios: rebase
-    falcosecurity/kilt: rebase
-    falcosecurity/libs: rebase
-    falcosecurity/pdig: rebase
-    falcosecurity/plugins: rebase
-    falcosecurity/plugin-sdk-go: rebase
-    falcosecurity/plugin-sdk-cpp: rebase
-    falcosecurity/template-repository: rebase
-    falcosecurity/test-infra: rebase
+    falcosecurity: rebase
   queries:
+    # Query for repos that DON'T need release notes
     - repos:
         - falcosecurity/.github
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/advocacy
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/charts
-      labels:
+        - falcosecurity/community
+        - falcosecurity/driverkit
+        - falcosecurity/event-generator
+        - falcosecurity/evolution
+        - falcosecurity/falco-exporter
+        - falcosecurity/falco-website
+        - falcosecurity/falcosidekick
+        - falcosecurity/falcosidekick-ui
+        - falcosecurity/katacoda-scenarios
+        - falcosecurity/pdig
+        - falcosecurity/plugin-sdk-cpp
+        - falcosecurity/plugins
+        - falcosecurity/template-repository
+        - falcosecurity/test-infra
+      labels: &default_required_labels
         - approved
         - lgtm
         - "dco-signoff: yes"
@@ -318,381 +225,24 @@ tide:
         - do-not-merge/work-in-progress
         - needs-rebase
       reviewApprovedRequired: true
+
+    # Query for repos that DO need release notes (should be in sync with repos that adopt `release-note` plugin)
     - repos:
         - falcosecurity/client-go
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/event-generator
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/falco
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/client-py
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/client-rs
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/cloud-native-security-hub
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/cloud-native-security-hub-frontend
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/cloud-native-security-hub-backend
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/community
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/driverkit
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/evolution
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/falco
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/falcosidekick
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/falcosidekick-ui
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/falcoctl
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/falco
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/falco-aws-terraform
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/falco-exporter
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/falco-website
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/katacoda-scenarios
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/kilt
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/libs
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/pdig
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/plugins
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
         - falcosecurity/plugin-sdk-go
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
+      labels: *default_required_labels
       missingLabels:
         - do-not-merge
         - do-not-merge/hold
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
         - do-not-merge/release-note-label-needed
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/plugin-sdk-cpp
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true  
-    - repos:
-        - falcosecurity/test-infra
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
-      reviewApprovedRequired: true
-    - repos:
-        - falcosecurity/template-repository
-      labels:
-        - approved
-        - lgtm
-        - "dco-signoff: yes"
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
         - needs-rebase
       reviewApprovedRequired: true

--- a/config/jobs/check-prow-config/check-prow-config.yaml
+++ b/config/jobs/check-prow-config/check-prow-config.yaml
@@ -5,34 +5,37 @@ presubmits:
         - ^master$
       decorate: true
       skip_report: false
-      always_run: true
+      run_if_changed: '^(config/(config|plugins).yaml$|config/jobs/.*.yaml$)'
       spec:
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20220414-949f7bddd3
             command:
               - checkconfig
             args:
-            - --config-path=config/config.yaml
-            - --job-config-path=config/jobs
-            - --plugin-config=config/plugins.yaml
+              - --config-path=config/config.yaml
+              - --job-config-path=config/jobs
+              - --plugin-config=config/plugins.yaml
+              - --strict
         nodeSelector:
           Archtype: "x86"
+
 periodics:
 - name: check-prow-config-periodic
   interval: 1h
   decorate: true
   extra_refs:
-  - org: falcosecurity
-    repo: test-infra
-    base_ref: master
+    - org: falcosecurity
+      repo: test-infra
+      base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20220414-949f7bddd3
-      command:
-      - checkconfig
-      args:
-      - --config-path=config/config.yaml
-      - --job-config-path=config/jobs
-      - --plugin-config=config/plugins.yaml
+      - image: gcr.io/k8s-prow/checkconfig:v20220414-949f7bddd3
+        command:
+          - checkconfig
+        args:
+          - --config-path=config/config.yaml
+          - --job-config-path=config/jobs
+          - --plugin-config=config/plugins.yaml
+          - --strict
     nodeSelector:
       Archtype: "x86"

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -1,43 +1,14 @@
 approve:
   - repos:
-      - falcosecurity/.github
-      - falcosecurity/advocacy
-      - falcosecurity/charts
-      - falcosecurity/client-go
-      - falcosecurity/client-py
-      - falcosecurity/client-rs
-      - falcosecurity/cloud-native-security-hub
-      - falcosecurity/cloud-native-security-hub-frontend
-      - falcosecurity/cloud-native-security-hub-backend
-      - falcosecurity/community
-      - falcosecurity/evolution
-      - falcosecurity/driverkit
-      - falcosecurity/event-generator
-      - falcosecurity/falcoctl
-      - falcosecurity/falcosidekick
-      - falcosecurity/falcosidekick-ui
-      - falcosecurity/falco-aws-terraform
-      - falcosecurity/falco-exporter
-      - falcosecurity/falco-website
-      - falcosecurity/katacoda-scenarios
-      - falcosecurity/kilt
-      - falcosecurity/pdig
-      - falcosecurity/plugins
-      - falcosecurity/plugin-sdk-go
-      - falcosecurity/plugin-sdk-cpp
-      - falcosecurity/template-repository
-      - falcosecurity/test-infra
+      - falcosecurity
     lgtm_acts_as_approve: true
     require_self_approval: false
     commandHelpLink: https://prow.falco.org/command-help
   - repos:
       - falcosecurity/falco
       - falcosecurity/libs
-    lgtm_acts_as_approve: true
-    require_self_approval: false
-    commandHelpLink: https://prow.falco.org/command-help
     ignore_review_state: true
-    
+
 blunderbuss:
   max_request_count: 2
   use_status_availability: true
@@ -64,42 +35,12 @@ label:
 
 lgtm:
   - repos:
-      - falcosecurity/.github
-      - falcosecurity/advocacy
-      - falcosecurity/charts
-      - falcosecurity/client-go
-      - falcosecurity/client-py
-      - falcosecurity/client-rs
-      - falcosecurity/cloud-native-security-hub
-      - falcosecurity/cloud-native-security-hub-frontend
-      - falcosecurity/cloud-native-security-hub-backend
-      - falcosecurity/community
-      - falcosecurity/evolution
-      - falcosecurity/driverkit
-      - falcosecurity/event-generator
-      - falcosecurity/falco
-      - falcosecurity/falcoctl
-      - falcosecurity/falcosidekick
-      - falcosecurity/falcosidekick-ui
-      - falcosecurity/falco-aws-terraform
-      - falcosecurity/falco-exporter
-      - falcosecurity/falco-website
-      - falcosecurity/katacoda-scenarios
-      - falcosecurity/kilt
-      - falcosecurity/libs
-      - falcosecurity/pdig
-      - falcosecurity/plugins
-      - falcosecurity/plugin-sdk-go
-      - falcosecurity/plugin-sdk-cpp
-      - falcosecurity/template-repository
-      - falcosecurity/test-infra
+      - falcosecurity
     review_acts_as_lgtm: true
     store_tree_hash: true
     trusted_team_for_sticky_lgtm: test-infra-maintainers
 
 repo_milestone:
-  # Default/fallback milestone maintainers
-  # To obtain the team ID: curl -H "Authorization: token <token>" "https://api.github.com/orgs/falcosecurity/teams"
   "":
     maintainers_id: 3283563
     maintainers_team: maintainers
@@ -136,30 +77,6 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: client-rs
-    prs: true
-    regexp: ^kind/
-    missing_comment: |
-      There is not a label identifying the kind of this PR.
-      Please specify it either using `/kind <group>` or manually from the side menu.
-  - missing_label: needs-kind
-    org: falcosecurity
-    repo: cloud-native-security-hub
-    prs: true
-    regexp: ^kind/
-    missing_comment: |
-      There is not a label identifying the kind of this PR.
-      Please specify it either using `/kind <group>` or manually from the side menu.
-  - missing_label: needs-kind
-    org: falcosecurity
-    repo: cloud-native-security-hub-frontend
-    prs: true
-    regexp: ^kind/
-    missing_comment: |
-      There is not a label identifying the kind of this PR.
-      Please specify it either using `/kind <group>` or manually from the side menu.
-  - missing_label: needs-kind
-    org: falcosecurity
-    repo: cloud-native-security-hub-backend
     prs: true
     regexp: ^kind/
     missing_comment: |
@@ -294,7 +211,7 @@ require_matching_label:
     regexp: ^kind/
     missing_comment: |
       There is not a label identifying the kind of this PR.
-      Please specify it either using `/kind <group>` or manually from the side menu.    
+      Please specify it either using `/kind <group>` or manually from the side menu.
   - missing_label: needs-kind
     org: falcosecurity
     repo: libs
@@ -321,756 +238,86 @@ triggers:
   only_org_members: true
 
 plugins:
-  falcosecurity/.github:
+  falcosecurity:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/advocacy:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/charts:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - approve
+      - assign
+      - blunderbuss
+      - branchcleaner
+      - cat
+      - dco
+      - dog
+      - goose
+      - help
+      - hold
+      - label
+      - lifecycle
+      - lgtm
+      - mergecommitblocker
+      - require-matching-label
+      - retitle
+      - size
+      - skip
+      - trigger
+      - verify-owners
+      - welcome
+      - wip
   falcosecurity/client-go:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - golint
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - golint
+      - release-note
   falcosecurity/client-py:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - release-note
   falcosecurity/client-rs:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/cloud-native-security-hub:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - release-note
-    - require-matching-label
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/cloud-native-security-hub-frontend:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - release-note
-    - require-matching-label
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/cloud-native-security-hub-backend:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - golint
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - release-note
-    - require-matching-label
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/community:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/evolution:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - release-note
   falcosecurity/driverkit:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - golint
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - golint
   falcosecurity/event-generator:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - golint
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - golint
   falcosecurity/falco:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - milestone
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - milestone
+      - release-note
   falcosecurity/falcosidekick:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - golint
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - golint
   falcosecurity/falcosidekick-ui:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - golint
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/falco-aws-terraform:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - require-matching-label
-    - retitle
-    - size
-    - trigger
-    - verify-owners
-    - welcome
-    - wip
+      - golint
   falcosecurity/falco-exporter:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - golint
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - golint
   falcosecurity/falcoctl:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - golint
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/falco-website:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/katacoda-scenarios:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - golint
+      - release-note
   falcosecurity/kilt:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - release-note
   falcosecurity/libs:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - trigger
-    - verify-owners
-    - welcome
-    - wip
+      - release-note
   falcosecurity/pdig:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - milestone
-    - retitle
-    - size
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/plugins:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - require-matching-label
-    - retitle
-    - size
-    - trigger
-    - verify-owners
-    - welcome
-    - wip
+      - milestone
   falcosecurity/plugin-sdk-go:
     plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - release-note
-    - require-matching-label
-    - retitle
-    - size
-    - trigger
-    - verify-owners
-    - welcome
-    - wip
-  falcosecurity/plugin-sdk-cpp:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - goose
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - mergecommitblocker
-    - require-matching-label
-    - retitle
-    - size
-    - trigger
-    - verify-owners
-    - welcome
-    - wip  
-  falcosecurity/template-repository:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - branchcleaner
-    - cat
-    - dco
-    - dog
-    - help
-    - hold
-    - label
-    - lifecycle
-    - lgtm
-    - size
-    - verify-owners
-    - welcome
-    - wip
+      - release-note
   falcosecurity/test-infra:
     plugins:
-    - approve # Allow OWNERS to /approve
-    - assign # Allow /assign and /cc
-    - blunderbuss # Auto-assign people
-    - branchcleaner
-    - cat # /meow replies with cat pictures
-    - config-updater # auto-update config.yaml and plugins.yaml on changes
-    - dco # checks for DCO sign off on commits
-    - dog # /bark replies with dog pictures
-    - goose
-    - help # Support /help and /good-first-issue
-    - hold  # Support /hold to delay merge
-    - lifecycle # Allow /lifecycle stale
-    - lgtm # Allow /lgtm
-    - retitle
-    - size # Auto-label size of PR
-    - trigger  # Allow people to configure CI jobs to /test
-    - verify-owners # Validates OWNERS file changes in PRs.
-    - welcome # welcomes new PR users
-    - wip # Auto-hold PRs with WIP in title
+      - config-updater
 
 external_plugins:
-  falcosecurity/.github:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/advocacy:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/charts:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/client-go:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/client-py:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/client-rs:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/cloud-native-security-hub:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/cloud-native-security-hub-frontend:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/cloud-native-security-hub-backend:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/community:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/driverkit:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/evolution:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/event-generator:
+  falcosecurity:
     - name: needs-rebase
       events:
         - pull_request
   falcosecurity/falco:
-    - name: needs-rebase
-      events:
-        - pull_request
     - name: saymyname
       endpoint: http://saymyname.default.svc.cluster.local:8787
       events:
         - issue_comment
-  falcosecurity/falcosidekick:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/falcosidekick-ui:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/falco-aws-terraform:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/falco-exporter:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/falcoctl:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/falco-website:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/katacoda-scenarios:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/kilt:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/libs:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/pdig:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/plugins:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/plugin-sdk-go:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/plugin-sdk-cpp:
-    - name: needs-rebase
-      events:
-        - pull_request      
-  falcosecurity/template-repository:
-    - name: needs-rebase
-      events:
-        - pull_request
-  falcosecurity/test-infra:
-    - name: needs-rebase
-      events:
-        - pull_request


### PR DESCRIPTION
This PR:
- Cleans up some legacy references (eg. archived repos)
- Makes use of [YAML anchors and aliases](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases) when possible
- Uniforms the list of plugins our repos make use of, and the list of `tide` queries used to populate merge pools
- Abstracts common configurations under org keys instead of repeating repos list
- Adds `skip` plugin

🚨 **Warning for reviewers:** I have tested all of those modifications against a local Prow cluster, PLEASE do the same and refrain from blind-approving

Signed-off-by: Michele Zuccala <michele@zuccala.com>