### PR TITLE
build(images): upgrade base image to golang 1.18

### DIFF
--- a/images/update-maintainers/Dockerfile
+++ b/images/update-maintainers/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.17 AS pullrequestcreator
+FROM golang:1.18 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
 
-FROM golang:1.17 AS maintainersgenerator
+FROM golang:1.18 AS maintainersgenerator
 
 RUN wget -qO- "https://api.github.com/repos/leodido/maintainers-generator/releases/latest" | grep -Po '"browser_download_url": "\K.*?(?=")' | xargs wget -qO- | tar -xvz
 


### PR DESCRIPTION
This PR should fix the following error:
```
[0m[91m# k8s.io/test-infra/prow/config/secret
../../prow/config/secret/agent.go:73:19: syntax error: unexpected [, expecting (
../../prow/config/secret/reloader.go:27:30: syntax error: unexpected any, expecting ]
../../prow/config/secret/reloader.go:32:25: syntax error: unexpected (, expecting name or (
../../prow/config/secret/reloader.go:33:1: syntax error: non-declaration statement outside function body
../../prow/config/secret/reloader.go:35:31: syntax error: unexpected [, expecting comma or )
../../prow/config/secret/reloader.go:50:31: syntax error: unexpected [, expecting comma or )
../../prow/config/secret/reloader.go:52:2: syntax error: non-declaration statement outside function body
../../prow/config/secret/reloader.go:89:31: syntax error: unexpected [, expecting comma or )
../../prow/config/secret/reloader.go:95:31: syntax error: unexpected [, expecting comma or )
../../prow/config/secret/secret.go:34:32: syntax error: unexpected [, expecting (
../../prow/config/secret/secret.go:34:32: too many errors
note: module requires Go 1.18
```
See https://prow.falco.org/view/s3/falco-prow-logs/pr-logs/pull/falcosecurity_test-infra/689/build-images-update-maintainers/1520071553373442048