### PR TITLE
chore(config/org.yaml): add myself (Lowaiz) as driverkit maintainer

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -433,6 +433,7 @@ orgs:
           - dwindsor
           - FedeDP
           - EXONER4TED
+          - Lowaiz
         privacy: closed
         repos:
           driverkit: maintain


### PR DESCRIPTION
What type of PR is this?

/kind documentation

Any specific area of the project related to this PR?

/area governance

What this PR does / why we need it:

As my proposition to become a falcosecurity/driverkit maintainers has been accepted (https://github.com/falcosecurity/driverkit/pull/259), I added myself to the organizatiuon file as requested.

Which issue(s) this PR fixes:

None