### PR TITLE
new(driverkit): configs regenerated after each dbg update

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -64,7 +64,9 @@ generate:
 		)\
 	)
 
+# clean old configurations before generating the new ones
 generate/auto:
+	rm -rf config/*
 	$(foreach ARCH,$(TARGET_ARCHS),\
 		utils/scrape_and_generate $(ARCH); \
 	)

--- a/driverkit/README.md
+++ b/driverkit/README.md
@@ -131,6 +131,8 @@ You can also validate the configurations you generate with `make validate`, and 
 
 You can find more info about the Driverkit Build Grid [here](#driverkit-build-grid).
 
+It should be noted that the Driverkit Build Grid configurations are kept only for the last kernel-crawler's result, as the crawler represents the uniqe source of truth. Therefore, added configurations will be dropped on Driverkit Build Grid updates but published artifacts will not be cleaned up and will still remain available.
+
 ### Q: How do you publish new drivers?
 
 A: If you have proper S3 permissions from Terraform or Prow, run


### PR DESCRIPTION
Every time the dbg gets updated, config files are deleted and generated again in order to always get fresh configurations. In this way there will not be attempts to build old (unbuildable) versions.
Old and already builded drivers will still remain in the bucket.
An alternative would be to delete only configurations older than six months (as in #917 ).