### PR TITLE
fix(config,driverkit,images): fix kernel-crawler -> test-infra dbg automation

### DIFF
--- a/config/jobs/update-dbg/update-dbg.yaml
+++ b/config/jobs/update-dbg/update-dbg.yaml
@@ -2,9 +2,8 @@ postsubmits:
   falcosecurity/kernel-crawler:
     - name: update-dbg
       decorate: true
-      run_if_changed: '^kernels/'
       branches:
-        - ^main$
+        - ^kernels$
       extra_refs:
       # Check out the falcosecurity/test-infra repo
       # This will be the working directory

--- a/driverkit/utils/scrape_and_generate
+++ b/driverkit/utils/scrape_and_generate
@@ -5,7 +5,7 @@ set -euo pipefail
 DRY_RUN="${DRY_RUN:-false}"
 TMPDIR="$(mktemp -d)"
 ARCH="$1"
-LIST_URL="https://raw.githubusercontent.com/falcosecurity/kernel-crawler/main/kernels/${ARCH}/list.json"
+LIST_URL="https://raw.githubusercontent.com/falcosecurity/kernel-crawler/kernels/${ARCH}/list.json"
 
 function pretty_echo() {
 	echo

--- a/images/update-kernels/entrypoint.sh
+++ b/images/update-kernels/entrypoint.sh
@@ -19,6 +19,7 @@ set -o pipefail
 GH_PROXY="${GH_PROXY:-"http://ghproxy"}"
 GH_ORG="${GH_ORG:-"falcosecurity"}"
 GH_REPO="${GH_REPO:-"kernel-crawler"}"
+GH_TARGET_BRANCH="${GH_TARGET_BRANCH:-"kernels"}"
 BOT_NAME="${BOT_NAME:-"poiana"}"
 BOT_MAIL="${BOT_MAIL:-"51138685+poiana@users.noreply.github.com"}"
 BOT_GPG_KEY_PATH="${BOT_GPG_KEY_PATH:-"/root/gpg-signing-key/poiana.asc"}"
@@ -84,13 +85,13 @@ create_pr() {
         "https://${user}:$(cat "$1")@github.com/${GH_ORG}/${GH_REPO}" \
         "HEAD:${branch}"
 
-    echo "> creating pull-request to merge ${user}:${branch} into main..." >&2
+    echo "> creating pull-request to merge ${user}:${branch} into ${GH_TARGET_BRANCH} branch." >&2
     body="This PR updates the list of kernels from the latest crawling. Do not edit this PR."
 
     pr-creator \
         --github-endpoint="${GH_PROXY}" \
         --github-token-path="$1" \
-        --org="${GH_ORG}" --repo="${GH_REPO}" --branch=main \
+        --org="${GH_ORG}" --repo="${GH_REPO}" --branch=${GH_TARGET_BRANCH} \
         --title="${title}" --match-title="${title}" \
         --body="${body}" \
         --local --source="${branch}" \


### PR DESCRIPTION
Current `update-dbg` job is using `run_if_changed` key that is not available for postsubmits job (https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md), thus it is not triggered.
To workaround this issue, we let `update-kernels` job open a PR targeting `kernels` branch on kernel-crawler; then, `update-dbg` will run for merge to that branch.

kernel-crawler `kernels` branch will only have arch subfolders with their lists, and will be protected.