### PR TITLE
update(images): bump driverkit version to 0.9.6

### DIFF
--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -2,8 +2,8 @@ FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.9.2/driverkit_0.9.2_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.9.2_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.9.6/driverkit_0.9.6_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.9.6_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 


### PR DESCRIPTION
```
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>
```

Bump driverkit version to 0.9.6. 

For more info check the driverkit changelog: https://github.com/falcosecurity/driverkit/releases/tag/v0.9.6