### PR TITLE
fix(tools): force server-side flag when applying ARC resources.

### DIFF
--- a/tools/deploy_prow.sh
+++ b/tools/deploy_prow.sh
@@ -74,7 +74,7 @@ function launchMonitoring(){
 }
 
 function launchARC(){
-  kubectl apply -f https://github.com/actions/actions-runner-controller/releases/download/v0.27.1/actions-runner-controller.yaml
+  kubectl apply -f https://github.com/actions/actions-runner-controller/releases/download/v0.27.1/actions-runner-controller.yaml --server-side
   kubectl create secret generic controller-manager -n actions-runner-system --from-literal=github_token=${PROW_OAUTH_TOKEN}
   kubectl apply -f config/prow/arc/
 }


### PR DESCRIPTION
This is needed to avoid
> Error from server (Invalid): error when creating "https://github.com/actions/actions-runner-controller/releases/download/v0.27.1/actions-runner-controller.yaml": CustomResourceDefinition.apiextensions.k8s.io "runnerdeployments.actions.summerwind.dev" is invalid: metadata.annotations: Too long: must have at most 262144 bytes

Errors.
https://github.com/actions/actions-runner-controller/issues/1317