### PR TITLE
chore: config for amazonlinux2_5.4.204-113.362

### DIFF
--- a/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.yaml
+++ b/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.yaml
@@ -1,0 +1,7 @@
+kernelversion: 1
+kernelrelease: 5.4.204-113.362.amzn2.x86_64
+target: amazonlinux2
+architecture: amd64
+output:
+  module: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.ko
+  probe: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.o

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.yaml
@@ -1,0 +1,7 @@
+kernelversion: 1
+kernelrelease: 5.4.204-113.362.amzn2.x86_64
+target: amazonlinux2
+architecture: amd64
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.4.204-113.362.amzn2.x86_64_1.o


### PR DESCRIPTION
This commit adds configuration files for a new AWS linux kernel version
5.4.204-113.36

Signed-off-by: arminioa <arminio.andrei@gmail.com>