### PR TITLE
Add flycheck-falco-rules to test-infra

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -227,6 +227,10 @@ branch-protection:
           required_status_checks:
             contexts:
               - "netlify/falcosecurity/deploy-preview"
+        flycheck-falco-rules:
+          branches:
+            main:
+              protect: true
         kernel-crawler:
           required_status_checks:
             contexts:
@@ -333,6 +337,7 @@ tide:
     falcosecurity/falco-exporter: rebase
     falcosecurity/falcoctl: rebase
     falcosecurity/falco-website: rebase
+    falcosecurity/flycheck-falco-rules: rebase
     falcosecurity/kernel-crawler: rebase
     falcosecurity/kilt: rebase
     falcosecurity/libs: rebase
@@ -626,6 +631,20 @@ tide:
         - do-not-merge/hold
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
+        - needs-rebase
+      reviewApprovedRequired: true
+    - repos:
+        - falcosecurity/flycheck-falco-rules
+      labels:
+        - approved
+        - lgtm
+        - "dco-signoff: yes"
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - do-not-merge/release-note-label-needed
         - needs-rebase
       reviewApprovedRequired: true
     - repos:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -27,6 +27,7 @@ orgs:
       - cpanato
       - darryk10
       - dwindsor
+      - ewilderj
       - EXONER4TED
       - FedeDP
       - fjogeleit
@@ -173,6 +174,13 @@ orgs:
         description: Source code of the official Falco website
         has_projects: true
         homepage: https://falco.org
+      flycheck-falco-rules:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        description: Falco Rules Syntax Checker for Emacs, Using Flycheck
+        default_branch: main
+        has_projects: true
       falcoctl:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -286,7 +294,7 @@ orgs:
         default_branch: main
         description: A tool to automatically update supported syscalls in libs
         has_projects: false
-        has_wiki: false  
+        has_wiki: false
       template-repository:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -473,6 +481,15 @@ orgs:
         privacy: closed
         repos:
           falco-website: maintain
+      flycheck-falco-rules-maintainers:
+        description: maintainers of falcosecurity/flycheck-falco-rules
+        maintainers:
+          - mstemm
+          - ewilderj
+        members:
+        privacy: closed
+        repos:
+          flycheck-falco-rules: maintain
       falcoctl-maintainers:
         description: maintainers of falcosecurity/falcoctl
         maintainers:
@@ -588,6 +605,7 @@ orgs:
           falcoctl: admin
           falcosidekick: admin
           falcosidekick-ui: admin
+          flycheck-falco-rules: admin
           kernel-crawler: admin
           kilt: admin
           libs: admin

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -20,6 +20,7 @@ approve:
       - falcosecurity/falcoctl
       - falcosecurity/falcosidekick
       - falcosecurity/falcosidekick-ui
+      - falcosecurity/flycheck-falco-rules
       - falcosecurity/kernel-crawler
       - falcosecurity/kernel-module
       - falcosecurity/kilt
@@ -96,6 +97,7 @@ lgtm:
       - falcosecurity/falco-aws-terraform
       - falcosecurity/falco-exporter
       - falcosecurity/falco-website
+      - falcosecurity/flycheck-falco-rules
       - falcosecurity/kernel-crawler
       - falcosecurity/kilt
       - falcosecurity/libs
@@ -261,6 +263,14 @@ require_matching_label:
   - missing_label: needs-kind
     org: falcosecurity
     repo: falco-website
+    issues: true
+    regexp: ^kind/
+    missing_comment: |
+      There is not a label identifying the kind of this issue.
+      Please specify it either using `/kind <group>` or manually from the side menu.
+  - missing_label: needs-kind
+    org: falcosecurity
+    repo: flycheck-falco-rules
     issues: true
     regexp: ^kind/
     missing_comment: |
@@ -771,6 +781,29 @@ plugins:
       - verify-owners
       - welcome
       - wip
+  falcosecurity/flycheck-falco-rules:
+    plugins:
+      - approve
+      - assign
+      - blunderbuss
+      - branchcleaner
+      - cat
+      - dco
+      - dog
+      - goose
+      - help
+      - hold
+      - label
+      - lifecycle
+      - lgtm
+      - mergecommitblocker
+      - require-matching-label
+      - retitle
+      - size
+      - trigger
+      - verify-owners
+      - welcome
+      - wip
   falcosecurity/kernel-crawler:
     plugins:
       - approve
@@ -1115,6 +1148,10 @@ external_plugins:
       events:
         - pull_request
   falcosecurity/falco-website:
+    - name: needs-rebase
+      events:
+        - pull_request
+  falcosecurity/flycheck-falco-rules:
     - name: needs-rebase
       events:
         - pull_request


### PR DESCRIPTION
I didn't add any prow jobs, as the current tests use github actions. Not sure if that is preferred to prow or not.

Added all the other configs using falco-aws-terraform as a template.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>