### PR TITLE
encode only a component

### DIFF
--- a/images/update-drivers-website/index.html
+++ b/images/update-drivers-website/index.html
@@ -121,7 +121,7 @@
     <script>
         var url = new URL(window.location);
         $(document).ready(function() {
-            $.getJSON(encodeURI('./'+lib+'.json'), function(data) {
+            $.getJSON('./'+encodeURIComponent(lib)+'.json', function(data) {
                 Object.entries(data['index']).forEach (([key, value]) => {
                     var searchPrms = new URLSearchParams(window.location.search);
                     searchPrms.delete('search');


### PR DESCRIPTION
Signed-off-by: Thomas Labarussias <issif+github@gadz.org>

enforce the encoding of `lib` only. should fix the #878 