### PR TITLE
vote: propose fededp as a test-infra maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@ approvers:
   - jonahjon
   - leogr
   - zuc
+  - fededp
 emeritus_approvers:
   - leodido
   - fntlnz


### PR DESCRIPTION
I would like to propose myself as a test-infra maintainer.
I was highly involved in multiple stuff, like: arm64 Falco support, dbg fixes and improvements, like the kernel-crawler automation pipeline, and i helped as much as i could with fixing issues here and there.

According to our [governance](https://github.com/falcosecurity/evolution/blob/main/GOVERNANCE.md#maintainership), we need a majority vote to take a decision.
Here you can find the rules for the majority vote: point_down
https://github.com/falcosecurity/evolution/blob/main/GOVERNANCE.md#majority-vote


EDIT:
* Vote starts today, 6th of december, 2022
* Vote ends 13th of december, 2022