### PR TITLE
new(driverkit): validate only presubmit build drivers jobs

### DIFF
--- a/config/jobs/build-drivers/build-drivers.local
+++ b/config/jobs/build-drivers/build-drivers.local
@@ -14,6 +14,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: localhost:5000/build-drivers
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-drivers.local
+++ b/config/jobs/build-drivers/build-drivers.local
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-drivers-amazonlinux-presubmit
+  - name: validate-drivers-amazonlinux-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -20,7 +20,7 @@ presubmits:
         imagePullPolicy: Always
         securityContext:
           privileged: true
-  - name: build-drivers-amazonlinux2-presubmit
+  - name: validate-drivers-amazonlinux2-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-amazonlinux.yaml
+++ b/config/jobs/build-drivers/build-new-amazonlinux.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-amazonlinux-presubmit
+  - name: validate-new-drivers-amazonlinux-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -28,7 +28,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-amazonlinux2-presubmit
+  - name: validate-new-drivers-amazonlinux2-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-amazonlinux.yaml
+++ b/config/jobs/build-drivers/build-new-amazonlinux.yaml
@@ -16,6 +16,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -42,6 +44,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-centos.yaml
+++ b/config/jobs/build-drivers/build-new-centos.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -44,6 +46,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -71,6 +75,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -98,6 +104,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-centos.yaml
+++ b/config/jobs/build-drivers/build-new-centos.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-centos-2-presubmit
+  - name: validate-new-drivers-centos-2-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -29,7 +29,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-centos-3-presubmit
+  - name: validate-new-drivers-centos-3-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -58,7 +58,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-centos-4-presubmit
+  - name: validate-new-drivers-centos-4-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -87,7 +87,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-centos-5-presubmit
+  - name: validate-new-drivers-centos-5-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-debian.yaml
+++ b/config/jobs/build-drivers/build-new-debian.yaml
@@ -16,6 +16,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-debian.yaml
+++ b/config/jobs/build-drivers/build-new-debian.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-debian-presubmit
+  - name: validiate-new-drivers-debian-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-minikube.yaml
+++ b/config/jobs/build-drivers/build-new-minikube.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-minikube-presubmit
+  - name: validate-new-drivers-minikube-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-minikube.yaml
+++ b/config/jobs/build-drivers/build-new-minikube.yaml
@@ -16,6 +16,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -44,6 +46,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -71,6 +75,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-ubuntu-aws-3-presubmit
+  - name: validate-new-drivers-ubuntu-aws-3-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -29,7 +29,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-aws-4-presubmit
+  - name: validate-new-drivers-ubuntu-aws-4-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -58,7 +58,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-aws-5-presubmit
+  - name: validate-new-drivers-ubuntu-aws-5-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -44,6 +46,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -71,6 +75,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-ubuntu-azure-3-presubmit
+  - name: validate-new-drivers-ubuntu-azure-3-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -29,7 +29,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-azure-4-presubmit
+  - name: validate-new-drivers-ubuntu-azure-4-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -58,7 +58,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-azure-5-presubmit
+  - name: validate-new-drivers-ubuntu-azure-5-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -44,6 +46,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -71,6 +75,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-ubuntu-gcp-3-presubmit
+  - name: validate-new-drivers-ubuntu-gcp-3-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -29,7 +29,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-gcp-4-presubmit
+  - name: validate-new-drivers-ubuntu-gcp-4-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -58,7 +58,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-gcp-5-presubmit
+  - name: validate-new-drivers-ubuntu-gcp-5-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -44,6 +46,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -71,6 +75,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-ubuntu-generic-3-presubmit
+  - name: validate-new-drivers-ubuntu-generic-3-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -29,7 +29,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-generic-4-presubmit
+  - name: validate-new-drivers-ubuntu-generic-4-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -58,7 +58,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-generic-5-presubmit
+  - name: valdiate-new-drivers-ubuntu-generic-5-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
@@ -17,6 +17,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -44,6 +46,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:
@@ -71,6 +75,8 @@ presubmits:
         env:
         - name: AWS_REGION
           value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
         image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
         imagePullPolicy: Always
         securityContext:

--- a/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
@@ -1,6 +1,6 @@
 presubmits:
   falcosecurity/test-infra:
-  - name: build-new-drivers-ubuntu-gke-3-presubmit
+  - name: validate-new-drivers-ubuntu-gke-3-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -29,7 +29,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-gke-4-presubmit
+  - name: validate-new-drivers-ubuntu-gke-4-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes
@@ -58,7 +58,7 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
-  - name: build-new-drivers-ubuntu-gke-5-presubmit
+  - name: validate-new-drivers-ubuntu-gke-5-presubmit
     decorate: true
     skip_report: false
     agent: kubernetes

--- a/images/build-drivers/build-drivers.sh
+++ b/images/build-drivers/build-drivers.sh
@@ -19,7 +19,7 @@ DBG_FILTERS['TARGET_KERNEL']="${2}"
 DBG_FILTERS['TARGET_VERSION']="${3}"
 DBG_FILTERS['TARGET_ARCH']="${4}"
 DBG_MAKE_BUILD_OPTIONS=""
-DBG_MAKE_BUILD_TARGET="specific_target"
+DBG_MAKE_BUILD_TARGET="${DBG_MAKE_BUILD_TARGET:-"specific_target"}"
 DBG_MAKE_PUBLISH_TARGET="publish_s3"
 DBG_WORKDIR="${DBG_WORKDIR:-/home/prow/go/src/github.com/falcosecurity/test-infra/driverkit}"
 
@@ -73,7 +73,6 @@ function build() {
 	DBG_COMMIT=$(git log -1 --format=format:%H --full-diff -- ./)
 
 	pretty_echo "Found current driverkit version DBG_COMMIT $DBG_COMMIT. Running DBG build..."
-	
 	$make $DBG_MAKE_BUILD_OPTIONS $DBG_MAKE_BUILD_TARGET
 	
 	pretty_echo "DBG build complete"

--- a/images/build-drivers/build-drivers.sh
+++ b/images/build-drivers/build-drivers.sh
@@ -11,6 +11,7 @@ set -o errexit
 # PUBLISH_S3: whether to publish built drivers to S3
 # DBG_WORKDIR: the absolute path from where to run DBG
 # ENSURE_DOCKER: whether to ensure Docker daemon running
+# DBG_MAKE_BUILD_TARGET: specify the makefile target
 
 # Needed Bash >= 4.0
 declare -A DBG_FILTERS


### PR DESCRIPTION
Since our dbg is best-effort, there is no need to spend time in building drivers in presubmit jobs since they won't be uploaded anywhere.
Just validate them.