### PR TITLE
feat: upgrade driverkit to 0.7.0

### DIFF
--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -2,8 +2,8 @@ FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.6.0/driverkit_0.6.0_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.6.0_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.7.0/driverkit_0.7.0_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.7.0_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 


### PR DESCRIPTION
With the new driverkit release we want to upgrade test-infra https://github.com/falcosecurity/driverkit/releases/tag/v0.7.0