### PR TITLE
new(config): add falcosecurity/rules repository config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -272,6 +272,10 @@ branch-protection:
           branches:
             master:
               protect: true
+        rules:
+          branches:
+            main:
+              protect: true
         syscalls-bumper:
           required_status_checks:
             contexts:
@@ -326,6 +330,7 @@ tide:
     falcosecurity/plugins: rebase
     falcosecurity/plugin-sdk-go: rebase
     falcosecurity/plugin-sdk-cpp: rebase
+    falcosecurity/rules: rebase
     falcosecurity/syscalls-bumper: rebase
     falcosecurity/template-repository: rebase
     falcosecurity/test-infra: rebase
@@ -720,6 +725,18 @@ tide:
         - do-not-merge/work-in-progress
         - needs-rebase
       reviewApprovedRequired: true
+    - repos:
+      - falcosecurity/rules
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
     - repos:
         - falcosecurity/syscalls-bumper
       labels:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -271,6 +271,13 @@ orgs:
         allow_squash_merge: false
         description: Falco plugins registry
         has_projects: true
+      rules:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        description: Falco rule repository
+        has_projects: false
+        has_wiki: false
       syscalls-bumper:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -628,6 +635,14 @@ orgs:
         privacy: closed
         repos:
           plugins: maintain
+      rules-maintainers:
+        description: maintainers of falcosecurity/rules
+        maintainers:
+          - leogr
+          - LucaGuerra
+        privacy: closed
+        repos:
+          rules: maintain
       syscalls-bumper-maintainers:
         description: maintainers of falcosecurity/syscalls-bumper
         maintainers:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -31,6 +31,7 @@ approve:
       - falcosecurity/plugin-sdk-cpp
       - falcosecurity/plugin-sdk-go
       - falcosecurity/plugins
+      - falcosecurity/rules
       - falcosecurity/syscalls-bumper
       - falcosecurity/template-repository
       - falcosecurity/test-infra
@@ -103,6 +104,7 @@ lgtm:
       - falcosecurity/plugins
       - falcosecurity/plugin-sdk-go
       - falcosecurity/plugin-sdk-cpp
+      - falcosecurity/rules
       - falcosecurity/syscalls-bumper
       - falcosecurity/template-repository
       - falcosecurity/test-infra
@@ -942,6 +944,28 @@ plugins:
       - verify-owners
       - welcome
       - wip
+  falcosecurity/rules:
+    plugins:
+      - approve
+      - assign
+      - blunderbuss
+      - branchcleaner
+      - cat
+      - dco
+      - dog
+      - goose
+      - help
+      - hold
+      - label
+      - lifecycle
+      - lgtm
+      - mergecommitblocker
+      - retitle
+      - size
+      - trigger
+      - verify-owners
+      - welcome
+      - wip
   falcosecurity/syscalls-bumper:
     plugins:
       - approve
@@ -1114,6 +1138,10 @@ external_plugins:
       events:
         - pull_request
   falcosecurity/plugin-sdk-cpp:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/rules:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

A new repo was born today! https://github.com/falcosecurity/rules becomes a new home for the Falco rules, with big plans for proper versioning, CI/CD and more!