### PR TITLE
add Issif as member for website

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -343,9 +343,9 @@ orgs:
         description: maintainers of falcosidekick-ui
         maintainers:
           - leogr
+          - Issif
         members:
           - cpanato
-          - Issif
           - fjogeleit
         privacy: closed
         repos:
@@ -502,6 +502,7 @@ orgs:
           - radhikapc
           - jasondellaluce
           - Rajakavitha1
+          - Issif
         privacy: closed
         repos:
           falco-website: maintain


### PR DESCRIPTION
According to https://github.com/falcosecurity/falco-website/pull/562 I'm now allowed to review and approve the PR for falco-website, but without this change, my approval are not valid for poiana.

PS: I also added myself as maintainer of falcosidekick-ui, I'm the creator after all