### PR TITLE
update(config/org.yaml): add jasondellaluce to github-maintainers team

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -483,6 +483,7 @@ orgs:
           - leogr
         members:
           - maxgio92
+          - jasondellaluce
         privacy: closed
         repos:
           .github: maintain


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>