### PR TITLE
update(config): change a required libs job

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -240,7 +240,7 @@ branch-protection:
               - "build-libs-linux-amd64 😁 (system_deps_minimal)"
               - "build-libs-linux-amd64-asan 🧐"
               - "build-libs-arm64 🥶 (system_deps)"
-              - "build-and-test-modern-bpf-x86 😇 (bundled_deps)"
+              - "test-drivers-x86 😇 (bundled_deps)"
               - "build-modern-bpf-arm64 🙃 (system_deps)"
               - "build-modern-bpf-s390x 😁 (system_deps)"
           branches:


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

This PR removes the required job "build-and-test-modern-bpf-x86 😇 (bundled_deps)", and adds a new required job "test-drivers-x86 😇 (bundled_deps)".

/hold until we have 2 approves on https://github.com/falcosecurity/libs/pull/832