### PR TITLE
fix(config/plugins.yaml): add missing milestone maintainers team setting

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -128,6 +128,9 @@ repo_milestone:
     maintainers_id: 3832091
     maintainers_team: pdig-maintainers
     maintainers_friendly_name: maintainers of falcosecurity/pdig
+  falcosecurity/falcoctl:
+    maintainers_team: falcoctl-maintainers
+    maintainers_friendly_name: maintainers of falcosecurity/falcoctl
 
 require_matching_label:
   - missing_label: needs-kind


### PR DESCRIPTION
Prow milestone plugin [checks](https://github.com/kubernetes/test-infra/blob/master/prow/plugins/milestone/milestone.go#L116) if the user to be in the milestone maintainer team.

`repo_milestone` Prow config field should fix the issue and allow `falcoctl-maintainers` Github team to apply milestone, chatops-way, with `/milestone` command.

Fixes #1001