### PR TITLE
chore(config): run update-dbg job as soon as new kernel lists are merged in main in kernel-crawler repo

### DIFF
--- a/config/jobs/update-dbg/update-dbg.yaml
+++ b/config/jobs/update-dbg/update-dbg.yaml
@@ -1,41 +1,44 @@
-periodics:
-  - name: update-dbg
-    cron: "0 10 5,20 * *"
-    decorate: true
-    extra_refs:
-    # Check out the falcosecurity/test-infra repo
-    # This will be the working directory
-    - org: falcosecurity
-      repo: test-infra
-      base_ref: master
-      workdir: true
-    spec:
-      containers:
-      # See images/update-dbg
-      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-dbg
-        imagePullPolicy: Always
-        command:
-        - /entrypoint.sh
-        args:
-        - /etc/github-token/oauth
-        env:
-        - name: GH_PROXY
-          value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
-        volumeMounts:
-        - name: github
-          mountPath: /etc/github-token
-          readOnly: true
-        - name: gpg-signing-key
-          mountPath: /root/gpg-signing-key/
-          readOnly: true
-      volumes:
-      - name: github
-        secret:
-          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
-          secretName: oauth-token
-      - name: gpg-signing-key
-        secret:
-          secretName: poiana-gpg-signing-key
-          defaultMode: 0400
-      nodeSelector:
-        Archtype: "x86"
+postsubmits:
+  falcosecurity/kernel-crawler:
+    - name: update-dbg
+      decorate: true
+      run_if_changed: '^kernels/'
+      branches:
+        - ^main$
+      extra_refs:
+      # Check out the falcosecurity/test-infra repo
+      # This will be the working directory
+      - org: falcosecurity
+        repo: test-infra
+        base_ref: master
+        workdir: true
+      spec:
+        containers:
+        # See images/update-dbg
+        - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-dbg
+          imagePullPolicy: Always
+          command:
+            - /entrypoint.sh
+          args:
+            - /etc/github-token/oauth
+          env:
+            - name: GH_PROXY
+              value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+          volumeMounts:
+            - name: github
+              mountPath: /etc/github-token
+              readOnly: true
+            - name: gpg-signing-key
+              mountPath: /root/gpg-signing-key/
+              readOnly: true
+        volumes:
+          - name: github
+            secret:
+            # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+              secretName: oauth-token
+          - name: gpg-signing-key
+            secret:
+              secretName: poiana-gpg-signing-key
+              defaultMode: 0400
+        nodeSelector:
+          Archtype: "x86"


### PR DESCRIPTION
This allows us to better manage the cross dependency between the update-dbg and update-kernels jobs:
update-kernels will open the PR on kernel-crawler, and as soon as someone approves it (and then it gets merged),
the update-dbg job will trigger.

In the end, we are now able to eg:
* avoid triggering the update-dbg jobs should we don't want to, by just avoiding merging the update-kernels created PR on kernel-crawler repo
* trigger the update-dbg job as quick as possible by merging the kernel-crawler auto PR every week (thus triggering update-dbg weekly).