### PR TITLE
chore(config/clusters/ecr): allow force delete on update-syscalls repo

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -54,6 +54,16 @@ resource "aws_ecr_repository" "update_kernels" {
   }
 }
 
+resource "aws_ecr_repository" "update_syscalls" {
+  name = "test-infra/update-syscalls"
+
+  force_delete = true
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}
+
 resource "aws_ecr_repository" "update_dbg" {
   name = "test-infra/update-dbg"
   encryption_configuration {


### PR DESCRIPTION
This PR allows force delete of the `update-syscalls` ECR repository, before deleting it (next PR).

Signed-off-by: Massimiliano Giovagnoli <me@maxgio.it>