### PR TITLE
fix(dbg): avoid passing a huge kernelconfigdata (see: flatcar) as env variable

### DIFF
--- a/driverkit/README.md
+++ b/driverkit/README.md
@@ -49,6 +49,14 @@ These are the available filters as environment variables:
 
 Notice all the filters are optional (except for `generate` where they are mandatory).
 
+##### Available generate-specific variables
+
+These are the available used as environment variables:
+
+- all of the above filter variables
+- `TARGET_KERNEL_DEFCONFIG`: a path to a file that contains the base64 encoded defconfig for the kernel. Optional.
+- `TARGET_HEADERS`: a list of headers for the current kernel. Optional.
+
 ##### Examples
 
 You can filter a specific distro with a specific kernel (i.e. 5.9.0 release and version #1):

--- a/driverkit/utils/generate
+++ b/driverkit/utils/generate
@@ -145,8 +145,9 @@ generate_yamls() {
         echo "kernelurls: ${TARGET_HEADERS}" >> ${FILE}
     fi
 
-    if [ -n "${TARGET_KERNEL_DEFCONFIG}" ] && [ "${TARGET_KERNEL_DEFCONFIG}" != "null" ]; then
-        echo "kernelconfigdata: ${TARGET_KERNEL_DEFCONFIG}" >> ${FILE}
+    TARGET_KERNEL_DEFCONFIG_DATA="$(<${TARGET_KERNEL_DEFCONFIG})"
+    if [ -n "${TARGET_KERNEL_DEFCONFIG_DATA}" ] && [ "${TARGET_KERNEL_DEFCONFIG_DATA}" != "null" ]; then
+        echo "kernelconfigdata: ${TARGET_KERNEL_DEFCONFIG_DATA}" >> ${FILE}
     fi
 }
 

--- a/driverkit/utils/scrape_and_generate
+++ b/driverkit/utils/scrape_and_generate
@@ -17,9 +17,6 @@ function get_kernel_releases() {
 }
 
 function generate_from_kernel_releases() {
-	local target_match="ubuntu-gke"
-	local target_replace="ubuntu-generic"
-
 	for distro_family in $(jq -cr '. | keys[]' $TMPDIR/sample.json); do
 		while read -r release
 		do
@@ -29,14 +26,15 @@ function generate_from_kernel_releases() {
 			read -r kerneldefconfig
 			pretty_echo "Generating configs for:"
 			echo "release: $release	version: $version	target: $target"
+			echo ${kerneldefconfig} > "$TMPDIR/kernelconfigdata" # pass by file to avoid exceeding the bash env size limit
 			test $DRY_RUN == "true" || \
 				make -C "$(dirname $0)/.." \
 				-e TARGET_ARCH="${ARCH}" \
 				-e TARGET_KERNEL_RELEASE="${release}" \
 				-e TARGET_KERNEL_VERSION="${version}" \
-				-e TARGET_DISTRO="${target/${target_match}/${target_replace}}" \
+				-e TARGET_DISTRO="${target}" \
 				-e TARGET_HEADERS="${kernelurls}" \
-				-e TARGET_KERNEL_DEFCONFIG="${kerneldefconfig}" \
+				-e TARGET_KERNEL_DEFCONFIG="$TMPDIR/kernelconfigdata" \
 				generate >/dev/null
 		done < <(jq -cr ".${distro_family}[] | (.kernelrelease, .kernelversion, .target, .headers, .kernelconfigdata)" $TMPDIR/sample.json)
 	done

--- a/images/update-kernels/Dockerfile
+++ b/images/update-kernels/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18 AS pullrequestcreator
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
 
-FROM falcosecurity/kernel-crawler:0.1.3
+FROM falcosecurity/kernel-crawler:0.2.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
Instead, pass it through a file.
Env variables have size limit of 32KB.
Moreover, dropped replacement of ubuntu-gke with ubuntu-generic now that we support ubuntu-gke.