### PR TITLE
update(config): enable milestone plugin on falcosecurity/libs

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -885,6 +885,7 @@ plugins:
       - lifecycle
       - lgtm
       - mergecommitblocker
+      - milestone
       - release-note
       - require-matching-label
       - retitle


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

Since we started tagging and releasing libs and drivers (see: https://github.com/falcosecurity/libs/releases), we may make a good use of the milestone plugin on the `libs` repo to define the roadmaps of each new release.