### PR TITLE
Drivers website

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -60,3 +60,10 @@ resource "aws_ecr_repository" "update_dbg" {
     encryption_type = "KMS"
   }
 }
+
+resource "aws_ecr_repository" "update_drivers_website" {
+  name = "test-infra/update-drivers-website"
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}

--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -280,3 +280,31 @@ presubmits:
           privileged: true
       nodeSelector:
         Archtype: "x86"      
+  - name: build-images-update-drivers-website
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-drivers-website/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/build.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-drivers-website"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+      nodeSelector:
+        Archtype: "x86"  

--- a/config/jobs/build-prow-images/publish-images.yaml
+++ b/config/jobs/build-prow-images/publish-images.yaml
@@ -281,3 +281,32 @@ postsubmits:
           privileged: true
       nodeSelector:
         Archtype: "x86"           
+  - name: publish-images-update-drivers-website
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-drivers-website/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-drivers-website"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+      nodeSelector:
+        Archtype: "x86"              
+         

--- a/config/jobs/update-drivers-website/update-drivers-website.yaml
+++ b/config/jobs/update-drivers-website/update-drivers-website.yaml
@@ -1,0 +1,23 @@
+periodics:
+  - name: update-drivers-website
+    cron: '0 0 * * *'  # every midnight, daily
+    decorate: true
+    extra_refs:
+    # Check out the falcosecurity/test-infra repo
+    # This will be the working directory
+    - org: falcosecurity
+      repo: test-infra
+      base_ref: master
+      workdir: true
+    spec:
+      containers:
+      # See images/update-drivers-site
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-drivers-website
+        imagePullPolicy: Always
+        command:
+        - /entrypoint.sh
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+      nodeSelector:
+        Archtype: "x86"

--- a/images/update-drivers-website/Dockerfile
+++ b/images/update-drivers-website/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.18
+
+ADD updateDriversWebsite.go .
+RUN go build -v -o update-drivers-website ./updateDriversWebsite.go
+COPY update-drivers-website /bin
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    awscli \
+    && apt-get clean
+
+COPY entrypoint.sh /
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/update-drivers-website/Makefile
+++ b/images/update-drivers-website/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+IMG_SLUG := test-infra
+IMG_NAME := update-drivers-website
+IMG_TAG ?= latest
+
+ACCOUNT := 292999226676
+DOCKER_PUSH_REPOSITORY = dkr.ecr.eu-west-1.amazonaws.com
+
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME):$(IMG_TAG)"
+
+build-push: build-image push-image
+
+build-image:
+	docker build --no-cache -t "$(IMG_SLUG)/$(IMG_NAME)" .
+
+push-image:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" $(IMAGE)
+	docker push $(IMAGE)
+
+local-registry:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" localhost:5000/$(IMG_NAME)
+	docker push localhost:5000/$(IMG_NAME)

--- a/images/update-drivers-website/entrypoint.sh
+++ b/images/update-drivers-website/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 The Falco Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+S3_DRIVERS_BUCKET ?= "falco-distribution"
+S3_DRIVERS_KEY_PREFIX ?= "driver"
+
+# $1: the program to check
+function check_program {
+    if hash "$1" 2>/dev/null; then
+        type -P "$1" >&/dev/null
+    else
+        echo "> aborting because $1 is required..." >&2
+       return 1
+    fi
+}
+
+# Meant to be run in the https://github.com/falcosecurity/test-infra repository.
+main() {
+    # Checks
+    check_program "awscli"
+    check_program "update-drivers-website"
+    
+    # Build updated json
+    update-drivers-website /tmp/website
+    
+    # Push the updated files to s3 bucket
+    aws s3 cp "/tmp/website/" s3://${S3_DRIVERS_BUCKET}/${S3_DRIVERS_KEY_PREFIX}/site --recursive --include "*.json" --include "index.html" --acl public-read
+    
+    exit 0
+}
+
+main

