### PR TITLE
new: add an update-syscalls job that runs monthly

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -54,6 +54,13 @@ resource "aws_ecr_repository" "update_kernels" {
   }
 }
 
+resource "aws_ecr_repository" "update_syscalls" {
+  name = "test-infra/update-syscalls"
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}
+
 resource "aws_ecr_repository" "update_dbg" {
   name = "test-infra/update-dbg"
   encryption_configuration {

--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -307,4 +307,32 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        Archtype: "x86"  
+        Archtype: "x86"
+  - name: build-images-update-syscalls
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-syscalls/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/build.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-syscalls"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+      nodeSelector:
+        Archtype: "x86"      

--- a/config/jobs/build-prow-images/publish-images.yaml
+++ b/config/jobs/build-prow-images/publish-images.yaml
@@ -308,5 +308,33 @@ postsubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        Archtype: "x86"              
+        Archtype: "x86"
+  - name: publish-images-update-syscalls
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-syscalls/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-syscalls"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+      nodeSelector:
+        Archtype: "x86"      
          

--- a/config/jobs/update-syscalls/update-syscalls.yaml
+++ b/config/jobs/update-syscalls/update-syscalls.yaml
@@ -1,0 +1,39 @@
+periodics:
+  - name: update-syscalls
+    cron: '0 6 1 * *'  # every 1st day of month, at 6am
+    decorate: true
+    extra_refs:
+    - org: falcosecurity
+      repo: libs
+      base_ref: master
+      workdir: true
+    spec:
+      containers:
+      # See images/update-syscalls
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-syscalls
+        imagePullPolicy: Always
+        command:
+        - /entrypoint.sh
+        args:
+        - /etc/github-token/oauth
+        env:
+        - name: GH_PROXY
+          value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+        - name: gpg-signing-key
+          mountPath: /root/gpg-signing-key/
+          readOnly: true
+      volumes:
+      - name: github
+        secret:
+          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+          secretName: oauth-token
+      - name: gpg-signing-key
+        secret:
+          secretName: poiana-gpg-signing-key
+          defaultMode: 0400
+      nodeSelector:
+        Archtype: "x86"

--- a/images/update-syscalls/Dockerfile
+++ b/images/update-syscalls/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.18 AS pullrequestcreator
+
+RUN git clone https://github.com/kubernetes/test-infra
+RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
+
+FROM golang:1.19 AS builder
+
+RUN git clone https://github.com/FedeDP/SyscallsBumper.git
+RUN cd SyscallsBumper && make build
+
+FROM debian:buster
+
+COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin
+COPY --from=builder /go/SyscallsBumper/build/bumper /bin
+
+COPY entrypoint.sh /
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/update-syscalls/Dockerfile
+++ b/images/update-syscalls/Dockerfile
@@ -5,13 +5,13 @@ RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
 
 FROM golang:1.19 AS builder
 
-RUN git clone https://github.com/FedeDP/SyscallsBumper.git
-RUN cd SyscallsBumper && make build
+RUN git clone https://github.com/FedeDP/syscalls-bumper.git
+RUN cd syscalls-bumper && make build
 
 FROM debian:buster
 
 COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin
-COPY --from=builder /go/SyscallsBumper/build/bumper /bin
+COPY --from=builder /go/syscalls-bumper/build/syscalls-bumper /bin
 
 COPY entrypoint.sh /
 

--- a/images/update-syscalls/Makefile
+++ b/images/update-syscalls/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+IMG_SLUG := test-infra
+IMG_NAME := update-syscalls
+IMG_TAG ?= latest
+
+ACCOUNT := 292999226676
+DOCKER_PUSH_REPOSITORY = dkr.ecr.eu-west-1.amazonaws.com
+
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME):$(IMG_TAG)"
+
+build-push: build-image push-image
+
+build-image:
+	docker build --no-cache -t "$(IMG_SLUG)/$(IMG_NAME)" .
+
+push-image:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" $(IMAGE)
+	docker push $(IMAGE)
+
+local-registry:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" localhost:5000/$(IMG_NAME)
+	docker push localhost:5000/$(IMG_NAME)

--- a/images/update-syscalls/entrypoint.sh
+++ b/images/update-syscalls/entrypoint.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 The Falco Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Args from environment (with defaults)
+GH_PROXY="${GH_PROXY:-"http://ghproxy"}"
+GH_ORG="${GH_ORG:-"falcosecurity"}"
+GH_REPO="${GH_REPO:-"libs"}"
+GH_SOURCE_BRANCH="${GH_SOURCE_BRANCH:-"update/syscalls"}"
+GH_TARGET_BRANCH="${GH_TARGET_BRANCH:-"master"}"
+BOT_NAME="${BOT_NAME:-"poiana"}"
+BOT_MAIL="${BOT_MAIL:-"51138685+poiana@users.noreply.github.com"}"
+BOT_GPG_KEY_PATH="${BOT_GPG_KEY_PATH:-"/root/gpg-signing-key/poiana.asc"}"
+BOT_GPG_PUBLIC_KEY="${BOT_GPG_PUBLIC_KEY:-"EC9875C7B990D55F3B44D6E45F284448FF941C8F"}"
+
+export GIT_COMMITTER_NAME=${BOT_NAME}
+export GIT_COMMITTER_EMAIL=${BOT_MAIL}
+export GIT_AUTHOR_NAME=${BOT_NAME}
+export GIT_AUTHOR_EMAIL=${BOT_MAIL}
+
+bump_syscalls() {
+    bumper --repo-root ${pwd} --overwrite
+    return $?
+}
+
+# Sets git user configs, otherwise errors out.
+# $1: git user name
+# $2: git user email
+ensure_git_config() {
+    echo "> configuring git user (name=$1, email=$2)..." >&2
+    git config --global user.name "$1"
+    git config --global user.email "$2"
+
+    git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    return 1
+}
+
+# Configures GPG key, otherwise errors out.
+# $1: GPG key location
+# $2: GPG ASCII armored public key
+ensure_gpg_key() {
+    echo "> configuring git with gpg key=$1..." >&2
+    gpg --import "$1"
+    git config --global commit.gpgsign true
+    git config --global user.signingkey "$2"
+
+    git config --global commit.gpgsign &>/dev/null && git config --global user.signingkey &>/dev/null && return 0
+    echo "ERROR: git gpg key location, public key ID unset. No defaults provided" >&2
+    return 1
+}
+
+# Creates a pull-request in case there are changes to commit and to push.
+# $1: path of the file containing the token
+create_pr() {
+    nchanges=$(git status --porcelain=v1 2> /dev/null | wc -l)
+    if [ "${nchanges}" -eq "0" ]; then
+        echo "> moving on since there are no changes..." >&2
+        return 0;
+    fi
+
+    echo "> creating commit..." >&2
+    title="update(driver): update syscalls tables."
+    git add .
+    git commit -s -m "${title}"
+
+    user=$(get_user_from_token "$1")
+    echo "> pushing commit as ${user} on branch ${GH_SOURCE_BRANCH}..." >&2
+    git push -f \
+        "https://${user}:$(cat "$1")@github.com/${GH_ORG}/${GH_REPO}" \
+        "HEAD:${GH_SOURCE_BRANCH}"
+
+    echo "> creating pull-request to merge ${user}:${GH_SOURCE_BRANCH} into ${GH_TARGET_BRANCH} branch." >&2
+    body="This PR updates the list of supported syscalls from the latest kernel. Do not edit this PR."
+
+    pr-creator \
+        --github-endpoint="${GH_PROXY}" \
+        --github-token-path="$1" \
+        --org="${GH_ORG}" --repo="${GH_REPO}" --branch=${GH_TARGET_BRANCH} \
+        --title="${title}" --match-title="${title}" \
+        --body="${body}" \
+        --local --source="${GH_SOURCE_BRANCH}" \
+        --allow-mods --confirm
+}
+
+# $1: path of the file containing the token
+get_user_from_token() {
+    curl --silent -H "Authorization: token $(cat "$1")" "https://api.github.com/user" | grep -Po '"login": "\K.*?(?=")'
+}
+
+# $1: the program to check
+function check_program {
+    if hash "$1" 2>/dev/null; then
+        type -P "$1" >&/dev/null
+    else
+        echo "> aborting because $1 is required..." >&2
+       return 1
+    fi
+}
+
+# Meant to be run in the https://github.com/falcosecurity/test-infra repository.
+# $1: path of the file containing the token
+main() {
+    # Checks
+    check_program "gpg"
+    check_program "git"
+    check_program "curl"
+    check_program "pr-creator"
+    check_program "bumper"
+
+    # Settings
+    ensure_git_config "${BOT_NAME}" "${BOT_MAIL}"
+    ensure_gpg_key "${BOT_GPG_KEY_PATH}" "${BOT_GPG_PUBLIC_KEY}"
+
+    bump_syscalls
+    
+    # Create PR (in case there are changes)
+    create_pr "$1"
+}
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <path to github token>" >&2
+    exit 1
+fi
+
+main "$@"

--- a/images/update-syscalls/entrypoint.sh
+++ b/images/update-syscalls/entrypoint.sh
@@ -32,7 +32,7 @@ export GIT_AUTHOR_NAME=${BOT_NAME}
 export GIT_AUTHOR_EMAIL=${BOT_MAIL}
 
 bump_syscalls() {
-    bumper --repo-root ${pwd} --overwrite
+    syscalls-bumper --repo-root ${pwd} --overwrite
     return $?
 }
 
@@ -119,7 +119,7 @@ main() {
     check_program "git"
     check_program "curl"
     check_program "pr-creator"
-    check_program "bumper"
+    check_program "syscalls-bumper"
 
     # Settings
     ensure_git_config "${BOT_NAME}" "${BOT_MAIL}"


### PR DESCRIPTION
It will update the supported syscalls by falcosecurity/libs to latest available in the linux kernel, as generic events.

For now it uses `fededp/syscalls-bumper`, but the repo is in the process of being donated to falcosecurity: https://github.com/falcosecurity/evolution/issues/209
I will update the PR accordingly as soon as it is donated.
/hold
