### PR TITLE
fix(config/clusters): added policies for S3 access update-driver-website workflow

### DIFF
--- a/.github/workflows/update-drivers-website.yml
+++ b/.github/workflows/update-drivers-website.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: "arn:aws:iam::292999226676:role/terraform-20230120142903096000000002"
+          role-to-assume: "arn:aws:iam::292999226676:role/github_actions-test-infra-s3"
           aws-region: ${{ env.AWS_S3_REGION }}
 
       - name: Create output folder

--- a/config/clusters/iam.tf
+++ b/config/clusters/iam.tf
@@ -218,6 +218,44 @@ data "aws_iam_policy_document" "rules_s3_access" {
   }
 }
 
+# Test-infra repository
+
+module "test-infra_s3_role" {
+  source    = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.10.0"
+  create = true
+  subjects = [
+    "falcosecurity/test-infra:ref:refs/heads/master"
+  ]
+  policies = {
+    test-infra_s3_access = "${aws_iam_policy.test-infra_s3_access.arn}"
+  }
+}
+
+resource "aws_iam_policy" "test-infra_s3_access" {
+  name_prefix = "github_actions-test-infra-s3"
+  description = "GitHub actions S3 access policy for test-infra update-drivers-website workflow"
+  policy      = data.aws_iam_policy_document.test-infra_s3_access.json
+}
+
+data "aws_iam_policy_document" "test-infra_s3_access" {
+  statement {
+    sid    = "UploadTestInfraS3Access"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObjectAcl",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::falco-distribution/driver/site/*",
+      "arn:aws:s3:::falco-distribution/driver/site",
+    ]
+  }
+}
+
 # Falcosidekick repository
 
 module "falcosidekick_ecr_role" {

--- a/config/clusters/iam.tf
+++ b/config/clusters/iam.tf
@@ -223,6 +223,7 @@ data "aws_iam_policy_document" "rules_s3_access" {
 module "test-infra_s3_role" {
   source    = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
   version = "5.10.0"
+  name = "github_actions-test-infra-s3"
   create = true
   subjects = [
     "falcosecurity/test-infra:ref:refs/heads/master"


### PR DESCRIPTION
This PR adds the policy to allow update-driver-website workflow to upload to S3