### PR TITLE
cleanup(prow): removed build/publish update-syscalls jobs

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -54,13 +54,6 @@ resource "aws_ecr_repository" "update_kernels" {
   }
 }
 
-resource "aws_ecr_repository" "update_syscalls" {
-  name = "test-infra/update-syscalls"
-  encryption_configuration {
-    encryption_type = "KMS"
-  }
-}
-
 resource "aws_ecr_repository" "update_dbg" {
   name = "test-infra/update-dbg"
   encryption_configuration {

--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -336,31 +336,3 @@ presubmits:
           privileged: true
       nodeSelector:
         Archtype: "x86"
-  - name: build-images-update-syscalls
-    decorate: true
-    path_alias: github.com/falcosecurity/test-infra
-    skip_report: false
-    agent: kubernetes
-    run_if_changed: '^images/update-syscalls/'
-    branches:
-      - ^master$
-    spec:
-      containers:
-      - command:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/build.sh"
-        args:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-syscalls"
-        env:
-        - name: AWS_REGION
-          value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
-        imagePullPolicy: Always
-        resources:
-          requests:
-            memory: 3Gi
-            cpu: 1.5
-            ephemeral-storage: "2Gi"
-        securityContext:
-          privileged: true
-      nodeSelector:
-        Archtype: "x86"      

--- a/config/jobs/build-prow-images/publish-images.yaml
+++ b/config/jobs/build-prow-images/publish-images.yaml
@@ -337,32 +337,3 @@ postsubmits:
           privileged: true
       nodeSelector:
         Archtype: "x86"
-  - name: publish-images-update-syscalls
-    decorate: true
-    path_alias: github.com/falcosecurity/test-infra
-    skip_report: false
-    agent: kubernetes
-    run_if_changed: '^images/update-syscalls/'
-    branches:
-      - ^master$
-    spec:
-      containers:
-      - command:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
-        args:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-syscalls"
-        env:
-        - name: AWS_REGION
-          value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
-        imagePullPolicy: Always
-        resources:
-          requests:
-            memory: 3Gi
-            cpu: 1.5
-            ephemeral-storage: "2Gi"
-        securityContext:
-          privileged: true
-      nodeSelector:
-        Archtype: "x86"      
-         


### PR DESCRIPTION
This PR removes update-syscalls build/publish jobs from prow configuration files (see [https://github.com/falcosecurity/test-infra/pull/976](https://github.com/falcosecurity/test-infra/pull/976)).