### PR TITLE
update(config): falcoctl branches

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -181,6 +181,12 @@ branch-protection:
           branches:
             main:
               protect: true
+            gh-pages:
+              protect: true
+              enforce_admins: false # do not enforce all configured restrictions for admins, since our bot needs to push while the CI workflow is running
+              required_pull_request_reviews: # disable PR reviews since our bot needs to push while the CI workflow is running
+                require_code_owner_reviews: false
+                required_approving_review_count: 0
         falco-website:
           branches:
             master:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -179,7 +179,7 @@ branch-protection:
               - "ci/circleci: test"
         falcoctl:
           branches:
-            master:
+            main:
               protect: true
         falco-website:
           branches:


### PR DESCRIPTION
The first commit fixes https://github.com/falcosecurity/falcoctl/issues/151

The second commit sets up the `gh-pages` branch (we will use it to publish an artifact index, in a similar way we are doing for charts). 


