### PR TITLE
chore(config): added tests-integration-arm64 to Falco required_status _checks

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -147,8 +147,8 @@ branch-protection:
             contexts:
               - "ci/circleci: tests-driver-loader-integration"
               - "ci/circleci: tests-integration"
+              - "ci/circleci: tests-integration-arm64"
               # note: we don't need build jobs, since tests depends on them
-              # todo(leogr,FedeDP): ARM64 tests
           branches:
             master:
               protect: true


### PR DESCRIPTION
https://github.com/falcosecurity/falco/pull/2099 is introducing arm64 integration tests for Falco.
Open this one in wip to avoid forgetting :)