### PR TITLE
revert: "Bump prow from v20230315-6d54c174f4 to v20230324-8697ff4d24"

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,10 +34,10 @@ plank:
       timeout: 24h # Up to 24 hours for driverkit builder jobs
       grace_period: 10m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20230324-8697ff4d24"
-        initupload: "gcr.io/k8s-prow/initupload:v20230324-8697ff4d24"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20230324-8697ff4d24"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20230324-8697ff4d24"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20230315-6d54c174f4"
+        initupload: "gcr.io/k8s-prow/initupload:v20230315-6d54c174f4"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20230315-6d54c174f4"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20230315-6d54c174f4"
       gcs_configuration:
         bucket: s3://falco-prow-logs
         path_strategy: explicit

--- a/config/jobs/branchprotector/branchprotector.yaml
+++ b/config/jobs/branchprotector/branchprotector.yaml
@@ -11,7 +11,7 @@ postsubmit:
       run_if_changed: '^config/config.yaml$'
       spec:
         containers:
-          - image: gcr.io/k8s-prow/branchprotector:v20230324-8697ff4d24
+          - image: gcr.io/k8s-prow/branchprotector:v20230315-6d54c174f4
             command:
               - branchprotector
             args:
@@ -44,7 +44,7 @@ periodics:
     skip_report: false
     spec:
       containers:
-        - image: gcr.io/k8s-prow/branchprotector:v20230324-8697ff4d24
+        - image: gcr.io/k8s-prow/branchprotector:v20230315-6d54c174f4
           command:
             - branchprotector
           args:

--- a/config/jobs/check-prow-config/check-prow-config.yaml
+++ b/config/jobs/check-prow-config/check-prow-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       always_run: true
       spec:
         containers:
-          - image: gcr.io/k8s-prow/checkconfig:v20230324-8697ff4d24
+          - image: gcr.io/k8s-prow/checkconfig:v20230315-6d54c174f4
             command:
               - checkconfig
             args:
@@ -27,7 +27,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20230324-8697ff4d24
+    - image: gcr.io/k8s-prow/checkconfig:v20230315-6d54c174f4
       command:
       - checkconfig
       args:

--- a/config/jobs/lifecycle-bot/periodic-close.yaml
+++ b/config/jobs/lifecycle-bot/periodic-close.yaml
@@ -7,7 +7,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-prow/commenter:v20230324-8697ff4d24
+        - image: gcr.io/k8s-prow/commenter:v20230315-6d54c174f4
           command:
             - commenter
           args:

--- a/config/jobs/lifecycle-bot/periodic-rotten.yaml
+++ b/config/jobs/lifecycle-bot/periodic-rotten.yaml
@@ -7,7 +7,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-prow/commenter:v20230324-8697ff4d24
+        - image: gcr.io/k8s-prow/commenter:v20230315-6d54c174f4
           command:
             - commenter
           args:

--- a/config/jobs/lifecycle-bot/periodic-stale.yaml
+++ b/config/jobs/lifecycle-bot/periodic-stale.yaml
@@ -7,7 +7,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-prow/commenter:v20230324-8697ff4d24
+        - image: gcr.io/k8s-prow/commenter:v20230315-6d54c174f4
           command:
             - commenter
           args:

--- a/config/jobs/peribolos/peribolos.yaml
+++ b/config/jobs/peribolos/peribolos.yaml
@@ -9,7 +9,7 @@ presubmits:
       run_if_changed: '^config/org.yaml$|^config/jobs/peribolos/.*'
       spec:
         containers:
-          - image: gcr.io/k8s-prow/peribolos:v20230324-8697ff4d24
+          - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
             command:
               - peribolos
             args:
@@ -45,7 +45,7 @@ postsubmits:
       run_if_changed: '^config/org.yaml$|^config/jobs/peribolos/.*'
       spec:
         containers:
-          - image: gcr.io/k8s-prow/peribolos:v20230324-8697ff4d24
+          - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
             command:
               - peribolos
             args:
@@ -84,7 +84,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/k8s-prow/peribolos:v20230324-8697ff4d24
+        - image: gcr.io/k8s-prow/peribolos:v20230315-6d54c174f4
           command:
             - peribolos
           args:

--- a/config/prow/crier.yaml
+++ b/config/prow/crier.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/crier:v20230315-6d54c174f4
         env:
         - name: AWS_REGION
           value: eu-west-1

--- a/config/prow/deck.yaml
+++ b/config/prow/deck.yaml
@@ -113,7 +113,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/deck:v20230315-6d54c174f4
         env:
         - name: AWS_REGION #required for splyglass bucket looku
           value: eu-west-1

--- a/config/prow/ghproxy.yaml
+++ b/config/prow/ghproxy.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/ghproxy:v20230315-6d54c174f4
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/hook.yaml
+++ b/config/prow/hook.yaml
@@ -68,7 +68,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/hook:v20230315-6d54c174f4
         imagePullPolicy: Always
         args:
         - --github-endpoint=http://ghproxy

--- a/config/prow/horologium.yaml
+++ b/config/prow/horologium.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/horologium:v20230315-6d54c174f4
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/needs-rebase.yaml
+++ b/config/prow/needs-rebase.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/needs-rebase:v20230315-6d54c174f4
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/prow-controller-manager.yaml
+++ b/config/prow/prow-controller-manager.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "prow-controller-manager"
       containers:
         - name: prow-controller-manager
-          image: gcr.io/k8s-prow/prow-controller-manager:v20230324-8697ff4d24
+          image: gcr.io/k8s-prow/prow-controller-manager:v20230315-6d54c174f4
           env:
           - name: AWS_REGION
             value: eu-west-1

--- a/config/prow/sinker.yaml
+++ b/config/prow/sinker.yaml
@@ -116,7 +116,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/sinker:v20230315-6d54c174f4
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/statusreconciler.yaml
+++ b/config/prow/statusreconciler.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/status-reconciler:v20230315-6d54c174f4
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/config/prow/tide.yaml
+++ b/config/prow/tide.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20230324-8697ff4d24
+        image: gcr.io/k8s-prow/tide:v20230315-6d54c174f4
         env:
         - name: AWS_REGION
           value: eu-west-1


### PR DESCRIPTION
Reverts falcosecurity/test-infra#1071

Seems like it is causing issues to the prow-controller-manager, since no prow job could be scheduled after that PR was merged: https://prow.falco.org/