### PR TITLE
cleanup(config/jobs): remove update-drivers-website build/publish image trigger 

### DIFF
--- a/config/jobs/build-prow-images/build-images.yaml
+++ b/config/jobs/build-prow-images/build-images.yaml
@@ -279,32 +279,4 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        Archtype: "x86"     
-  - name: build-images-update-drivers-website
-    decorate: true
-    path_alias: github.com/falcosecurity/test-infra
-    skip_report: false
-    agent: kubernetes
-    run_if_changed: '^images/update-drivers-website/'
-    branches:
-      - ^master$
-    spec:
-      containers:
-      - command:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/build.sh"
-        args:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-drivers-website"
-        env:
-        - name: AWS_REGION
-          value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
-        imagePullPolicy: Always
-        resources:
-          requests:
-            memory: 3Gi
-            cpu: 1.5
-            ephemeral-storage: "2Gi"
-        securityContext:
-          privileged: true
-      nodeSelector:
         Archtype: "x86"

--- a/config/jobs/build-prow-images/publish-images.yaml
+++ b/config/jobs/build-prow-images/publish-images.yaml
@@ -281,31 +281,3 @@ postsubmits:
           privileged: true
       nodeSelector:
         Archtype: "x86"        
-  - name: publish-images-update-drivers-website
-    decorate: true
-    path_alias: github.com/falcosecurity/test-infra
-    skip_report: false
-    agent: kubernetes
-    run_if_changed: '^images/update-drivers-website/'
-    branches:
-      - ^master$
-    spec:
-      containers:
-      - command:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/publish.sh"
-        args:
-          - "/home/prow/go/src/github.com/falcosecurity/test-infra/images/update-drivers-website"
-        env:
-        - name: AWS_REGION
-          value: eu-west-1
-        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/docker-dind
-        imagePullPolicy: Always
-        resources:
-          requests:
-            memory: 3Gi
-            cpu: 1.5
-            ephemeral-storage: "2Gi"
-        securityContext:
-          privileged: true
-      nodeSelector:
-        Archtype: "x86"


### PR DESCRIPTION
This PR removes the `update-drivers-website` job from the prow image (see #1013)