### PR TITLE
cleanup(driverkit): dropped a rocky config whose name was wrong

### DIFF
--- a/driverkit/config/2.0.0+driver/x86_64/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/2.0.0+driver/x86_64/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,5 +1,0 @@
-kernelversion: 1
-kernelrelease: 4.18.0-348.el8.0.2.x86_64
-target: rocky
-output:
-  module: output/2.0.0+driver/x86_64/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/39ae7d40496793cf3d3e7890c9bbdc202263836b/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,5 +1,0 @@
-kernelversion: 1
-kernelrelease: 4.18.0-348.el8.0.2.x86_64
-target: rocky
-output:
-  module: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko

--- a/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
+++ b/driverkit/config/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/rocky_4.18.0-348.12.2.el8_5.x86_64_1.yaml
@@ -1,5 +1,0 @@
-kernelversion: 1
-kernelrelease: 4.18.0-348.el8.0.2.x86_64
-target: rocky
-output:
-  module: output/b7eb0dd65226a8dc254d228c8d950d07bf3521d2/falco_rocky_4.18.0-348.el8.0.2.x86_64_1.ko


### PR DESCRIPTION
And whose correct name config is already in place.