### PR TITLE
fix(driverkit-config): Fix configuration of driverkit for ubuntu driver

### DIFF
--- a/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/ubuntu-generic_5.4.0-117-generic_132.yaml
+++ b/driverkit/config/319368f1ad778691164d33d59945e00c5752cd27/ubuntu-generic_5.4.0-117-generic_132.yaml
@@ -2,5 +2,5 @@ kernelversion: 132
 kernelrelease: 5.4.0-117-generic
 target: ubuntu-generic
 output:
-  module: output/319368f1ad7786117164d33d59945e00c5752cd27/falco_ubuntu-generic_5.4.0-117-generic_132.ko
-  probe: output/319368f1ad7786117164d33d59945e00c5752cd27/falco_ubuntu-generic_5.4.0-117-generic_132.o
+  module: output/319368f1ad778691164d33d59945e00c5752cd27/falco_ubuntu-generic_5.4.0-117-generic_132.ko
+  probe: output/319368f1ad778691164d33d59945e00c5752cd27/falco_ubuntu-generic_5.4.0-117-generic_132.o


### PR DESCRIPTION
Fix configuration of driverkit for ubuntu-generic with kernel v5.4.0-117 for driver v319368f1ad778691164d33d59945e00c5752cd27