### PR TITLE
cleanup(config/clusters/ecr): force delete on update-kernels repo

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -49,6 +49,9 @@ resource "aws_ecr_repository" "update_deployment_files" {
 
 resource "aws_ecr_repository" "update_kernels" {
   name = "test-infra/update-kernels"
+
+  force_delete = true
+
   encryption_configuration {
     encryption_type = "KMS"
   }


### PR DESCRIPTION
This PR allows force delete of the `update-kernels` ECR repository, before deleting it (see #988).