### PR TITLE
update(OWNERS): move inactive approvers to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,8 @@
 approvers:
-  - leodido
-  - fntlnz
   - maxgio92
   - jonahjon
   - leogr
   - zuc
+emeritus_approvers:
+  - leodido
+  - fntlnz

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,6 +1,4 @@
 approvers:
-  - leodido
-  - fntlnz
   - jonahjon
   - maxgio92
 reviewers:
@@ -9,3 +7,6 @@ reviewers:
   - markyjackson-taulia
   - jonahjon
   - maxgio92
+emeritus_approvers:
+  - leodido
+  - fntlnz

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -2,11 +2,7 @@ approvers:
   - jonahjon
   - maxgio92
 reviewers:
-  - leodido
-  - fntlnz
   - markyjackson-taulia
-  - jonahjon
-  - maxgio92
 emeritus_approvers:
   - leodido
   - fntlnz

--- a/config/jobs/OWNERS
+++ b/config/jobs/OWNERS
@@ -1,6 +1,4 @@
 approvers:
-  - leodido
-  - fntlnz
   - jonahjon
   - maxgio92
 reviewers:
@@ -9,3 +7,6 @@ reviewers:
   - markyjackson-taulia
   - jonahjon
   - maxgio92
+emeritus_approvers:
+  - leodido
+  - fntlnz

--- a/config/jobs/OWNERS
+++ b/config/jobs/OWNERS
@@ -2,11 +2,7 @@ approvers:
   - jonahjon
   - maxgio92
 reviewers:
-  - leodido
-  - fntlnz
   - markyjackson-taulia
-  - jonahjon
-  - maxgio92
 emeritus_approvers:
   - leodido
   - fntlnz

--- a/config/jobs/build-drivers/OWNERS
+++ b/config/jobs/build-drivers/OWNERS
@@ -1,6 +1,4 @@
 approvers:
-  - leodido
-  - fntlnz
   - jonahjon
   - maxgio92
 reviewers:
@@ -9,3 +7,6 @@ reviewers:
   - markyjackson-taulia
   - jonahjon
   - maxgio92
+emeritus_approvers:
+  - leodido
+  - fntlnz

--- a/config/jobs/build-drivers/OWNERS
+++ b/config/jobs/build-drivers/OWNERS
@@ -2,11 +2,7 @@ approvers:
   - jonahjon
   - maxgio92
 reviewers:
-  - leodido
-  - fntlnz
   - markyjackson-taulia
-  - jonahjon
-  - maxgio92
 emeritus_approvers:
   - leodido
   - fntlnz

--- a/config/prow/OWNERS
+++ b/config/prow/OWNERS
@@ -1,6 +1,4 @@
 approvers:
-  - leodido
-  - fntlnz
   - jonahjon
   - maxgio92
 reviewers:
@@ -9,3 +7,6 @@ reviewers:
   - markyjackson-taulia
   - jonahjon
   - maxgio92
+emeritus_approvers:
+  - leodido
+  - fntlnz

--- a/config/prow/OWNERS
+++ b/config/prow/OWNERS
@@ -2,11 +2,7 @@ approvers:
   - jonahjon
   - maxgio92
 reviewers:
-  - leodido
-  - fntlnz
   - markyjackson-taulia
-  - jonahjon
-  - maxgio92
 emeritus_approvers:
   - leodido
   - fntlnz


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it:**

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from approvers to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes:**

**Special notes for your reviewer:**

Opened this in favor of #751, as following up the suggestion of https://github.com/falcosecurity/test-infra/pull/751#pullrequestreview-1041853681.