--- a/images/update-drivers-website/index.html
+++ b/images/update-drivers-website/index.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <meta charset="utf-8">
+    <title>Falco Probes</title>
+    <meta name="author" content="">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.1.3/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.12.1/css/dataTables.bootstrap5.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/1.12.1/js/dataTables.bootstrap5.min.js"></script>
+    <style>
+        .dataTables_filter {
+            padding-right: 10px;
+        }
+        .dataTables_length {
+            padding-left: 10px;
+        }
+        .btn {
+            padding-bottom: 15px;
+        }
+        .ebpf {
+            background-color: #1C5EF5;
+        }
+        .kmod {
+            background-color: #F78919;
+        }
+        .x86_64 {
+            background-color: #5d00f2;
+        }
+        .aarch64 {
+            background-color: #0b912f;
+        }
+        .form-select {
+            margin-left: 16px;
+            margin-bottom: 5px;
+            display: inline;
+        }
+    </style>
+    <script>
+        var url = new URL(window.location);
+        var lib = url.searchParams.get('lib');
+        if (lib == null) {
+            lib = "3.0.0+driver";
+            url.searchParams.set('lib', lib);
+        };
+        var target = url.searchParams.get('target')
+        if (target == null) {
+            target = "amazonlinux2";
+            url.searchParams.set('target', target);
+        };
+        var arch = url.searchParams.get('arch')
+        if (arch == null) {
+            arch = "x86_64";
+            url.searchParams.set('arch', arch);
+        };
+        var kind = url.searchParams.get('kind')
+        if (kind == null) {
+            kind = "ebpf";
+            url.searchParams.set('kind', kind);
+        };
+        var search = url.searchParams.get('search')
+        if (search == null) {
+            search = "";
+        };
+        window.history.pushState({}, '', url);
+        $.getJSON('./index.json', function(data) {
+            Object.entries(data).forEach (([key,value]) => {
+                var searchPrms = new URLSearchParams(window.location.search);
+                searchPrms.delete('search');
+                var selected = searchPrms.get('lib');
+                searchPrms.set('lib', value);
+                var element = document.createElement('option');
+                element.text = value;
+                if (selected == value) {
+                    element.selected = value;
+                }
+                element.value = "?"+searchPrms.toString();
+                document.getElementById('lib').appendChild(element);
+            });
+        });
+    </script>
+    </head>
+    <body>
+    <div>
+        <img src="https://sysdig.com/wp-content/uploads/2018/10/Falco-horizontal-logo-teal_2x.png" height="55" alt="falco logo">
+    </div>
+    <div style="padding-left: 10px;">
+        Lib:
+        <select class="form-select w-25" id="lib" onchange="if (this.value) window.location.href=this.value"></select>
+    </div>
+    <div id="arch" style="padding-left: 10px;">
+        Arch:
+    </div>
+    <div id="kind" style="padding-left: 10px;">
+        Kind:
+    </div>
+    <div id="target" style="padding-left: 10px; padding-bottom: 15px;">
+        Target:
+    </div>
+    <table id="drivers" class="table table-striped table-condensed" style="padding-left: 10px;">
+        <thead>
+            <tr>
+                <th>Lib</th>
+                <th>Arch</th>
+                <th>Target</th>
+                <th>Kind</th> 
+                <th>Kernel</th> 
+                <th>Name</th>
+                <th>Size</th>
+                <th>Download</th>
+                <th>LastModified</th>
+                <th>Link</th>
+            </tr>
+        </thead>
+    </table>
+    </body>
+    <script>
+        var url = new URL(window.location);
+        $(document).ready(function() {
+            $.getJSON('./'+lib+'.json', function(data) {
+                Object.entries(data['index']).forEach (([key, value]) => {
+                    var searchPrms = new URLSearchParams(window.location.search);
+                    searchPrms.delete('search');
+                    var selected = searchPrms.get(key);
+                    if (key != "lib") {
+                        searchPrms.set(key, 'all');
+                        var element = document.createElement('a');
+                        element.className = "btn btn-outline-primary btn-sm";
+                        if (selected == 'all') {
+                            element.className = "btn btn-primary btn-sm";
+                        }
+                        element.style = "margin: 5px; padding-top: 8px; padding-bottom: 10px;"
+                        element.text = 'ALL';
+                        element.href = "?"+searchPrms.toString();
+                        document.getElementById(key).appendChild(element);
+                    }
+                    for (var item of value) {
+                        searchPrms.set(key, item);
+                        if (key != "lib") {
+                            var element = document.createElement('a');
+                            element.className = "btn btn-outline-primary btn-sm";
+                            if (selected == item) {
+                                element.className = "btn btn-primary btn-sm";
+                            }
+                            element.style = "margin: 5px; padding-top: 8px; padding-bottom: 10px;"
+                            element.text = item;
+                            element.href = "?"+searchPrms.toString();
+                            document.getElementById(key).appendChild(element);
+                        }
+                    }
+                });
+                var drivers = [];
+                data['drivers'].forEach (value => {
+                    if (value.arch != url.searchParams.get('arch') && url.searchParams.get('arch') != 'all') {
+                        return;
+                    }
+                    if (value.kind != url.searchParams.get('kind') && url.searchParams.get('kind') != 'all') {
+                        return;
+                    }
+                    if (value.target != url.searchParams.get('target') && url.searchParams.get('target') != 'all') {
+                        return;
+                    }
+                    drivers.push(value);
+                });
+                $('#drivers').DataTable({
+                    "search": {"search": search },
+                    "paging": true,
+                    "pageLength": 100,
+                    "data": drivers,
+                    "order": [[ 2, "asc" ]],
+                    columns : [
+                        { "data" : "lib"},
+                        {
+                            "data": 'arch',
+                            render: function (data) {
+                                if (data === "x86_64") {
+                                    return '<span class="badge x86_64">'+data+'</span>'
+                                }
+                                if (data === "aarch64") {
+                                    return '<span class="badge aarch64">'+data+'</span>'
+                                }
+                                return data
+                            },
+                        },
+                        { "data" : "target"},
+                        {
+                            "data": 'kind',
+                            "search": "ebpf",
+                            render: function (data) {
+                                if (data === "ebpf") {
+                                    return '<span class="badge ebpf">'+data+'</span>'
+                                }
+                                if (data === "kmod") {
+                                    return '<span class="badge kmod">'+data+'</span>'
+                                }
+                                return data
+                            },
+                        },
+                        { "data" : "kernel"},
+                        { "data" : "name"},
+                        { "data" : "size"},
+                        {
+                            "data": 'download',
+                            render: function (data) {
+                                return '<a href="'+data+'" download="'+data+'"><i class="bi bi-download" style="padding-left: 30px;"></i></a>'
+                            },
+                        },
+                        { "data" : "lastmodified"},
+                        { 
+                            "data" : "name",
+                            render: function (data) {
+                                url.searchParams.set('search', data);
+                                return '<a href="?'+url.searchParams.toString()+'"><i class="bi bi-link"></i></a>';
+                            }
+                        },
+                    ]
+                });
+            });
+        });
+    </script>
+</html>

