### PR TITLE
fix(driverkit): fixed utils/build arch_to_driverkit_arch() case statement

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -47,7 +47,7 @@ specific_target_old: $(patsubst config_%,%,$(subst /,_,$(wildcard config/${TARGE
 specific_target_new: $(patsubst config_%,%,$(subst /,_,$(wildcard config/${TARGET_VERSION}*/${TARGET_ARCH}/${TARGET_DISTRO}_${TARGET_KERNEL}-*)))
 
 prepare: $(addprefix prepare_,$(VERSIONS))
-publish: $(addprefix publish_,$(VERSIONS))
+publish: publish_s3 # alias publish_s3; artifactory is no more supported
 publish_s3: $(addprefix publish_s3_,$(VERSIONS))
 
 generate:
@@ -116,18 +116,6 @@ ifneq ("$(wildcard output/$(1)/aarch64/*.o)","")
 	@mkdir -p output/$(1)/ebpf-probe/aarch64
 	@mv -f output/$(1)/aarch64/*.o output/$(1)/ebpf-probe/aarch64
 endif
-
-prepare_$(1): split_$(1)_kernelmodules split_$(1)_ebpfprobes
-	@echo "upserting falcosecurity/driver/kernel-module/$(1) version..."
-	jfrog bt vs falcosecurity/driver/kernel-module/$(1) --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/driver/kernel-module/$(1) --desc="Falco kernel module" --released=`date -u +"%Y-%m-%dT%H:%M:%S.000Z"` --user poiana --key ${BINTRAY_SECRET}
-	@echo "upserting falcosecurity/driver/ebpf-probe/$(1) version..."
-	jfrog bt vs falcosecurity/driver/ebpf-probe/$(1) --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/driver/ebpf-probe/$(1) --desc="Falco eBPF probe" --released=`date -u +"%Y-%m-%dT%H:%M:%S.000Z"` --user poiana --key ${BINTRAY_SECRET}
-
-publish_$(1): prepare_$(1)
-	@echo "publishing kernel modules (version $(1)) to bintray ..."
-	jfrog bt u "output/$(1)/kernel-module/*" falcosecurity/driver/kernel-module/$(1) $(1)/ --user poiana --key ${BINTRAY_SECRET} --publish --override
-	@echo "publishing eBPF probes (version $(1)) to bintray ..."
-	jfrog bt u "output/$(1)/ebpf-probe/*" falcosecurity/driver/ebpf-probe/$(1) $(1)/ --user poiana --key ${BINTRAY_SECRET} --publish --override
 
 publish_s3_$(1): split_$(1)_kernelmodules split_$(1)_ebpfprobes
 	if [ -d "output/$(1)/ebpf-probe" ]; then \

--- a/driverkit/utils/build
+++ b/driverkit/utils/build
@@ -35,10 +35,10 @@ check_s3_existence() {
 
 arch_to_driverkit_arch() {
 	case "$1" in
-		"x86_64")
+		"x86_64/"|"") # TODO: remove "" once we drop support for old tree
 			echo -n "amd64"
 			;;
-		"aarch64")
+		"aarch64/")
 			echo -n "arm64"
 			;;
 		*)
@@ -71,12 +71,6 @@ fi
 # Build 
 if [[ ${should_build} == "true" ]]; then
     mkdir -p output/${driver_version}/${arch}
-    if [[ -n "${arch}" ]]; then
-        # if we have an architecture in our config path, force use it
-        ${DRIVERKIT} docker -c ${input} --driverversion ${driver_version} --architecture $(arch_to_driverkit_arch ${arch}) --timeout 1000 || echo ${input} >> output/failing.log
-    else
-        # we only support x86_64
-        # TODO: remove once we drop support for old tree
-        ${DRIVERKIT} docker -c ${input} --driverversion ${driver_version} --architecture amd64 --timeout 1000 || echo ${input} >> output/failing.log
-    fi
+    # if we have an architecture in our config path, force use it
+    ${DRIVERKIT} docker -c ${input} --driverversion ${driver_version} --architecture $(arch_to_driverkit_arch ${arch}) --timeout 1000 || echo ${input} >> output/failing.log
 fi

--- a/driverkit/utils/checkfiles
+++ b/driverkit/utils/checkfiles
@@ -45,14 +45,14 @@ fi
 if [ -n "${output_probe}" ]; then
     output_probe_filename="${output_probe##*/}"
     if [ "${output_probe_filename}" != "falco_${target}_${kernelrelease}_${kernelversion}.o" ]; then
-        >&2 echo "output probe filename is wrong (${1})"
+        >&2 echo "output probe filename is wrong (${1}); expected: falco_${target}_${kernelrelease}_${kernelversion}.o, has ${output_probe_filename}"
         exit 1
     fi
 
     # TODO: rm this external check once old format support is dropped (and we always have an arch)
     if [[ -n "${arch}" ]]; then
-        if [ "$arch" != "$(get_arch_from_path ${output_probe})" ]; then
-            >&2 echo "output probe filename has wrong architecture in its config path (${1})"
+        if [ "${arch}" != "$(get_arch_from_path ${output_probe})" ]; then
+            >&2 echo "output probe filename has wrong architecture in its config path (${1}); expected $(get_arch_from_path ${output_probe}), has ${arch}"
             exit 1
         fi
     fi
@@ -62,14 +62,14 @@ fi
 if [ -n "${output_module}" ]; then
     output_module_filename="${output_module##*/}"
     if [ "${output_module_filename}" != "falco_${target}_${kernelrelease}_${kernelversion}.ko" ]; then
-        >&2 echo "output module filename is wrong (${1})"
+        >&2 echo "output module filename is wrong (${1}); expected falco_${target}_${kernelrelease}_${kernelversion}.ko, has ${output_module_filename}"
         exit 1
     fi
 
     # TODO: rm this external check once old format support is dropped (and we always have an arch)
     if [[ -n "${arch}" ]]; then
-        if [ "$arch" != "$(get_arch_from_path ${output_module})" ]; then
-             >&2 echo "output module filename has wrong architecture in its config path (${1})"
+        if [ "${arch}" != "$(get_arch_from_path ${output_module})" ]; then
+             >&2 echo "output module filename has wrong architecture in its config path (${1}); expected $(get_arch_from_path ${output_module}), has ${arch}"
              exit 1
         fi
     fi


### PR DESCRIPTION
Moreover, improved checkfiles script to be more verbose when printing errors.

Finally, dropped unsupported artifactory publish target from driverkit makefile.

Extracted from #744