### PR TITLE
fix(config/org.yaml): add missing maintainer to `kilt`

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -422,6 +422,7 @@ orgs:
         maintainers:
           - leodido
           - fntlnz
+          - gnosek
         members:
           - admiral0
         privacy: closed


### PR DESCRIPTION
@gnosek is present in the to the `OWNERS` file (see [here](https://github.com/falcosecurity/kilt/blob/7c97c711c0d239b512c148dbd7c483b5a705fc9b/OWNERS#L5)) of the [kilt](https://github.com/falcosecurity/kilt) repository, but `config/org.yaml` does not reflect that.

This PR fixes this issue.