--- a/images/update-drivers-website/updateDriversWebsite.go
+++ b/images/update-drivers-website/updateDriversWebsite.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const source = "https://falco-distribution.s3-eu-west-1.amazonaws.com/?list-type=2&prefix=driver"
+const download = "https://download.falco.org/"
+
+type ListBucketResult struct {
+	XMLName               xml.Name  `xml:"ListBucketResult"`
+	Contents              []Content `xml:"Contents"`
+	NextContinuationToken string    `xml:"NextContinuationToken"`
+	IsTruncated           string    `xml:"IsTruncated"`
+}
+
+type Content struct {
+	Lib          string `json:"lib"`
+	Arch         string `json:"arch"`
+	Kind         string `json:"kind"`
+	Kernel       string `json:"kernel"`
+	Target       string `json:"target"`
+	Key          string `xml:"Key" json:"name"`
+	Download     string `json:"download"`
+	SizeBytes    int    `xml:"Size" json:"sizebytes"`
+	Size         string `xml:"SizeString" json:"size"`
+	LastModified string `xml:"LastModified" json:"lastmodified"`
+}
+
+type List struct {
+	Libs    []string `json:"lib"`
+	Archs   []string `json:"arch"`
+	Kinds   []string `json:"kind"`
+	Targets []string `json:"target"`
+}
+
+type JSONFile struct {
+	Index   List      `json:"index"`
+	Drivers []Content `json:"drivers"`
+}
+
+var (
+	destFolder string
+	jsonFiles  map[string]JSONFile
+)
+
+func init() {
+	jsonFiles = make(map[string]JSONFile)
+	if len(os.Args) < 2 || os.Args[1] == "" {
+		destFolder, _ = os.Getwd()
+	}
+	destFolder = strings.TrimSuffix(os.Args[1], "/")
+	if err := os.MkdirAll(filepath.Dir(destFolder), 0754); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func main() {
+	fetchXML("")
+	for i, j := range jsonFiles {
+		f, err := json.Marshal(j)
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = ioutil.WriteFile(i, f, 0755)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	l := []string{}
+	for _, i := range jsonFiles {
+		l = removeDuplicateStr(append(l, i.Index.Libs...))
+	}
+	f, err := json.Marshal(l)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = ioutil.WriteFile(destFolder+"/index.json", f, 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func fetchXML(token string) {
+	url := source
+	if token != "" {
+		url += "&continuation-token=" + neturl.QueryEscape(token)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer resp.Body.Close()
+
+	byteValue, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	var listBucket ListBucketResult
+	if err := xml.Unmarshal(byteValue, &listBucket); err != nil {
+		log.Fatalln(err)
+	}
+
+	for _, i := range listBucket.Contents {
+		k := i.Key
+		if !strings.HasSuffix(k, ".ko") && !strings.HasSuffix(k, ".o") {
+			continue
+		}
+		var key, lib, arch, kind, target, kernel string
+		s := strings.Split(k, "/")
+		lib = s[1]
+		switch len(s) {
+		case 3:
+			arch = "x86_64"
+			key = s[2]
+		case 4:
+			arch = s[2]
+			key = s[3]
+		default:
+			continue
+		}
+		target = strings.Split(key, "_")[1]
+		kernel = strings.TrimSuffix(strings.TrimSuffix(strings.Split(key, "_")[2], ".o"), ".ko")
+		switch filepath.Ext(key) {
+		case ".o":
+			kind = "ebpf"
+		case ".ko":
+			kind = "kmod"
+		default:
+			kind = "unknown"
+		}
+
+		jf := jsonFiles[destFolder+"/"+lib+".json"]
+		jf.Index.Libs = removeDuplicateStr(append(jf.Index.Libs, lib))
+		jf.Index.Archs = removeDuplicateStr(append(jf.Index.Archs, arch))
+		jf.Index.Kinds = removeDuplicateStr(append(jf.Index.Kinds, kind))
+		jf.Index.Targets = removeDuplicateStr(append(jf.Index.Targets, target))
+
+		jf.Drivers = append(jf.Drivers, Content{
+			Lib:          lib,
+			Arch:         arch,
+			Key:          key,
+			Kernel:       kernel,
+			Target:       target,
+			SizeBytes:    i.SizeBytes,
+			Size:         humaneteBytes(uint64(i.SizeBytes)),
+			LastModified: i.LastModified,
+			Kind:         kind,
+			Download:     download + neturl.QueryEscape(k),
+		})
+		jsonFiles[destFolder+"/"+lib+".json"] = jf
+	}
+
+	if listBucket.IsTruncated == "true" {
+		fetchXML(listBucket.NextContinuationToken)
+	}
+}
+
+func removeDuplicateStr(strSlice []string) []string {
+	allKeys := make(map[string]bool)
+	list := []string{}
+	for _, item := range strSlice {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}
+
+func humaneteBytes(s uint64) string {
+	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+	if s < 10 {
+		return fmt.Sprintf("%d B", s)
+	}
+	e := math.Floor(math.Log(float64(s)) / math.Log(1024.0))
+	suffix := sizes[int(e)]
+	val := math.Floor(float64(s)/math.Pow(1024.0, e)*10+0.5) / 10
+	f := "%.0f %s"
+	if val < 10 {
+		f = "%.1f %s"
+	}
+
+	return fmt.Sprintf(f, val, suffix)
+}


### PR DESCRIPTION
Signed-off-by: Thomas Labarussias <issif+github@gadz.org>

To allow people to easy search among available drivers, I propose to upload into the [S3 bucket](https://download.falco.org/?prefix=driver/) a website which looks like:

![image](https://user-images.githubusercontent.com/4520100/196440607-2dc7daac-2172-417c-99a4-b8ac0e71cb06.png)


To work, we need to generate json files listing all drivers with their details, this is done by a go script. This go script should be run after each merge into /driverkit/config.