### PR TITLE
chore(config/prow/monitoring: temporarily expose grafana http only

### DIFF
--- a/config/prow/monitoring/grafana_expose.yaml
+++ b/config/prow/monitoring/grafana_expose.yaml
@@ -27,12 +27,12 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 3001}]'
   name: grafana
   namespace: prow-monitoring
 spec:
   rules:
-  - host: monitoring.prow.falco.org
+  - host: k8s-prowmoni-grafana-40c9b7b6f0-1965243181.eu-west-1.elb.amazonaws.com
     http:
       paths:
       - path: /*
@@ -41,5 +41,5 @@ spec:
           service:
             name: grafana
             port:
-              number: 80
+              name: http
 


### PR DESCRIPTION
This PR configures temporarily the exposition of Prow Monitoring stack's Grafana dashboard at:
- http only
- AWS application load balancer DNS name

/cc @jasondellaluce @FedeDP 