### PR TITLE
adding new configuration files for amazonlinux2_5.4.209-116.367.amzn2

### DIFF
--- a/driverkit/config/2.0.0+driver/aarch64/amazonlinux2_5.4.209-116.367.amzn2.aarch64_1.yaml
+++ b/driverkit/config/2.0.0+driver/aarch64/amazonlinux2_5.4.209-116.367.amzn2.aarch64_1.yaml
@@ -1,0 +1,8 @@
+kernelversion: 1
+kernelrelease: 5.4.209-116.367.amzn2.aarch64
+target: amazonlinux2
+architecture: arm64
+output:
+  module: output/2.0.0+driver/aarch64/falco_amazonlinux2_5.4.209-116.367.amzn2.aarch64_1.ko
+  probe: output/2.0.0+driver/aarch64/falco_amazonlinux2_5.4.209-116.367.amzn2.aarch64_1.o
+kernelurls: ["http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/stable/aarch64/63d547a4bc53f9ac146f4d2e99ab4366940c2eb12c05ec862d23f2386fec6b06/../../../../../../blobstore/70a8ffbf0886639e5d0795d66962c9a8f8bf766a1cde8b353a692e2ba0391aef/kernel-devel-5.4.209-116.367.amzn2.aarch64.rpm"]

--- a/driverkit/config/2.0.0+driver/x86_64/amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.yaml
+++ b/driverkit/config/2.0.0+driver/x86_64/amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.yaml
@@ -1,0 +1,8 @@
+kernelversion: 1
+kernelrelease: 5.4.209-116.367.amzn2.x86_64
+target: amazonlinux2
+architecture: amd64
+output:
+  module: output/2.0.0+driver/x86_64/falco_amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.ko
+  probe: output/2.0.0+driver/x86_64/falco_amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.o
+kernelurls: ["http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/stable/x86_64/63d547a4bc53f9ac146f4d2e99ab4366940c2eb12c05ec862d23f2386fec6b06/../../../../../../blobstore/276f8434008720135c698d2edb1010c15b51d052d2bf3f9208e589dbe5da0899/kernel-devel-5.4.209-116.367.amzn2.x86_64.rpm"]

--- a/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.yaml
+++ b/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.yaml
@@ -1,0 +1,8 @@
+kernelversion: 1
+kernelrelease: 5.4.209-116.367.amzn2.x86_64
+target: amazonlinux2
+architecture: amd64
+output:
+  module: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.ko
+  probe: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.o
+kernelurls: ["http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/stable/x86_64/63d547a4bc53f9ac146f4d2e99ab4366940c2eb12c05ec862d23f2386fec6b06/../../../../../../blobstore/276f8434008720135c698d2edb1010c15b51d052d2bf3f9208e589dbe5da0899/kernel-devel-5.4.209-116.367.amzn2.x86_64.rpm"]

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.yaml
@@ -1,0 +1,8 @@
+kernelversion: 1
+kernelrelease: 5.4.209-116.367.amzn2.x86_64
+target: amazonlinux2
+architecture: amd64
+output:
+  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.ko
+  probe: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_amazonlinux2_5.4.209-116.367.amzn2.x86_64_1.o
+kernelurls: ["http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/stable/x86_64/63d547a4bc53f9ac146f4d2e99ab4366940c2eb12c05ec862d23f2386fec6b06/../../../../../../blobstore/276f8434008720135c698d2edb1010c15b51d052d2bf3f9208e589dbe5da0899/kernel-devel-5.4.209-116.367.amzn2.x86_64.rpm"]


### PR DESCRIPTION
Hi,

I recently updated my EKS AMI to fix some CVE but now Falco is failing since it miss a kernel module version.

Here are the new version, using [this tutorial](https://www.anycodings.com/1questions/1031057/linux-kernel-headers-are-missing-on-eks-cluster) to find the kernelUrls.

Please let me know if this PR misses something !

Signed-off-by: Julen Dixneuf <julend@padok.fr>