### PR TITLE
Set correct `CONTRIBUTING.md` path for DCO plugin

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -58,6 +58,11 @@ config_updater:
       name: job-config
       gzip: true
 
+dco:
+  "*":
+    contributing_branch: main
+    contributing_repo: falcosecurity/.github
+
 goose:
   key_path: /etc/unsplash/honk
 


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

This PR takes advantage of https://github.com/kubernetes/test-infra/pull/25495 to finally fix #430.