### PR TITLE
bulk update and cleanup of config/org.yaml

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -202,7 +202,7 @@ orgs:
     teams:
       admins:
         description: admins of the org
-        maintainers:
+        members:
           - caniszczyk
           - ldegio
           - leogr
@@ -213,9 +213,8 @@ orgs:
           advocacy: admin
       charts-maintainers:
         description: maintainers of the Falco Helm charts
-        maintainers:
-          - leogr
         members:
+          - leogr
           - cpanato
           - Issif
         privacy: closed
@@ -223,41 +222,38 @@ orgs:
           charts: maintain
       client-go-maintainers:
         description: maintainers of client-go
-        maintainers:
+        members:
           - leodido
           - leogr
-        members:
           - markyjackson-taulia
         privacy: closed
         repos:
           client-go: maintain
       client-py-maintainers:
         description: maintainers of client-py
-        maintainers:
-          - leodido
         members:
+          - leodido
           - mmat11
         privacy: closed
         repos:
           client-py: maintain
       client-rs-maintainers:
         description: ""
-        maintainers:
+        members:
           - leodido
         privacy: closed
         repos:
           client-rs: maintain
       community-maintainers:
         description: maintainers of the community repository
-        maintainers:
-          - leogr
         members:
+          - leogr
         privacy: closed
         repos:
           community: maintain
       deploy-kubernetes-maintainers:
         description: maintainers of deploy-kubernetes
-        maintainers:
+        members:
           - leogr
           - maxgio92
           - jasondellaluce
@@ -266,7 +262,7 @@ orgs:
           deploy-kubernetes: maintain
       driverkit-maintainers:
         description: maintainers of driverkit
-        maintainers:
+        members:
           - leodido
           - dwindsor
           - fededp
@@ -275,7 +271,7 @@ orgs:
           driverkit: maintain
       event-generator-maintainers:
         description: maintainers of the event-generator
-        maintainers:
+        members:
           - leogr
           - fededp
         privacy: closed
@@ -283,9 +279,8 @@ orgs:
           event-generator: maintain
       evolution-maintainers:
         description: maintainers of the evolution repository
-        maintainers:
-          - leogr
         members:
+          - leogr
           - nestorsalceda
           - maxgio92
         privacy: closed
@@ -293,7 +288,7 @@ orgs:
           evolution: maintain
       falco-aws-terraform-maintainers:
         description: ""
-        maintainers:
+        members:
           - mstemm
           - leogr
           - jasondellaluce
@@ -304,39 +299,36 @@ orgs:
           falco-aws-terraform: maintain
       falco-exporter-maintainers:
         description: maintainers of falco-exporter
-        maintainers:
+        members:
           - leogr
         privacy: closed
         repos:
           falco-exporter: maintain
       falco-maintainers:
         description: maintainers of the main Falco repository
-        maintainers:
+        members:
           - leogr
           - mstemm
           - jasondellaluce
           - fededp
-        members:
           - Kaizhe
         privacy: closed
         repos:
           falco: maintain
       falcoctl-maintainers:
         description: falcoctl maintainers
-        maintainers:
+        members:
           - leogr
           - mstemm
-        members:
           - markyjackson-taulia
         privacy: closed
         repos:
           falcoctl: maintain
       falcosidekick-maintainers:
         description: maintainers of falcosidekick
-        maintainers:
+        members:
           - leogr
           - Issif
-        members:
           - cpanato
           - fjogeleit
         privacy: closed
@@ -344,10 +336,9 @@ orgs:
           falcosidekick: maintain
       falcosidekick-ui-maintainers:
         description: maintainers of falcosidekick-ui
-        maintainers:
+        members:
           - leogr
           - Issif
-        members:
           - cpanato
           - fjogeleit
         privacy: closed
@@ -355,23 +346,22 @@ orgs:
           falcosidekick-ui: maintain
       github-maintainers:
         description: maintainers of the .github repository
-        maintainers:
+        members:
           - leogr
           - maxgio92
         repos:
           .github: maintain
       katacoda-scenarios-maintainers:
         description: ""
-        maintainers:
-          - leogr
         members:
+          - leogr
           - developer-guy
         privacy: closed
         repos:
           katacoda-scenarios: maintain
       kernel-crawler-maintainers:
         description: kernel-crawler maintainers
