### PR TITLE
Add support for minikube drivers

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -22,8 +22,12 @@ TARGET_KERNEL_RELEASE ?= *
 TARGET_KERNEL_VERSION ?= *
 TARGET_KERNEL ?= ${TARGET_KERNEL_RELEASE}_${TARGET_KERNEL_VERSION}
 TARGET_ARCH ?= *
+# If TARGET_ARCH value is "*" then we consider all the the supported archs in ALL_ARCHS,
+# otherwise we just keep the one passed as parameter.
 TARGET_ARCHS := $(if $(call eq,$(TARGET_ARCH),*),$(ALL_ARCHS),$(TARGET_ARCH))
 TARGET_HEADERS ?=
+TARGET_KERNEL_RELEASE ?=
+TARGET_KERNEL_VERSION ?=
 S3_DRIVERS_BUCKET ?= "falco-distribution"
 S3_DRIVERS_KEY_PREFIX ?= "driver"
 SKIP_EXISTING ?= true
@@ -58,7 +62,7 @@ publish_s3: $(addprefix publish_s3_,$(VERSIONS))
 generate:
 	$(foreach ARCH,$(TARGET_ARCHS),\
 		$(foreach VERSION,$(VERSIONS),\
-			utils/generate -a '$(ARCH)' -k '${TARGET_KERNEL}' -d '${TARGET_DISTRO}' -h '${TARGET_HEADERS}' -v '${VERSION}'; \
+			utils/generate -a '$(ARCH)' -k '${TARGET_KERNEL_VERSION}' -r '${TARGET_KERNEL_RELEASE}' -d '${TARGET_DISTRO}' -h '${TARGET_HEADERS}' -v '${VERSION}'; \
 		)\
 	)
 

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -26,8 +26,7 @@ TARGET_ARCH ?= *
 # otherwise we just keep the one passed as parameter.
 TARGET_ARCHS := $(if $(call eq,$(TARGET_ARCH),*),$(ALL_ARCHS),$(TARGET_ARCH))
 TARGET_HEADERS ?=
-TARGET_KERNEL_RELEASE ?=
-TARGET_KERNEL_VERSION ?=
+TARGET_KERNEL_DEFCONFIG ?=
 S3_DRIVERS_BUCKET ?= "falco-distribution"
 S3_DRIVERS_KEY_PREFIX ?= "driver"
 SKIP_EXISTING ?= true
@@ -62,7 +61,7 @@ publish_s3: $(addprefix publish_s3_,$(VERSIONS))
 generate:
 	$(foreach ARCH,$(TARGET_ARCHS),\
 		$(foreach VERSION,$(VERSIONS),\
-			utils/generate -a '$(ARCH)' -k '${TARGET_KERNEL_VERSION}' -r '${TARGET_KERNEL_RELEASE}' -d '${TARGET_DISTRO}' -h '${TARGET_HEADERS}' -v '${VERSION}'; \
+			utils/generate -a '$(ARCH)' -k '${TARGET_KERNEL}' -r '${TARGET_KERNEL_RELEASE}' -t '${TARGET_KERNEL_VERSION}' -d '${TARGET_DISTRO}' -h '${TARGET_HEADERS}' -v '${VERSION}' -c '${TARGET_KERNEL_DEFCONFIG}'; \
 		)\
 	)
 

--- a/driverkit/utils/generate
+++ b/driverkit/utils/generate
@@ -16,10 +16,13 @@ declare -A output=()
 
 CURRENT_DIR="$(pwd)"
 
-while getopts ":a:k:d:v:h:r:" arg; do
+while getopts ":a:k:d:v:h:c:r:t:" arg; do
   case $arg in
     a)
       TARGET_ARCH=${OPTARG}
+      ;;
+    k)
+      TARGET_KERNEL=${OPTARG}
       ;;
     d)
       TARGET_DISTRO=${OPTARG}
@@ -30,10 +33,13 @@ while getopts ":a:k:d:v:h:r:" arg; do
     h)
       TARGET_HEADERS=${OPTARG}
       ;;
+    c)
+      TARGET_KERNEL_DEFCONFIG=${OPTARG}
+      ;;
     r)
       TARGET_KERNEL_RELEASE=${OPTARG}
       ;;
-    k)
+    t)
       TARGET_KERNEL_VERSION=${OPTARG}
       ;;
   esac
@@ -61,9 +67,6 @@ if [ -z ${TARGET_VERSION} ]; then
     exit 1
 fi
 
-compute_kernel() {
-    TARGET_KERNEL="${TARGET_KERNEL_RELEASE}_${TARGET_KERNEL_VERSION}"
-}
 
 check_outputs() {
     regex='([0-9]+)\.([0-9]+)'
@@ -185,11 +188,14 @@ generate_yamls() {
     then
         echo "  probe: output/${SUBPATH}/${PROBE_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.o" >> ${FILE}
     fi
-    if [[ -n "${TARGET_HEADERS}" ]]; then
+    if [ -n "${TARGET_HEADERS}" ] && [ "${TARGET_HEADERS}" != "null" ]; then
         echo "kernelurls: ${TARGET_HEADERS}" >> ${FILE}
+    fi
+
+    if [ -n "${TARGET_KERNEL_DEFCONFIG}" ] && [ "${TARGET_KERNEL_DEFCONFIG}" != "null" ]; then
+        echo "kernelconfigdata: ${TARGET_KERNEL_DEFCONFIG}" >> ${FILE}
     fi
 }
 
-compute_kernel
 check_outputs || exit 0
 generate_yamls

--- a/driverkit/utils/generate
+++ b/driverkit/utils/generate
@@ -16,13 +16,10 @@ declare -A output=()
 
 CURRENT_DIR="$(pwd)"
 
-while getopts ":a:k:d:v:h:" arg; do
+while getopts ":a:k:d:v:h:r:" arg; do
   case $arg in
     a)
       TARGET_ARCH=${OPTARG}
