### PR TITLE
fix(images): fixed deps for update-kernels image.

### DIFF
--- a/images/update-kernels/Dockerfile
+++ b/images/update-kernels/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-lxml \
     python3-requests \
     python3-click \
+    python3-cffi \
+    python3-pygit2 \
     && apt-get clean
 
 COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin


### PR DESCRIPTION
Installing the new kernel-crawler `pygit2` dep with `pip3 install` leads to 
```
     Complete output from command python setup.py egg_info:
      Failed building wheel for cffi
    ERROR: Failed to build one or more wheels
    /tmp/pip-build-env-vsds4ub9/lib/python3.7/site-packages/setuptools/installer.py:30: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
      SetuptoolsDeprecationWarning,
    Traceback (most recent call last):
      File "/tmp/pip-build-env-vsds4ub9/lib/python3.7/site-packages/setuptools/installer.py", line 82, in fetch_build_egg
        subprocess.check_call(cmd)
      File "/usr/lib/python3.7/subprocess.py", line 347, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['/usr/bin/python3', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmpixukgcjs', '--quiet', 'cffi>=1.9.1']' returned non-zero exit status 1. 
```

Fix it by properly installing additional deps from debian repositories.