-        maintainers:
+        members:
           - fededp
           - maxgio92
           - leogr
@@ -381,20 +371,18 @@ orgs:
           kernel-crawler: maintain
       kilt-maintainers:
         description: ""
-        maintainers:
+        members:
           - leodido
           - gnosek
-        members:
           - admiral0
         privacy: closed
         repos:
           kilt: maintain
       libs-maintainers:
         description: libs maintainers
-        maintainers:
+        members:
           - ldegio
           - leogr
-        members:
           - Andreagit97
           - gnosek
           - fededp
@@ -404,7 +392,7 @@ orgs:
           libs: maintain
       libs-sdk-go-maintainers:
         description: libs-sdk-go maintainers
-        maintainers:
+        members:
           - araujof
           - terylt
           - leogr
@@ -415,7 +403,7 @@ orgs:
           libs-sdk-go: maintain
       machine_users:
         description: bots
-        maintainers:
+        members:
           - poiana
         privacy: closed
         repos:
@@ -445,53 +433,48 @@ orgs:
           test-infra: admin
       pdig-maintainers:
         description: maintainers of pdig
-        maintainers:
+        members:
           - leodido
           - ldegio
-        members:
           - gnosek
         privacy: closed
         repos:
           pdig: maintain
       plugin-sdk-cpp-maintainers:
         description: ""
-        maintainers:
+        members:
           - leodido
           - ldegio
           - leogr
           - mstemm
-        members:
           - fededp
         privacy: closed
         repos:
           plugin-sdk-cpp: read
       plugin-sdk-go-maintainers:
         description: ""
-        maintainers:
+        members:
           - ldegio
           - leogr
           - mstemm
-        members:
           - jasondellaluce
         privacy: closed
         repos:
           plugin-sdk-go: maintain
       plugins-maintainers:
         description: ""
-        maintainers:
+        members:
           - ldegio
           - leogr
           - mstemm
-        members:
           - jasondellaluce
         privacy: closed
         repos:
           plugins: maintain
       test-infra-maintainers:
         description: Maintainers of falcosecurity/test-infra
-        maintainers:
-          - leogr
         members:
+          - leogr
           - maxgio92
           - zuc
           - jonahjon
@@ -500,9 +483,8 @@ orgs:
           test-infra: maintain
       website-maintainers:
         description: maintainers of falco-website and docs
-        maintainers:
-          - leogr
         members:
+          - leogr
           - jasondellaluce
           - Issif
         privacy: closed

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -20,38 +20,25 @@ orgs:
       - araujof
       - Andreagit97
       - admiral0
-      - airadier
       - bencer
       - cpanato
       - darryk10
-      - developer-guy
       - dwindsor
       - fededp
       - fjogeleit
       - gnosek
-      - henridf
       - Issif
       - jasondellaluce
       - jonahjon
       - Kaizhe
-      - KeisukeYamashita
       - kris-nova
       - leodido
-      - lucperkins
-      - markyjackson-taulia
-      - mattpag
-      - maxgio92
       - mfdii
+      - markyjackson-taulia
+      - maxgio92
       - mmat11
       - Molter73
-      - mumoshu
       - nestorsalceda
-      - nibalizer
-      - pabloopez
-      - radhikapc
-      - Rajakavitha1
-      - sreedaum
-      - tembleking
       - terylt
       - zuc
 
@@ -229,7 +216,6 @@ orgs:
         maintainers:
           - leogr
         members:
-          - nibalizer
           - cpanato
           - Issif
         privacy: closed
@@ -241,7 +227,6 @@ orgs:
           - leodido
           - leogr
         members:
-          - mfdii
           - markyjackson-taulia
         privacy: closed
         repos:
@@ -267,8 +252,6 @@ orgs:
         maintainers:
           - leogr
         members:
-          - nibalizer
-          - mfdii
         privacy: closed
         repos:
           community: maintain
@@ -354,11 +337,8 @@ orgs:
           - leogr
           - Issif
         members:
-          - nibalizer
           - cpanato
           - fjogeleit
-          - developer-guy
-          - KeisukeYamashita
         privacy: closed
         repos:
           falcosidekick: maintain
@@ -379,7 +359,6 @@ orgs:
           - leogr
         members:
           - developer-guy
-          - pabloopez
         privacy: closed
         repos:
           katacoda-scenarios: maintain
