### PR TITLE
Add Rocky Linux kmod configs

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_rocky_4.18.0-348.2.1.el8_5.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.20.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_rocky_4.18.0-348.20.1.el8_5.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_rocky_4.18.0-348.7.1.el8_5.x86_64_1.ko

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_rocky_4.18.0-348.2.1.el8_5.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.20.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_rocky_4.18.0-348.20.1.el8_5.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_rocky_4.18.0-348.7.1.el8_5.x86_64_1.ko

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.12.2.el8_5.x86_64
+target: rocky
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_rocky_4.18.0-348.12.2.el8_5.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_rocky_4.18.0-348.2.1.el8_5.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.20.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_rocky_4.18.0-348.20.1.el8_5.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_rocky_4.18.0-348.7.1.el8_5.x86_64_1.ko

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_rocky_4.18.0-348.2.1.el8_5.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.20.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_rocky_4.18.0-348.20.1.el8_5.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_rocky_4.18.0-348.7.1.el8_5.x86_64_1.ko

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.2.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.2.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_rocky_4.18.0-348.2.1.el8_5.x86_64_1.ko

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.20.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.20.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_rocky_4.18.0-348.20.1.el8_5.x86_64_1.ko

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.7.1.el8_5.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.7.1.el8_5.x86_64
+target: rocky
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_rocky_4.18.0-348.7.1.el8_5.x86_64_1.ko

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.el8.0.2.x86_64_1.yaml
@@ -1,0 +1,5 @@
+kernelversion: 1
+kernelrelease: 4.18.0-348.el8.0.2.x86_64
+target: rocky
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko


### PR DESCRIPTION
Signed-off-by: David Windsor <dwindsor@secureworks.com>

Adds configs for all Rocky Linux kernel drivers:

- 4.18.0-348.12.2.el8_5.x86_64
- 4.18.0-348.2.1.el8_5.x86_64
- 4.18.0-348.20.1.el8_5.x86_64
- 4.18.0-348.7.1.el8_5.x86_64
- 4.18.0-348.el8.0.2.x86_64