### PR TITLE
Add missing trigger plugin to kernel-crawler

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -877,6 +877,7 @@ plugins:
       - require-matching-label
       - retitle
       - size
+      - trigger
       - verify-owners
       - welcome
       - wip


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

This fixes the `update-dbg` job that is currently not being triggered correctly.

/cc @FedeDP 