### PR TITLE
chore(config/clusters/ecr-iam): removed update-kernels resource.

### DIFF
--- a/config/clusters/ecr-iam.tf
+++ b/config/clusters/ecr-iam.tf
@@ -56,11 +56,6 @@ resource "aws_ecr_repository_policy" "update_deployment_files" {
   policy     = data.aws_iam_policy_document.ecr_standard.json
 }
 
-resource "aws_ecr_repository_policy" "update_kernels" {
-  repository = aws_ecr_repository.update_kernels.name
-  policy     = data.aws_iam_policy_document.ecr_standard.json
-}
-
 resource "aws_ecr_repository_policy" "update_dbg" {
   repository = aws_ecr_repository.update_dbg.name
   policy     = data.aws_iam_policy_document.ecr_standard.json


### PR DESCRIPTION
This PR carries a little fix on `update-kernels` job removal form ecr config.