@@ -526,11 +505,7 @@ orgs:
         maintainers:
           - leogr
         members:
-          - lucperkins
-          - mfdii
-          - radhikapc
           - jasondellaluce
-          - Rajakavitha1
           - Issif
         privacy: closed
         repos:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -10,7 +10,6 @@ orgs:
 
     admins:
       - caniszczyk
-      - fntlnz
       - kris-nova
       - ldegio
       - leodido
@@ -220,7 +219,6 @@ orgs:
           - caniszczyk
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - thelinuxfoundation
           - mstemm
@@ -232,7 +230,6 @@ orgs:
         description: maintainers of the Falco Helm charts
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -246,7 +243,6 @@ orgs:
         description: maintainers of client-go
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -268,7 +264,6 @@ orgs:
         description: ""
         maintainers:
           - leodido
-          - fntlnz
         privacy: closed
         repos:
           client-rs: maintain
@@ -276,7 +271,6 @@ orgs:
         description: maintainers of the community repository
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -298,7 +292,6 @@ orgs:
         description: maintainers of driverkit
         maintainers:
           - leodido
-          - fntlnz
           - dwindsor
           - fededp
         privacy: closed
@@ -308,7 +301,6 @@ orgs:
         description: maintainers of the event-generator
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
           - fededp
@@ -319,7 +311,6 @@ orgs:
         description: maintainers of the evolution repository
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -351,7 +342,6 @@ orgs:
         description: maintainers of the main Falco repository
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -366,7 +356,6 @@ orgs:
         description: falcoctl maintainers
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -425,7 +414,6 @@ orgs:
         description: ""
         maintainers:
           - leodido
-          - fntlnz
           - gnosek
         members:
           - admiral0
@@ -437,7 +425,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
         members:
           - Andreagit97
@@ -492,7 +479,6 @@ orgs:
         description: falconers (can dismiss reviews and apply milestones)
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -505,7 +491,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
         members:
           - gnosek
         privacy: closed
@@ -516,7 +501,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - mstemm
         members:
@@ -529,7 +513,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -543,7 +526,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -556,7 +538,6 @@ orgs:
         description: Maintainers of falcosecurity/test-infra
         maintainers:
           - leodido
-          - fntlnz
           - leogr
         members:
           - maxgio92
@@ -569,7 +550,6 @@ orgs:
         description: maintainers of falco-website and docs
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -353,6 +353,13 @@ orgs:
         privacy: closed
         repos:
           falcosidekick-ui: maintain
+      github-maintainers:
+        description: maintainers of the .github repository
+        maintainers:
+          - leogr
+          - maxgio92
+        repos:
+          .github: maintain
       katacoda-scenarios-maintainers:
         description: ""
         maintainers:
@@ -436,15 +443,6 @@ orgs:
           plugins: admin
           template-repository: admin
           test-infra: admin
-      maintainers:
-        description: falconers (can dismiss reviews and apply milestones)
-        maintainers:
-          - leogr
-        members:
-          - jasondellaluce
-        privacy: secret
-        repos:
-          .github: maintain
       pdig-maintainers:
         description: maintainers of pdig
         maintainers:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -417,7 +417,7 @@ orgs:
         description: bots
         maintainers:
           - poiana
-        privacy: secret
+        privacy: closed
         repos:
           .github: admin
           charts: admin

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -12,7 +12,6 @@ orgs:
       - caniszczyk
       - kris-nova
       - ldegio
-      - leodido
       - leogr
       - mstemm
       - poiana
@@ -37,6 +36,7 @@ orgs:
       - jonahjon
       - Kaizhe
       - KeisukeYamashita
+      - leodido
       - lucperkins
       - markyjackson-taulia
       - mattpag
@@ -217,7 +217,6 @@ orgs:
         description: admins of the org
         maintainers:
           - caniszczyk
-          - leodido
           - ldegio
           - leogr
           - thelinuxfoundation
@@ -229,7 +228,6 @@ orgs:
       charts-maintainers:
         description: maintainers of the Falco Helm charts
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -270,7 +268,6 @@ orgs:
       community-maintainers:
         description: maintainers of the community repository
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -300,7 +297,6 @@ orgs:
       event-generator-maintainers:
         description: maintainers of the event-generator
         maintainers:
-          - leodido
           - leogr
           - kris-nova
           - fededp