-      ;;
-    k)
-      TARGET_KERNEL=${OPTARG}
       ;;
     d)
       TARGET_DISTRO=${OPTARG}
@@ -32,6 +29,12 @@ while getopts ":a:k:d:v:h:" arg; do
       ;;
     h)
       TARGET_HEADERS=${OPTARG}
+      ;;
+    r)
+      TARGET_KERNEL_RELEASE=${OPTARG}
+      ;;
+    k)
+      TARGET_KERNEL_VERSION=${OPTARG}
       ;;
   esac
 done
@@ -45,8 +48,12 @@ if [ -z ${TARGET_DISTRO} ]; then
     echo "TARGET_DISTRO can't be empty"
     exit 1
 fi
-if [ -z ${TARGET_KERNEL} ]; then
-    echo "TARGET_KERNEL can't be empty"
+if [ -z ${TARGET_KERNEL_RELEASE} ]; then
+    echo "TARGET_KERNEL_RELEASE can't be empty"
+    exit 1
+fi
+if [ -z ${TARGET_KERNEL_VERSION} ]; then
+    echo "TARGET_KERNEL_VERSION can't be empty"
     exit 1
 fi
 if [ -z ${TARGET_VERSION} ]; then
@@ -54,12 +61,8 @@ if [ -z ${TARGET_VERSION} ]; then
     exit 1
 fi
 
-compute_kernelversion() {
-    TARGET_KERNEL_VERSION=$(echo "${TARGET_KERNEL##*_}")
-}
-
-compute_kernelrelease() {
-    TARGET_KERNEL_RELEASE="${TARGET_KERNEL%_${TARGET_KERNEL_VERSION}}"
+compute_kernel() {
+    TARGET_KERNEL="${TARGET_KERNEL_RELEASE}_${TARGET_KERNEL_VERSION}"
 }
 
 check_outputs() {
@@ -187,7 +190,6 @@ generate_yamls() {
     fi
 }
 
-compute_kernelversion
-compute_kernelrelease
+compute_kernel
 check_outputs || exit 0
 generate_yamls

--- a/driverkit/utils/scrape_and_generate
+++ b/driverkit/utils/scrape_and_generate
@@ -32,6 +32,8 @@ function generate_from_kernel_releases() {
 				make -C "$(dirname $0)/.." \
 				-e TARGET_ARCH="${ARCH}" \
 				-e TARGET_KERNEL="${release}_${version}" \
+				-e TARGET_KERNEL_RELEASE="${release}" \
+				-e TARGET_KERNEL_VERSION="${version}" \
 				-e TARGET_DISTRO="${target/${target_match}/${target_replace}}" \
 				-e TARGET_HEADERS="${kernelurls}" \
 				generate >/dev/null

--- a/driverkit/utils/scrape_and_generate
+++ b/driverkit/utils/scrape_and_generate
@@ -26,18 +26,19 @@ function generate_from_kernel_releases() {
 			read -r version
 			read -r target
 			read -r kernelurls
+			read -r kerneldefconfig
 			pretty_echo "Generating configs for:"
 			echo "release: $release	version: $version	target: $target"
 			test $DRY_RUN == "true" || \
 				make -C "$(dirname $0)/.." \
 				-e TARGET_ARCH="${ARCH}" \
-				-e TARGET_KERNEL="${release}_${version}" \
 				-e TARGET_KERNEL_RELEASE="${release}" \
 				-e TARGET_KERNEL_VERSION="${version}" \
 				-e TARGET_DISTRO="${target/${target_match}/${target_replace}}" \
 				-e TARGET_HEADERS="${kernelurls}" \
+				-e TARGET_KERNEL_DEFCONFIG="${kerneldefconfig}" \
 				generate >/dev/null
-		done < <(jq -cr ".${distro_family}[] | (.kernelrelease, .kernelversion, .target, .headers)" $TMPDIR/sample.json)
+		done < <(jq -cr ".${distro_family}[] | (.kernelrelease, .kernelversion, .target, .headers, .kernelconfigdata)" $TMPDIR/sample.json)
 	done
 }
 


### PR DESCRIPTION
This PR adds the necessary bits to generate the `config` files for minikube. When running `scrape_and_generate` script with the appropriate input it will generate config files containing something similar to:
```yaml
kernelversion: 1_1.26.0
kernelrelease: 5.10.57
target: minikube
architecture: amd64
output:
  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_minikube_5.10.57_1_1.26.0.ko
  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_minikube_5.10.57_1_1.26.0.o
kernelconfigdata: Q09ORklHX0ZBTk9USUZZPXkKQ09ORklHX0tQUk9CRV9FVkVO...
```
The `kernel-crawler` has already been updated falcosecurity/kernel-crawler#31 as well as `driverkit` falcosecurity/driverkit#189. 

Furthermore this PR tries to simplify how `kernel_version` and `kernel_release` are handled in `generate` script. The idea is to pass both kernel version and release as separate arguments. The current implementation uses a variable called `TARGET_KERNEL` which contains both the release and version (TARGET_KERNEL="{release}_{version}. Then `TARGET_KERNEL` is again split in two different variables containing the release and version. In some case it becomes cumbersome to split the `TARGET_KERNEL` when multiple `_` are present in the string. For this reason having them separated in `generate` script is preferred and we just join the strings when needed.