### PR TITLE
Add missing configs for amazonlinux2 5.10.* series

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.102-99.473.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.o

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.106-102.504.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.o

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.109-104.500.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.o

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.50-44.131.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.o

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.59-52.142.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.o

--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.62-55.141.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.102-99.473.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.106-102.504.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.109-104.500.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.50-44.131.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.59-52.142.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.62-55.141.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.102-99.473.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.106-102.504.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.109-104.500.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.50-44.131.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.59-52.142.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.62-55.141.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.102-99.473.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.106-102.504.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.109-104.500.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.50-44.131.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.59-52.142.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.62-55.141.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.102-99.473.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.102-99.473.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.106-102.504.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.106-102.504.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.109-104.500.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.109-104.500.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.50-44.131.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.50-44.131.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.59-52.142.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.59-52.142.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.10.62-55.141.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.10.62-55.141.amzn2.x86_64_1.o


### PR DESCRIPTION
With the fix introduced in driverkit [#139](https://github.com/falcosecurity/driverkit/pull/139), we can now build amazonlinux2 5.10.x-series kernels and probes.

Signed-off-by: David Windsor <dwindsor@secureworks.com>