@@ -310,7 +306,6 @@ orgs:
       evolution-maintainers:
         description: maintainers of the evolution repository
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -333,7 +328,6 @@ orgs:
       falco-exporter-maintainers:
         description: maintainers of falco-exporter
         maintainers:
-          - leodido
           - leogr
         privacy: closed
         repos:
@@ -341,7 +335,6 @@ orgs:
       falco-maintainers:
         description: maintainers of the main Falco repository
         maintainers:
-          - leodido
           - leogr
           - mstemm
           - kris-nova
@@ -355,7 +348,6 @@ orgs:
       falcoctl-maintainers:
         description: falcoctl maintainers
         maintainers:
-          - leodido
           - leogr
           - mstemm
           - kris-nova
@@ -367,7 +359,6 @@ orgs:
       falcosidekick-maintainers:
         description: maintainers of falcosidekick
         maintainers:
-          - leodido
           - leogr
           - Issif
         members:
@@ -423,7 +414,6 @@ orgs:
       libs-maintainers:
         description: libs maintainers
         maintainers:
-          - leodido
           - ldegio
           - leogr
         members:
@@ -478,7 +468,6 @@ orgs:
       maintainers:
         description: falconers (can dismiss reviews and apply milestones)
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -511,7 +500,6 @@ orgs:
       plugin-sdk-go-maintainers:
         description: ""
         maintainers:
-          - leodido
           - ldegio
           - leogr
           - mstemm
@@ -524,7 +512,6 @@ orgs:
       plugins-maintainers:
         description: ""
         maintainers:
-          - leodido
           - ldegio
           - leogr
           - mstemm
@@ -537,7 +524,6 @@ orgs:
       test-infra-maintainers:
         description: Maintainers of falcosecurity/test-infra
         maintainers:
-          - leodido
           - leogr
         members:
           - maxgio92
@@ -549,7 +535,6 @@ orgs:
       website-maintainers:
         description: maintainers of falco-website and docs
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -351,14 +351,6 @@ orgs:
           - maxgio92
         repos:
           .github: maintain
-      katacoda-scenarios-maintainers:
-        description: ""
-        members:
-          - leogr
-          - developer-guy
-        privacy: closed
-        repos:
-          katacoda-scenarios: maintain
       kernel-crawler-maintainers:
         description: kernel-crawler maintainers
         members:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -212,25 +212,24 @@ orgs:
         repos:
           advocacy: admin
       charts-maintainers:
-        description: maintainers of the Falco Helm charts
+        description: maintainers of falcosecurity/charts
         members:
           - leogr
-          - cpanato
           - Issif
+          - cpanato
         privacy: closed
         repos:
           charts: maintain
       client-go-maintainers:
-        description: maintainers of client-go
+        description: maintainers of falcosecurity/client-go
         members:
           - leodido
           - leogr
-          - markyjackson-taulia
         privacy: closed
         repos:
           client-go: maintain
       client-py-maintainers:
-        description: maintainers of client-py
+        description: maintainers of falcosecurity/client-py
         members:
           - leodido
           - mmat11
@@ -238,30 +237,36 @@ orgs:
         repos:
           client-py: maintain
       client-rs-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/client-rs
         members:
           - leodido
         privacy: closed
         repos:
           client-rs: maintain
       community-maintainers:
-        description: maintainers of the community repository
+        description: maintainers of falcosecurity/community
         members:
           - leogr
+          - Issif
+          - Andreagit97
+          - terylt
+          - maxgio92
+          - araujof
         privacy: closed
         repos:
           community: maintain
       deploy-kubernetes-maintainers:
-        description: maintainers of deploy-kubernetes
+        description: maintainers of falcosecurity/deploy-kubernetes
         members:
           - leogr
           - maxgio92
           - jasondellaluce
+          - zuc
         privacy: closed
         repos:
           deploy-kubernetes: maintain
       driverkit-maintainers:
-        description: maintainers of driverkit
+        description: maintainers of falcosecurity/driverkit
         members:
           - leodido
           - dwindsor
@@ -270,7 +275,7 @@ orgs:
         repos:
           driverkit: maintain
       event-generator-maintainers:
-        description: maintainers of the event-generator
+        description: maintainers of falcosecurity/event-generator
         members:
           - leogr
           - fededp
