### PR TITLE
update(config/plugins): disable release-note for falcoctl

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -779,7 +779,6 @@ plugins:
       - label
       - lifecycle
       - lgtm
-      - release-note
       - require-matching-label
       - retitle
       - size


### PR DESCRIPTION
Having the release-note block is cumbersome for falcoctl (especially in its current status), so disabling it.