### PR TITLE
new(org): add LucaGuerra as admin

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -16,6 +16,7 @@ orgs:
       - poiana
       - thelinuxfoundation
       - jasondellaluce
+      - LucaGuerra
 
     members:
       - admiral0
@@ -37,7 +38,6 @@ orgs:
       - krisnova
       - leodido
       - loresuso
-      - LucaGuerra
       - markyjackson-taulia
       - maxgio92
       - mfdii


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

As a Falco core maintainer, I would like to volunteer as an admin to help other maintainers manage the GitHub organization. In addition, there are several things I'm working on or will be working on in the near future where I would like to help with GH administration tasks:
* Assisting in the development of OCI artifact repositories that we're introducing for rules and plugins. Admin permissions are helpful to troubleshoot and clean up such repositories;
* CI secret configuration and permission setup, e.g. related to the new rules and plugin repos;
* I have proposed a new WG for improving the Falco Software Supply Chain Security, starting this month. That work will require secret updates to enable additional signing and related configuration. I believe it would be helpful for a member of the WG to be able to perform these operations;
* I would also like to volunteer in helping make the org more secure by reviewing security data and configurations and assisting in case of potential security incidents.