@@ -278,16 +283,15 @@ orgs:
         repos:
           event-generator: maintain
       evolution-maintainers:
-        description: maintainers of the evolution repository
+        description: maintainers of falcosecurity/evolution
         members:
           - leogr
-          - nestorsalceda
           - maxgio92
         privacy: closed
         repos:
           evolution: maintain
       falco-aws-terraform-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/falco-aws-terraform
         members:
           - mstemm
           - leogr
@@ -298,46 +302,52 @@ orgs:
         repos:
           falco-aws-terraform: maintain
       falco-exporter-maintainers:
-        description: maintainers of falco-exporter
+        description: maintainers of falcosecurity/falco-exporter
         members:
           - leogr
+          - jasondellaluce
         privacy: closed
         repos:
           falco-exporter: maintain
       falco-maintainers:
-        description: maintainers of the main Falco repository
+        description: maintainers of falcosecurity/falco
         members:
-          - leogr
           - mstemm
+          - leogr
           - jasondellaluce
           - fededp
-          - Kaizhe
         privacy: closed
         repos:
           falco: maintain
-      falcoctl-maintainers:
-        description: falcoctl maintainers
+      falco-website-maintainers:
+        description: maintainers of falcosecurity/falco-website
         members:
           - leogr
-          - mstemm
-          - markyjackson-taulia
+          - jasondellaluce
+          - Issif
+        privacy: closed
+        repos:
+          falco-website: maintain
+      falcoctl-maintainers:
+        description: maintainers of falcosecurity/falcoctl
+        members:
+          - leogr
         privacy: closed
         repos:
           falcoctl: maintain
       falcosidekick-maintainers:
-        description: maintainers of falcosidekick
+        description: maintainers of falcosecurity/falcosidekick
         members:
-          - leogr
           - Issif
+          - leogr
           - cpanato
           - fjogeleit
         privacy: closed
         repos:
           falcosidekick: maintain
       falcosidekick-ui-maintainers:
-        description: maintainers of falcosidekick-ui
+        description: maintainers of falcosecurity/falcosidekick-ui
         members:
-          - leogr
           - Issif
           - cpanato
           - fjogeleit
@@ -345,14 +355,14 @@ orgs:
         repos:
           falcosidekick-ui: maintain
       github-maintainers:
-        description: maintainers of the .github repository
+        description: maintainers of falcosecurity/.github
         members:
           - leogr
           - maxgio92
         repos:
           .github: maintain
       kernel-crawler-maintainers:
-        description: kernel-crawler maintainers
+        description: maintainers of falcosecurity/kernel-crawler
         members:
           - fededp
           - maxgio92
@@ -362,34 +372,34 @@ orgs:
         repos:
           kernel-crawler: maintain
       kilt-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/kilt
         members:
+          - admiral0
           - leodido
           - gnosek
-          - admiral0
         privacy: closed
         repos:
           kilt: maintain
       libs-maintainers:
-        description: libs maintainers
+        description: maintainers of falcosecurity/libs
         members:
-          - ldegio
           - leogr
-          - Andreagit97
           - gnosek
+          - mstemm
           - fededp
-          - Molter73
+          - andreagit97
+          - molter73
         privacy: closed
         repos:
           libs: maintain
       libs-sdk-go-maintainers:
-        description: libs-sdk-go maintainers
+        description: maintainers of falcosecurity/libs-sdk-go
         members:
           - araujof
           - terylt
           - leogr
           - jasondellaluce
-          - Andreagit97
+          - andreagit97
         privacy: closed
         repos:
           libs-sdk-go: maintain
@@ -405,6 +415,7 @@ orgs:
           client-py: admin
           client-rs: admin
           community: admin
+          deploy-kubernetes: admin
           driverkit: admin
           event-generator: admin
           evolution: admin
@@ -415,70 +426,59 @@ orgs:
           falcoctl: admin
           falcosidekick: admin
           falcosidekick-ui: admin
-          katacoda-scenarios: admin
+          kernel-crawler: admin
           kilt: admin
           libs: admin
+          libs-sdk-go: admin
           pdig: admin
+          plugin-sdk-cpp: admin
           plugin-sdk-go: admin
           plugins: admin
-          template-repository: admin
           test-infra: admin
       pdig-maintainers:
-        description: maintainers of pdig
+        description: maintainers of falcosecurity/pdig
         members:
