### PR TITLE
update(config): update status check names

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -215,15 +215,15 @@ branch-protection:
             required_approving_review_count: 2
           required_status_checks:
             contexts:
-              - "CI Build: build-libs-linux-amd64 😁 (system_deps)"
-              - "CI Build: build-libs-linux-amd64 😁 (bundled_deps)"
-              - "CI Build: build-libs-linux-amd64 😁 (system_deps_w_chisels)"
-              - "CI Build: build-libs-linux-amd64 😁 (system_deps_minimal)"
-              - "CI Build: build-libs-linux-amd64-asan 🧐"
-              - "CI Build: build-libs-arm64 🥶 (system_deps)"
-              - "CI Build: build-and-test-modern-bpf-x86 😇 (bundled_deps)"
-              - "CI Build: build-modern-bpf-arm64 🙃 (system_deps)"
-              - "CI Build: build-modern-bpf-s390x 😁 (system_deps)"
+              - "build-libs-linux-amd64 😁 (system_deps)"
+              - "build-libs-linux-amd64 😁 (bundled_deps)"
+              - "build-libs-linux-amd64 😁 (system_deps_w_chisels)"
+              - "build-libs-linux-amd64 😁 (system_deps_minimal)"
+              - "build-libs-linux-amd64-asan 🧐"
+              - "build-libs-arm64 🥶 (system_deps)"
+              - "build-and-test-modern-bpf-x86 😇 (bundled_deps)"
+              - "build-modern-bpf-arm64 🙃 (system_deps)"
+              - "build-modern-bpf-s390x 😁 (system_deps)"
           branches:
             master:
               protect: true


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

Currently, the CI is waiting for jobs that somehow do not match GitHub action names running in CI. This PR aligns the names with what we can see in the UI, hopefully that is the correct name that is required to update the GitHub configuration.

![image](https://user-images.githubusercontent.com/35580196/190657507-fe1cbbb2-4863-4339-923b-2cae34848c35.png)
