### PR TITLE
set default driver for the website to the lastest release

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "nuxt.isNuxtApp": false
+}

--- a/images/update-drivers-website/index.html
+++ b/images/update-drivers-website/index.html
@@ -44,7 +44,7 @@
         var url = new URL(window.location);
         var lib = url.searchParams.get('lib');
         if (lib == null) {
-            lib = "3.0.0+driver";
+            lib = "3.0.1+driver";
             url.searchParams.set('lib', lib);
         };
         var target = url.searchParams.get('target')


### PR DESCRIPTION
Signed-off-by: Thomas Labarussias <issif+github@gadz.org>

This PR just updates the drivers website [https://download.falco.org/driver/site/index.html](https://download.falco.org/driver/site/index.html) to show the latest version of libs as default