### PR TITLE
cleanup(prow): removed build/publish update-kernels job

### DIFF
--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -279,35 +279,7 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        Archtype: "x86"
-  - name: build-images-update-kernels
-    decorate: true
-    path_alias: github.com/falcosecurity/test-infra
-    skip_report: false
-    agent: kubernetes
-    run_if_changed: '^images/update-kernels/'
-    branches:
-      - ^master$
-    spec:
-      containers:
-      - command:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/build.sh"
-        args:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-kernels"
-        env:
-        - name: AWS_REGION
-          value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
-        imagePullPolicy: Always
-        resources:
-          requests:
-            memory: 3Gi
-            cpu: 1.5
-            ephemeral-storage: "2Gi"
-        securityContext:
-          privileged: true
-      nodeSelector:
-        Archtype: "x86"      
+        Archtype: "x86"     
   - name: build-images-update-drivers-website
     decorate: true
     path_alias: github.com/falcosecurity/test-infra

--- a/config/jobs/build-prow-images/publish-images.yaml
+++ b/config/jobs/build-prow-images/publish-images.yaml
@@ -280,35 +280,7 @@ postsubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        Archtype: "x86"
-  - name: publish-images-update-kernels
-    decorate: true
-    path_alias: github.com/falcosecurity/test-infra
-    skip_report: false
-    agent: kubernetes
-    run_if_changed: '^images/update-kernels/'
-    branches:
-      - ^master$
-    spec:
-      containers:
-      - command:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
-        args:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-kernels"
-        env:
-        - name: AWS_REGION
-          value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
-        imagePullPolicy: Always
-        resources:
-          requests:
-            memory: 3Gi
-            cpu: 1.5
-            ephemeral-storage: "2Gi"
-        securityContext:
-          privileged: true
-      nodeSelector:
-        Archtype: "x86"           
+        Archtype: "x86"        
   - name: publish-images-update-drivers-website
     decorate: true
     path_alias: github.com/falcosecurity/test-infra


### PR DESCRIPTION
This PR removes update-kernels build and publish jobs from prow configuration files.
Job ported to GHA (see [here](https://github.com/falcosecurity/kernel-crawler/actions/workflows/update-kernels.yml)).