### PR TITLE
new(build): add job to update the main artifact index with rules from the rules repo

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -74,3 +74,10 @@ resource "aws_ecr_repository" "update_drivers_website" {
     encryption_type = "KMS"
   }
 }
+
+resource "aws_ecr_repository" "update_rules_index" {
+  name = "test-infra/update-rules-index"
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}

--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -168,6 +168,34 @@ presubmits:
           privileged: true
       nodeSelector:
         Archtype: "x86"
+  - name: build-images-update-rules-index
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-rules-index/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/build.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-rules-index"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+      nodeSelector:
+        Archtype: "x86"
   - name: build-images-update-falco-k8s-manifests
     decorate: true
     path_alias: github.com/falcosecurity/test-infra

--- a/config/jobs/build-prow-images/publish-images.yaml
+++ b/config/jobs/build-prow-images/publish-images.yaml
@@ -85,6 +85,34 @@ postsubmits:
           privileged: true
       nodeSelector:
         Archtype: "x86"
+  - name: publish-images-update-rules-index
+    decorate: true
+    path_alias: github.com/falcosecurity/test-infra
+    skip_report: false
+    agent: kubernetes
+    run_if_changed: '^images/update-rules-index/'
+    branches:
+      - ^master$
+    spec:
+      containers:
+      - command:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
+        args:
+          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-rules-index"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 3Gi
+            cpu: 1.5
+            ephemeral-storage: "2Gi"
+        securityContext:
+          privileged: true
+      nodeSelector:
+        Archtype: "x86"
   - name: publish-images-golang
     decorate: true
     path_alias: github.com/falcosecurity/test-infra

--- a/config/jobs/update-rules-index/update-rules-index.yaml
+++ b/config/jobs/update-rules-index/update-rules-index.yaml
@@ -1,0 +1,39 @@
+postsubmits:
+  falcosecurity/rules:
+    - name: update-rules-index-on-registry-changed-postsubmit
+      decorate: true
+      skip_report: false
+      agent: kubernetes
+      branches:
+        - ^main$
+      run_if_changed: "^registry.yaml"
+      spec:
+        containers:
+          # See images/update-rules-index
+          - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-rules-index:latest
+            imagePullPolicy: Always
+            command:
+              - /on-registry-changed.sh
+            args:
+              - /etc/github-token/oauth
+            env:
+              - name: GH_PROXY
+                value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+            volumeMounts:
+              - name: github
+                mountPath: /etc/github-token
+                readOnly: true
+              - name: gpg-signing-key
+                mountPath: /root/gpg-signing-key/
+                readOnly: true
+        volumes:
+          - name: github
+            secret:
+              # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+              secretName: oauth-token
+          - name: gpg-signing-key
+            secret:
+              secretName: poiana-gpg-signing-key
+              defaultMode: 0400
+        nodeSelector:
+          Archtype: "x86"

--- a/images/update-rules-index/Dockerfile
+++ b/images/update-rules-index/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.18 AS pullrequestcreator
+
+RUN git clone https://github.com/kubernetes/test-infra
+RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
+
+FROM golang:1.18
+
+LABEL usage="docker run -i -t -v /path/to/source:/workspace test-infra/update-rules-index"
+
+COPY --from=pullrequestcreator /go/test-infra/robots/pr-creator/pr-creator /bin
+
+COPY on-registry-changed.sh /
+RUN chmod +x /on-registry-changed.sh
+
+WORKDIR /workspace
+

--- a/images/update-rules-index/Makefile
+++ b/images/update-rules-index/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+IMG_SLUG := test-infra
+IMG_NAME := update-rules-index
+IMG_TAG ?= latest
+
+ACCOUNT := 292999226676
+DOCKER_PUSH_REPOSITORY = dkr.ecr.eu-west-1.amazonaws.com
+
+IMAGE := "$(ACCOUNT).$(DOCKER_PUSH_REPOSITORY)/$(IMG_SLUG)/$(IMG_NAME):$(IMG_TAG)"
+
+build-push: build-image push-image
+
+build-image:
+	docker build --no-cache -t "$(IMG_SLUG)/$(IMG_NAME)" .
+
+push-image:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" $(IMAGE)
+	docker push $(IMAGE)
+
+local-registry:
+	docker tag "$(IMG_SLUG)/$(IMG_NAME)" localhost:5000/$(IMG_NAME)
+	docker push localhost:5000/$(IMG_NAME)

