### PR TITLE
fix(config/jobs/build-drivers): corrected nodeSelector position

### DIFF
--- a/config/jobs/build-drivers/build-new-amazonlinux.yaml
+++ b/config/jobs/build-drivers/build-new-amazonlinux.yaml
@@ -112,13 +112,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-amazonlinux2-postsubmit
     decorate: true
     skip_report: false
@@ -173,10 +168,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-bottlerocket.yaml
+++ b/config/jobs/build-drivers/build-new-bottlerocket.yaml
@@ -116,13 +116,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-bottlerocket-5-postsubmit
     decorate: true
     skip_report: false
@@ -179,10 +174,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-centos.yaml
+++ b/config/jobs/build-drivers/build-new-centos.yaml
@@ -174,13 +174,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-centos-3-postsubmit
     decorate: true
     skip_report: false
@@ -237,13 +232,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-centos-4-postsubmit
     decorate: true
     skip_report: false
@@ -300,13 +290,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-centos-5-postsubmit
     decorate: true
     skip_report: false
@@ -363,10 +348,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-debian.yaml
+++ b/config/jobs/build-drivers/build-new-debian.yaml
@@ -84,10 +84,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-minikube.yaml
+++ b/config/jobs/build-drivers/build-new-minikube.yaml
@@ -84,10 +84,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
@@ -145,13 +145,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-aws-4-postsubmit
     decorate: true
     skip_report: false
@@ -208,13 +203,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-aws-5-postsubmit
     decorate: true
     skip_report: false
@@ -271,10 +261,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
@@ -145,13 +145,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-azure-4-postsubmit
     decorate: true
     skip_report: false
@@ -208,13 +203,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-azure-5-postsubmit
     decorate: true
     skip_report: false
@@ -271,10 +261,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
@@ -145,13 +145,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-gcp-4-postsubmit
     decorate: true
     skip_report: false
@@ -208,13 +203,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-gcp-5-postsubmit
     decorate: true
     skip_report: false
@@ -271,10 +261,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
@@ -145,13 +145,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-generic-4-postsubmit
     decorate: true
     skip_report: false
@@ -208,13 +203,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-generic-5-postsubmit
     decorate: true
     skip_report: false
@@ -271,11 +261,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
-
+      nodeSelector:
+        Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
@@ -145,13 +145,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-gke-4-postsubmit
     decorate: true
     skip_report: false
@@ -208,13 +203,8 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
   - name: build-new-drivers-ubuntu-gke-5-postsubmit
     decorate: true
     skip_report: false
@@ -271,11 +261,5 @@ postsubmits:
           requests:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
-        nodeSelector:
-              Archtype: "arm"
-        tolerations:
-            - key: "Archtype"
-              operator: "Equal"
-              value: "arm"
-              effect: "NoSchedule"
-
+      nodeSelector:
+        Archtype: "arm"


### PR DESCRIPTION
Since `nodeSelector` directives have been placed under the wrong section of jobs configuration files, they are moved out from `- command` directives in order to be correctly recognized.