-          - leodido
           - ldegio
           - gnosek
+          - leodido
         privacy: closed
         repos:
           pdig: maintain
       plugin-sdk-cpp-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/plugin-sdk-cpp
         members:
-          - leodido
           - ldegio
-          - leogr
+          - leodido
           - mstemm
+          - leogr
           - fededp
         privacy: closed
         repos:
-          plugin-sdk-cpp: read
+          plugin-sdk-cpp: maintain
       plugin-sdk-go-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/plugin-sdk-go
         members:
-          - ldegio
           - leogr
-          - mstemm
           - jasondellaluce
         privacy: closed
         repos:
           plugin-sdk-go: maintain
       plugins-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/plugins
         members:
-          - ldegio
-          - leogr
           - mstemm
+          - leogr
           - jasondellaluce
         privacy: closed
         repos:
           plugins: maintain
       test-infra-maintainers:
-        description: Maintainers of falcosecurity/test-infra
+        description: maintainers of falcosecurity/test-infra
         members:
-          - leogr
           - maxgio92
-          - zuc
           - jonahjon
+          - leogr
+          - zuc
         privacy: closed
         repos:
           test-infra: maintain
-      website-maintainers:
-        description: maintainers of falco-website and docs
-        members:
-          - leogr
-          - jasondellaluce
-          - Issif
-        privacy: closed
-        repos:
-          falco-website: maintain

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -10,7 +10,6 @@ orgs:
 
     admins:
       - caniszczyk
-      - kris-nova
       - ldegio
       - leogr
       - mstemm
@@ -36,6 +35,7 @@ orgs:
       - jonahjon
       - Kaizhe
       - KeisukeYamashita
+      - kris-nova
       - leodido
       - lucperkins
       - markyjackson-taulia
@@ -221,7 +221,6 @@ orgs:
           - leogr
           - thelinuxfoundation
           - mstemm
-          - kris-nova
         privacy: closed
         repos:
           advocacy: admin
@@ -229,7 +228,6 @@ orgs:
         description: maintainers of the Falco Helm charts
         maintainers:
           - leogr
-          - kris-nova
         members:
           - nibalizer
           - cpanato
@@ -242,7 +240,6 @@ orgs:
         maintainers:
           - leodido
           - leogr
-          - kris-nova
         members:
           - mfdii
           - markyjackson-taulia
@@ -269,7 +266,6 @@ orgs:
         description: maintainers of the community repository
         maintainers:
           - leogr
-          - kris-nova
         members:
           - nibalizer
           - mfdii
@@ -298,7 +294,6 @@ orgs:
         description: maintainers of the event-generator
         maintainers:
           - leogr
-          - kris-nova
           - fededp
         privacy: closed
         repos:
@@ -307,7 +302,6 @@ orgs:
         description: maintainers of the evolution repository
         maintainers:
           - leogr
-          - kris-nova
         members:
           - nestorsalceda
           - maxgio92
@@ -337,7 +331,6 @@ orgs:
         maintainers:
           - leogr
           - mstemm
-          - kris-nova
           - jasondellaluce
           - fededp
         members:
@@ -350,7 +343,6 @@ orgs:
         maintainers:
           - leogr
           - mstemm
-          - kris-nova
         members:
           - markyjackson-taulia
         privacy: closed
@@ -469,7 +461,6 @@ orgs:
         description: falconers (can dismiss reviews and apply milestones)
         maintainers:
           - leogr
-          - kris-nova
         members:
           - jasondellaluce
         privacy: secret
@@ -503,7 +494,6 @@ orgs:
           - ldegio
           - leogr
           - mstemm
-          - kris-nova
         members:
           - jasondellaluce
         privacy: closed
@@ -515,7 +505,6 @@ orgs:
           - ldegio
           - leogr
           - mstemm
-          - kris-nova
         members:
           - jasondellaluce
         privacy: closed
@@ -536,7 +525,6 @@ orgs:
         description: maintainers of falco-website and docs
         maintainers:
           - leogr
-          - kris-nova
         members:
           - lucperkins
           - mfdii


### PR DESCRIPTION
This PR synchs the [config/org.yaml](https://github.com/falcosecurity/test-infra/blob/master/config/org.yaml) with `OWNERS` files from all repositories and updates the repository status (ie. remove teams from archived repositories).

All details are in commits' messages.