### PR TITLE
fix: support plugin names containing dashes

### DIFF
--- a/config/jobs/build-plugins/build-plugins.yaml
+++ b/config/jobs/build-plugins/build-plugins.yaml
@@ -76,7 +76,7 @@ postsubmits:
       skip_report: false
       agent: kubernetes
       branches:
-        - ^[a-z]+[a-z0-9_]*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$
+        - ^[a-z]+[a-z0-9_\-]*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$
       spec:
         serviceAccountName: build-plugins
         containers:
@@ -98,7 +98,7 @@ postsubmits:
       skip_report: false
       agent: kubernetes
       branches:
-        - ^[a-z]+[a-z0-9_]*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$
+        - ^[a-z]+[a-z0-9_\-]*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$
       spec:
         serviceAccountName: build-plugins
         containers:

--- a/images/build-plugins/build-and-publish.sh
+++ b/images/build-plugins/build-and-publish.sh
@@ -16,12 +16,16 @@ PUBLISH_S3="${PUBLISH_S3:=false}"
 PUBLISH_TAG="${PUBLISH_TAG:=dev}"
 
 # see: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-VERSION_RGX="^[a-z]+[a-z0-9_]*-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?$"
+# note: we have a capturing group for the plugin name prefix, so that we can use
+# it to specify the right make release target
+VERSION_RGX="^([a-z]+[a-z0-9_\-]*)-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?$"
 
 if [[ $PULL_BASE_REF =~ $VERSION_RGX ]];
 then
     # Build only tagged package
-    make release/$(echo $PULL_BASE_REF | cut -f1 -d'-')
+    # note: BASH_REMATCH[1] points to the first capturing group of the matching
+    # regex, which is the plugin name
+    make release/${BASH_REMATCH[1]}
 
     # Publish artifacts in "stable" dir
     PUBLISH_TAG="stable"


### PR DESCRIPTION
For example, this prevents the new `k8saudit-eks` plugin from being released as table