### PR TITLE
fix(prow): do not fail if the secret already exists

### DIFF
--- a/tools/deploy_prow.sh
+++ b/tools/deploy_prow.sh
@@ -75,7 +75,7 @@ function launchMonitoring(){
 
 function launchARC(){
   kubectl apply -f https://github.com/actions/actions-runner-controller/releases/download/v0.27.1/actions-runner-controller.yaml --server-side --force-conflicts
-  kubectl create secret generic controller-manager -n actions-runner-system --from-literal=github_token=${PROW_OAUTH_TOKEN}
+  kubectl create secret generic controller-manager -n actions-runner-system --from-literal=github_token=${PROW_OAUTH_TOKEN} || true
   kubectl apply -f config/prow/arc/
 }
 


### PR DESCRIPTION
As per title, follow the same pattern used in the rest of the repo