### PR TITLE
update(images): bumped build-drivers driverkit to 0.10.2

### DIFF
--- a/driverkit/utils/generate
+++ b/driverkit/utils/generate
@@ -4,16 +4,6 @@
 DRIVER_NAME="falco"
 PROBE_NAME="falco"
 
-aarch64_MINIMUM_KVER=(
-        "eBPF:4.17"
-        "kmod:3.4"
-)
-x86_64_MINIMUM_KVER=(
-        "eBPF:4.14"
-        "kmod:2.6"
-)
-declare -A output=()
-
 CURRENT_DIR="$(pwd)"
 
 while getopts ":a:k:d:v:h:c:r:t:" arg; do
@@ -85,49 +75,6 @@ else
   compute_kernel
 fi
 
-check_outputs() {
-    regex='([0-9]+)\.([0-9]+)'
-    if [[ "${TARGET_KERNEL}" =~ ${regex} ]]
-    then
-        maj=${BASH_REMATCH[1]}
-        min=${BASH_REMATCH[2]}
-
-        # Use correct array for target arch
-        declare -n arrayname=${TARGET_ARCH}_MINIMUM_KVER
-        ctr=0
-        for min_kver in "${arrayname[@]}" ; do
-            KEY="${min_kver%%:*}"
-            VALUE="${min_kver##*:}"
-
-            if [[ "${VALUE}" =~ ${regex} ]]
-            then
-                req_maj=${BASH_REMATCH[1]}
-                req_min=${BASH_REMATCH[2]}
-
-                if [[ ( $maj -gt $req_maj ) || ( $maj -eq $req_maj && $min -ge $req_min ) ]]
-                then
-                    output["$KEY"]=1
-                    ctr=$((ctr+1))
-                else
-                    echo "Skipping $KEY output: version ($maj.$min) too low: minimum: ($req_maj.$req_min)"
-                fi
-            else
-                echo "Wrong minimum kernel version: ${VALUE}."
-                return 1
-            fi
-        done
-    else
-        echo "Wrong target kernel: ${TARGET_KERNEL}."
-        return 1
-    fi
-
-    if [[ $ctr -eq 0 ]];
-    then
-        echo "No outputs configured. Unsupported target kernel version: ${TARGET_KERNEL}."
-        return 1
-    fi
-}
-
 arch_to_driverkit_arch() {
 	case "$1" in
 		"x86_64")
@@ -180,31 +127,20 @@ generate_yamls() {
     echo "target: ${TARGET_DISTRO}"
     echo "architecture: ${DKARCH}"
     echo "output:"
-    if [[ ${output["kmod"]} -eq 1 ]]
-    then
-        echo "  module: output/${SUBPATH}/${DRIVER_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.ko"
-    fi
-    if [[ ${output["eBPF"]} -eq 1 ]]
-    then
-        echo "  probe: output/${SUBPATH}/${PROBE_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.o"
-    fi
-    if [[ -n "${TARGET_HEADERS}" ]]; then
+    echo "  module: output/${SUBPATH}/${DRIVER_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.ko"
+    echo "  probe: output/${SUBPATH}/${PROBE_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.o"
+    if [ -n "${TARGET_HEADERS}" ] && [ "${TARGET_HEADERS}" != "null" ]; then
         echo "kernelurls: ${TARGET_HEADERS}"
     fi
+    # Do not print kernelconfigdata here: too verbose!
     
     echo "kernelversion: ${TARGET_KERNEL_VERSION}" > ${FILE}
     echo "kernelrelease: ${TARGET_KERNEL_RELEASE}" >> ${FILE}
     echo "target: ${TARGET_DISTRO}" >> ${FILE}
     echo "architecture: ${DKARCH}" >> ${FILE}
     echo "output:" >> ${FILE}
-    if [[ ${output["kmod"]} -eq 1 ]]
-    then
-        echo "  module: output/${SUBPATH}/${DRIVER_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.ko" >> ${FILE}
-    fi
-    if [[ ${output["eBPF"]} -eq 1 ]]
-    then
-        echo "  probe: output/${SUBPATH}/${PROBE_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.o" >> ${FILE}
-    fi
+    echo "  module: output/${SUBPATH}/${DRIVER_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.ko" >> ${FILE}
+    echo "  probe: output/${SUBPATH}/${PROBE_NAME}_${TARGET_DISTRO}_${TARGET_KERNEL}.o" >> ${FILE}
     if [ -n "${TARGET_HEADERS}" ] && [ "${TARGET_HEADERS}" != "null" ]; then
         echo "kernelurls: ${TARGET_HEADERS}" >> ${FILE}
     fi
@@ -214,5 +150,4 @@ generate_yamls() {
     fi
 }
 
-check_outputs || exit 0
 generate_yamls

--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -2,8 +2,8 @@ FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.10.0/driverkit_0.10.0_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.10.0_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.10.1/driverkit_0.10.1_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.10.1_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 

--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -2,8 +2,8 @@ FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.10.1/driverkit_0.10.1_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.10.1_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.10.2/driverkit_0.10.2_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.10.2_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 

--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -2,8 +2,8 @@ FROM 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.9.7/driverkit_0.9.7_linux_amd64.tar.gz \
-    && tar -xvf driverkit_0.9.7_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/driverkit/releases/download/v0.10.0/driverkit_0.10.0_linux_amd64.tar.gz \
+    && tar -xvf driverkit_0.10.0_linux_amd64.tar.gz \
     && chmod +x driverkit \
     && mv driverkit /bin/driverkit
 


### PR DESCRIPTION
Moreover, dropped some useless checks for output-module and output probe in `generate` script: now driverkit(since 0.10.2) is smart enough to disable (with a warning) unsupported outputs.