### PR TITLE
new(config,tools): add Github actions runner controller support.

### DIFF
--- a/config/prow/runner.yaml
+++ b/config/prow/runner.yaml
@@ -1,0 +1,13 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: falco-runner-arm64
+spec:
+  replicas: 1
+  template:
+    spec:
+      dockerdWithinRunnerContainer: true
+      image: summerwind/actions-runner-dind
+      repository: falcosecurity/falco
+      nodeSelector:
+        Archtype: "arm"

--- a/tools/deploy_prow.sh
+++ b/tools/deploy_prow.sh
@@ -74,7 +74,7 @@ function launchMonitoring(){
 }
 
 function launchARC(){
-  kubectl apply -f https://github.com/actions/actions-runner-controller releases/download/v0.22.0/actions-runner-controller.yaml
+  kubectl apply -f https://github.com/actions/actions-runner-controller/releases/download/v0.27.1/actions-runner-controller.yaml
   kubectl create secret generic controller-manager -n actions-runner-system --from-literal=github_token=${PROW_OAUTH_TOKEN}
   kubectl apply -f ./config/prow/runner.yaml
 }

--- a/tools/deploy_prow.sh
+++ b/tools/deploy_prow.sh
@@ -17,6 +17,8 @@ function main() {
   launchProw
   echo "Launching Prow monitoring"
   launchMonitoring
+  echo "Launching Actions Runner Controller"
+  launchARC
   echo "All done!"
 }
 
@@ -69,6 +71,12 @@ function launchProw(){
 
 function launchMonitoring(){
   make -C config/prow/monitoring
+}
+
+function launchARC(){
+  kubectl apply -f https://github.com/actions/actions-runner-controller releases/download/v0.22.0/actions-runner-controller.yaml
+  kubectl create secret generic controller-manager -n actions-runner-system --from-literal=github_token=${PROW_OAUTH_TOKEN}
+  kubectl apply -f ./config/prow/runner.yaml
 }
 
 function cleanup() {


### PR DESCRIPTION
For reference, see https://github.com/actions/actions-runner-controller/.

Basically, we introduce a new resource `RunnerDeployment` that will manage github self-hosted runners requests from the falcosecurity/falco repository.

/cc @maxgio92 

/hold