### PR TITLE
refactor(config/jobs): run peribolos against org.yaml in evolution repo

### DIFF
--- a/config/jobs/peribolos/peribolos.yaml
+++ b/config/jobs/peribolos/peribolos.yaml
@@ -1,19 +1,19 @@
 presubmits:
-  falcosecurity/test-infra:
+  falcosecurity/evolution:
     - name: peribolos-pre-submit
       branches:
-        - ^master$
+        - ^main$
       decorate: true
       max_concurrency: 1
       skip_report: false
-      run_if_changed: '^config/org.yaml$|^config/jobs/peribolos/.*'
+      run_if_changed: '^org/org.yaml$'
       spec:
         containers:
           - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
             command:
               - peribolos
             args:
-              - --config-path=config/org.yaml
+              - --config-path=org/org.yaml
               - --fix-org
               - --fix-org-members
               - --fix-repos
@@ -35,14 +35,14 @@ presubmits:
           Archtype: "x86"
 
 postsubmits:
-  falcosecurity/test-infra:
+  falcosecurity/evolution:
     - name: peribolos-post-submit
       branches:
-        - ^master$
+        - ^main$
       decorate: true
       max_concurrency: 1
       skip_report: false
-      run_if_changed: '^config/org.yaml$|^config/jobs/peribolos/.*'
+      run_if_changed: '^org/org.yaml$'
       spec:
         containers:
           - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
@@ -50,7 +50,7 @@ postsubmits:
               - peribolos
             args:
               - --confirm
-              - --config-path=config/org.yaml
+              - --config-path=org/org.yaml
               - --fix-org
               - --fix-org-members
               - --fix-repos
@@ -80,8 +80,8 @@ periodics:
     always_run: true
     extra_refs:
       - org: falcosecurity
-        repo: test-infra
-        base_ref: master
+        repo: evolution
+        base_ref: main
     spec:
       containers:
         - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
@@ -89,7 +89,7 @@ periodics:
             - peribolos
           args:
             - --confirm
-            - --config-path=config/org.yaml
+            - --config-path=org/org.yaml
             - --fix-org
             - --fix-org-members
             - --fix-repos

--- a/config/jobs/peribolos/peribolos.yaml
+++ b/config/jobs/peribolos/peribolos.yaml
@@ -6,14 +6,14 @@ presubmits:
       decorate: true
       max_concurrency: 1
       skip_report: false
-      run_if_changed: '^org/org.yaml$'
+      run_if_changed: '^org.yaml$'
       spec:
         containers:
           - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
             command:
               - peribolos
             args:
-              - --config-path=org/org.yaml
+              - --config-path=org.yaml
               - --fix-org
               - --fix-org-members
               - --fix-repos
@@ -42,7 +42,7 @@ postsubmits:
       decorate: true
       max_concurrency: 1
       skip_report: false
-      run_if_changed: '^org/org.yaml$'
+      run_if_changed: '^org.yaml$'
       spec:
         containers:
           - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
@@ -50,7 +50,7 @@ postsubmits:
               - peribolos
             args:
               - --confirm
-              - --config-path=org/org.yaml
+              - --config-path=org.yaml
               - --fix-org
               - --fix-org-members
               - --fix-repos
@@ -89,7 +89,7 @@ periodics:
             - peribolos
           args:
             - --confirm
-            - --config-path=org/org.yaml
+            - --config-path=org.yaml
             - --fix-org
             - --fix-org-members
             - --fix-repos


### PR DESCRIPTION
This PR updates the Peribolos job to support `org.yaml` Github organization declarative configuration file, versioned in [`evolution`](https://github.com/falcosecurity/evolution).

#### Additional info

IMPORTANT: it needs first the points below in place:
- freeze of `org.yaml` file in **this** repository
- sync and merge of https://github.com/falcosecurity/evolution/pull/274

Superseedes #841.