--- a/images/update-rules-index/on-registry-changed.sh
+++ b/images/update-rules-index/on-registry-changed.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 The Falco Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GH_PROXY="${GH_PROXY:-"http://ghproxy"}"
+GH_ORG="${GH_ORG:-"falcosecurity"}"
+GH_REPO="${GH_REPO:-"rules"}"
+GH_INDEX_REPO="${GH_INDEX_REPO:-"falcoctl"}"
+GH_INDEX_REPO_BRANCH="${GH_INDEX_REPO_BRANCH:-"gh-pages"}"
+BOT_NAME="${BOT_NAME:-"poiana"}"
+BOT_MAIL="${BOT_MAIL:-"51138685+poiana@users.noreply.github.com"}"
+BOT_GPG_KEY_PATH="${BOT_GPG_KEY_PATH:-"/root/gpg-signing-key/poiana.asc"}"
+BOT_GPG_PUBLIC_KEY="${BOT_GPG_PUBLIC_KEY:-"EC9875C7B990D55F3B44D6E45F284448FF941C8F"}"
+
+export GIT_COMMITTER_NAME=${BOT_NAME}
+export GIT_COMMITTER_EMAIL=${BOT_MAIL}
+export GIT_AUTHOR_NAME=${BOT_NAME}
+export GIT_AUTHOR_EMAIL=${BOT_MAIL}
+
+# env variables needed to update index.
+export REGISTRY_USER=$GH_ORG
+export REGISTRY="ghcr.io"
+
+# Sets git user configs, otherwise errors out.
+# $1: git user name
+# $2: git user email
+ensure_git_config() {
+    echo "> configuring git user (name=$1, email=$2)..." >&2
+    git config --global user.name "$1"
+    git config --global user.email "$2"
+
+    git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    return 1
+}
+
+# Configures GPG key, otherwise errors out.
+# $1: GPG key location
+# $2: GPG ASCII armored public key
+ensure_gpg_key() {
+    echo "> configuring git with gpg key=$1..." >&2
+    gpg --import "$1"
+    git config --global commit.gpgsign true
+    git config --global user.signingkey "$2"
+
+    git config --global commit.gpgsign &>/dev/null && git config --global user.signingkey &>/dev/null && return 0
+    echo "ERROR: git gpg key location, public key ID unset. No defaults provided" >&2
+    return 1
+}
+
+# $1: path of the file containing the token
+get_user_from_token() {
+    curl --silent -H "Authorization: token $(cat "$1")" "https://api.github.com/user" | grep -Po '"login": "\K.*?(?=")'
+}
+
+# $1: temporary path to clone the repo
+clone_index_repo() {
+    echo "> cloning distribution index repository (https://github.com/${GH_ORG}/${GH_INDEX_REPO}.git)..." >&2
+    mkdir -p "$1"
+    pushd "$1"
+    git clone "https://github.com/${GH_ORG}/${GH_INDEX_REPO}.git"
+    pushd "${GH_INDEX_REPO}"
+    echo "> checkout ${GH_INDEX_REPO_BRANCH} branch..." >&2
+    git checkout ${GH_INDEX_REPO_BRANCH}
+    popd
+    popd
+}
+
+# $1: path of the file containing the token
+# $2: path to the local working copy of the index repo
+push_index() {
+    echo "> pushing distribution index..." >&2
+    pushd "$2"
+
+    git add index.yaml
+    git commit --message="update(index.yaml): new rules registry data" --signoff
+
+    # N.B., no force push here. 
+    # If other jobs modify the index and a git conflict occurs, 
+    # better to fail instead of overwriting their changes.
+    user=$(get_user_from_token "$1")
+    git push \
+        "https://${user}:$(cat "$1")@github.com/${GH_ORG}/${GH_INDEX_REPO}" \
+        "HEAD:${GH_INDEX_REPO_BRANCH}"
+
+    popd
+}
+
+# $1: the program to check
+function check_program {
+    if hash "$1" 2>/dev/null; then
+        type -P "$1" >&/dev/null
+    else
+        echo "> aborting because $1 is required..." >&2
+       return 1
+    fi
+}
+
+# Meant to be run in the https://github.com/falcosecurity/rules repository.
+# $1: path of the file containing the token
+main() {
+    # Checks
+    check_program "gpg"
+    check_program "git"
+    check_program "curl"
+    check_program "pr-creator"
+    check_program "awk"
+
+    # Settings
+    ensure_git_config "${BOT_NAME}" "${BOT_MAIL}"
+    ensure_gpg_key "${BOT_GPG_KEY_PATH}" "${BOT_GPG_PUBLIC_KEY}"
+    
+    # Clone the index repo and checkout to the correct branch
+    clone_index_repo "/tmp"
+
+    pushd build/registry
+
+    go build -o rules-registry ./...
+
+    popd
+
+    build/registry/rules-registry update-index registry.yaml /tmp/${GH_INDEX_REPO}/index.yaml
+
+    # Finally, commit and push the index
+    push_index "$1" "/tmp/${GH_INDEX_REPO}"
+
+}
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <path to github token>" >&2
+    exit 1
+fi
+
+main "$@"


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

I wish to replicate the same process that we have to update the index file with plugin registry data. Therefore, this PR introduces a new job with a new image that should react to the any registry file change in the rules repo and call the index update program. The program exists in the rules repo and can work on the same falcosecurity index file that we use for plugins, plus the rules registry.