### PR TITLE
fix(images,config): properly use kernel-crawler docker image as base image for update-kernels

### DIFF
--- a/config/jobs/update-kernels/update-kernels.yaml
+++ b/config/jobs/update-kernels/update-kernels.yaml
@@ -7,7 +7,7 @@ periodics:
     # This will be the working directory
     - org: falcosecurity
       repo: kernel-crawler
-      base_ref: main
+      base_ref: kernels
       workdir: true
     spec:
       containers:

--- a/images/update-kernels/Dockerfile
+++ b/images/update-kernels/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18 AS pullrequestcreator
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
 
-FROM falcosecurity/kernel-crawler:0.1.0
+FROM falcosecurity/kernel-crawler:0.1.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/images/update-kernels/Dockerfile
+++ b/images/update-kernels/Dockerfile
@@ -3,22 +3,13 @@ FROM golang:1.18 AS pullrequestcreator
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
 
-FROM debian:buster
+FROM falcosecurity/kernel_crawler:0.1.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     gnupg2 \
     curl \
-    python \
-    python3 \
-    python3-pip \
-    python3-setuptools \
-    python3-lxml \
-    python3-requests \
-    python3-click \
-    python3-cffi \
-    python3-pygit2 \
     && apt-get clean
 
 COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin

--- a/images/update-kernels/Dockerfile
+++ b/images/update-kernels/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18 AS pullrequestcreator
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
 
-FROM falcosecurity/kernel_crawler:0.1.0
+FROM falcosecurity/kernel-crawler:0.1.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/images/update-kernels/entrypoint.sh
+++ b/images/update-kernels/entrypoint.sh
@@ -32,20 +32,9 @@ export GIT_AUTHOR_NAME=${BOT_NAME}
 export GIT_AUTHOR_EMAIL=${BOT_MAIL}
 
 crawl_kernels() {
-    /usr/bin/pip3 install -e .
-    python3 __init__.py crawl --distro=* --out_fmt=driverkit > x86_64_list.json
-    python3 __init__.py crawl --distro=* --out_fmt=driverkit --arch=aarch64 > aarch64_list.json
+    kernel-crawler crawl --distro=* --out_fmt=driverkit > x86_64/list.json
+    kernel-crawler crawl --distro=* --out_fmt=driverkit --arch=aarch64 > aarch64/list.json
     return $?
-}
-
-checkout_target_branch_and_mv_files() {
-    # prow cloned this rebo in --single-branch mode.
-    # We need to reconfigure it to fetch all branches.
-    git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-    git fetch -v
-    git checkout ${GH_TARGET_BRANCH}
-    mv x86_64_list.json x86_64/list.json
-    mv aarch64_list.json aarch64/list.json
 }
 
 # Sets git user configs, otherwise errors out.
@@ -131,16 +120,13 @@ main() {
     check_program "git"
     check_program "curl"
     check_program "pr-creator"
+    check_program "kernel-crawler"
 
     # Settings
     ensure_git_config "${BOT_NAME}" "${BOT_MAIL}"
     ensure_gpg_key "${BOT_GPG_KEY_PATH}" "${BOT_GPG_PUBLIC_KEY}"
 
-    # Crawl kernels from main branch
     crawl_kernels
-    
-    # Checkout the correct branch and move files to correct locations
-    checkout_target_branch_and_mv_files
     
     # Create PR (in case there are changes)
     create_pr "$1"


### PR DESCRIPTION
Note: this requires https://github.com/falcosecurity/kernel-crawler/pull/46 and a kernel-crawler tag before being useful.