### PR TITLE
update(config): remove required arm64 jobs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -248,9 +248,7 @@ branch-protection:
               - "build-libs-linux-amd64 😁 (system_deps_w_chisels)"
               - "build-libs-linux-amd64 😁 (system_deps_minimal)"
               - "build-libs-linux-amd64-asan 🧐"
-              - "build-libs-arm64 🥶 (system_deps)"
               - "test-drivers-x86 😇 (bundled_deps)"
-              - "build-modern-bpf-arm64 🙃 (system_deps)"
               - "build-modern-bpf-s390x 😁 (system_deps)"
           branches:
             master:


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

According to this change in libs https://github.com/falcosecurity/libs/pull/864 we can remove the required GHA jobs for arm64