### PR TITLE
fix(utils-generate): Bringing back the compute functions

### DIFF
--- a/driverkit/utils/generate
+++ b/driverkit/utils/generate
@@ -70,6 +70,7 @@ compute_kernelrelease() {
 # If target kernel is not empty, compute release and version
 # Else, compute it with release and version
 if [ -n "${TARGET_KERNEL}" ]; then
+  echo "The '-k TARGET_KERNEL' option is deprecated, prefer the '-r TARGET_KERNEL_RELEASE -t TARGET_KERNEL_VERSION' combo"
   if [ -z "${TARGET_KERNEL_VERSION}" ]; then
     compute_kernelversion
   fi
@@ -78,7 +79,7 @@ if [ -n "${TARGET_KERNEL}" ]; then
   fi
 else
   if [ -z "${TARGET_KERNEL_RELEASE}" ] || [ -z "${TARGET_KERNEL_VERSION}" ]; then
-    echo "TARGET_KERNEL, TARGET_KERNEL_RELEASE, TARGET_KERNEL_RELEASE can't be empty at the same time"
+    echo "Options '-k TARGET_KERNEL', '- r TARGET_KERNEL_RELEASE', '-t TARGET_KERNEL_RELEASE' can't be empty at the same time"
     exit 1
   fi
   compute_kernel

--- a/driverkit/utils/generate
+++ b/driverkit/utils/generate
@@ -70,11 +70,11 @@ compute_kernelrelease() {
 # If target kernel is not empty, compute release and version
 # Else, compute it with release and version
 if [ -n "${TARGET_KERNEL}" ]; then
-  if [ -z "${TARGET_KERNEL_RELEASE}" ]; then
-    compute_kernelrelease
-  fi
   if [ -z "${TARGET_KERNEL_VERSION}" ]; then
     compute_kernelversion
+  fi
+  if [ -z "${TARGET_KERNEL_RELEASE}" ]; then
+    compute_kernelrelease
   fi
 else
   if [ -z "${TARGET_KERNEL_RELEASE}" ] || [ -z "${TARGET_KERNEL_VERSION}" ]; then

--- a/driverkit/utils/generate
+++ b/driverkit/utils/generate
@@ -45,28 +45,44 @@ while getopts ":a:k:d:v:h:c:r:t:" arg; do
   esac
 done
 
-
 if [ -z ${TARGET_ARCH} ]; then
     echo "TARGET_ARCH can't be empty"
     exit 1
 fi
+
 if [ -z ${TARGET_DISTRO} ]; then
     echo "TARGET_DISTRO can't be empty"
     exit 1
 fi
-if [ -z ${TARGET_KERNEL_RELEASE} ]; then
-    echo "TARGET_KERNEL_RELEASE can't be empty"
-    exit 1
-fi
-if [ -z ${TARGET_KERNEL_VERSION} ]; then
-    echo "TARGET_KERNEL_VERSION can't be empty"
-    exit 1
-fi
-if [ -z ${TARGET_VERSION} ]; then
-    echo "TARGET_VERSION can't be empty"
-    exit 1
-fi
 
+compute_kernel() {
+    TARGET_KERNEL="${TARGET_KERNEL_RELEASE}_${TARGET_KERNEL_VERSION}"
+}
+
+compute_kernelversion() {
+    TARGET_KERNEL_VERSION=$(echo "${TARGET_KERNEL##*_}")
+}
+
+compute_kernelrelease() {
+    TARGET_KERNEL_RELEASE="${TARGET_KERNEL%_${TARGET_KERNEL_VERSION}}"
+}
+
+# If target kernel is not empty, compute release and version
+# Else, compute it with release and version
+if [ -n "${TARGET_KERNEL}" ]; then
+  if [ -z "${TARGET_KERNEL_RELEASE}" ]; then
+    compute_kernelrelease
+  fi
+  if [ -z "${TARGET_KERNEL_VERSION}" ]; then
+    compute_kernelversion
+  fi
+else
+  if [ -z "${TARGET_KERNEL_RELEASE}" ] || [ -z "${TARGET_KERNEL_VERSION}" ]; then
+    echo "TARGET_KERNEL, TARGET_KERNEL_RELEASE, TARGET_KERNEL_RELEASE can't be empty at the same time"
+    exit 1
+  fi
+  compute_kernel
+fi
 
 check_outputs() {
     regex='([0-9]+)\.([0-9]+)'


### PR DESCRIPTION
generate kernel from release and version, generate release and version from kernel.

Signed-off-by: Lyonel Martinez <lyonel.martinez@numberly.com>

A previous update messed up a bit with params, getting exit due to at least one of `TARGET_KERNEL`/`TARGET_KERNEL_RELEASE`/`TARGET_KERNEL_VERSION` that was not set.
Bringing back some old functions to make it more breaking proof.

If `TARGET_KERNEL` is set, but not the release or version, we extract them from `TARGET_KERNEL`.
if `TARGET_KERNEL` is not set, we compute it with the release and version.