### PR TITLE
Add config for amazonlinux2_5.4.190-107.353

### DIFF
--- a/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
+++ b/driverkit/config/17f5df52a7d9ed6bb12d3b1768460def8439936d/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.190-107.353.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.ko
+  probe: output/17f5df52a7d9ed6bb12d3b1768460def8439936d/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.o

--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.190-107.353.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.o

--- a/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
+++ b/driverkit/config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.190-107.353.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.ko
+  probe: output/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.o

--- a/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
+++ b/driverkit/config/5c0b863ddade7a45568c0ac97d037422c9efb750/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.190-107.353.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.ko
+  probe: output/5c0b863ddade7a45568c0ac97d037422c9efb750/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.yaml
@@ -1,0 +1,6 @@
+kernelversion: 1
+kernelrelease: 5.4.190-107.353.amzn2.x86_64
+target: amazonlinux2
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.4.190-107.353.amzn2.x86_64_1.o


### PR DESCRIPTION
This commit adds configuration files for a new AWS linux kernel version
5.4.190-107.353.