### PR TITLE
update(config/jobs/build-drivers): tuning pods resources allocation

### DIFF
--- a/config/jobs/build-drivers/build-new-amazonlinux.yaml
+++ b/config/jobs/build-drivers/build-new-amazonlinux.yaml
@@ -23,9 +23,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-amazonlinux2-presubmit
@@ -51,9 +54,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 50% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-amazonlinux2022-presubmit
@@ -79,9 +85,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"      
 postsubmits:
@@ -109,9 +118,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-amazonlinux-postsubmit-arm
@@ -137,9 +149,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-amazonlinux2-postsubmit
@@ -165,9 +180,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-amazonlinux2-postsubmit-arm
@@ -193,9 +211,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-amazonlinux2022-postsubmit
@@ -221,9 +242,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-amazonlinux2022-postsubmit-arm
@@ -249,8 +273,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"      

--- a/config/jobs/build-drivers/build-new-amazonlinux.yaml
+++ b/config/jobs/build-drivers/build-new-amazonlinux.yaml
@@ -58,7 +58,7 @@ presubmits:
             cpu: 1.0
             memory: 4Gi
           requests:
-            cpu: 750m #m5large is 2vpcu and 8gb ram so this 50% of a node
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
             memory: 2Gi
       nodeSelector:
         Archtype: "x86"

--- a/config/jobs/build-drivers/build-new-bottlerocket.yaml
+++ b/config/jobs/build-drivers/build-new-bottlerocket.yaml
@@ -23,9 +23,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -53,9 +56,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-bottlerocket-postsubmit-arm
@@ -81,8 +87,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-centos.yaml
+++ b/config/jobs/build-drivers/build-new-centos.yaml
@@ -24,9 +24,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-centos-3-presubmit
@@ -53,9 +56,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-centos-4-presubmit
@@ -82,9 +88,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-centos-5-presubmit
@@ -111,9 +120,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-centos-6-presubmit
@@ -171,9 +183,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-centos-3-postsubmit
@@ -200,9 +215,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-centos-3-postsubmit-arm
@@ -229,9 +247,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-centos-4-postsubmit
@@ -258,9 +279,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-centos-4-postsubmit-arm
@@ -287,9 +311,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-centos-5-postsubmit
@@ -316,9 +343,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"    
   - name: build-new-drivers-centos-5-postsubmit-arm
@@ -345,9 +375,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-centos-6-postsubmit

--- a/config/jobs/build-drivers/build-new-centos.yaml
+++ b/config/jobs/build-drivers/build-new-centos.yaml
@@ -152,9 +152,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"      
 postsubmits:
@@ -407,9 +410,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"  
   - name: build-new-drivers-centos-6-postsubmit-arm
@@ -436,8 +442,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-debian.yaml
+++ b/config/jobs/build-drivers/build-new-debian.yaml
@@ -23,9 +23,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -53,9 +56,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-debian-postsubmit-arm
@@ -81,8 +87,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-fedora.yaml
+++ b/config/jobs/build-drivers/build-new-fedora.yaml
@@ -23,9 +23,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -53,9 +56,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-fedora-postsubmit-arm
@@ -81,8 +87,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-minikube.yaml
+++ b/config/jobs/build-drivers/build-new-minikube.yaml
@@ -23,9 +23,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -53,9 +56,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-minikube-postsubmit-arm
@@ -81,8 +87,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
@@ -24,9 +24,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-aws-4-presubmit
@@ -53,9 +56,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-aws-5-presubmit
@@ -82,9 +88,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-aws-6-presubmit
@@ -142,9 +151,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-aws-3-postsubmit-arm
@@ -171,9 +183,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-aws-4-postsubmit
@@ -200,9 +215,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-aws-4-postsubmit-arm
@@ -229,9 +247,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-aws-5-postsubmit
@@ -258,9 +279,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-aws-5-postsubmit-arm
@@ -287,9 +311,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-aws-6-postsubmit

--- a/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
@@ -120,9 +120,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -343,9 +346,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-aws-6-postsubmit-arm
@@ -372,8 +378,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
@@ -24,9 +24,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-azure-4-presubmit
@@ -53,9 +56,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-azure-5-presubmit
@@ -82,9 +88,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-azure-6-presubmit
@@ -142,9 +151,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-azure-3-postsubmit-arm
@@ -171,9 +183,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-azure-4-postsubmit
@@ -200,9 +215,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-azure-4-postsubmit-arm
@@ -229,9 +247,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-azure-5-postsubmit
@@ -258,9 +279,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-azure-5-postsubmit-arm
@@ -287,9 +311,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-azure-6-postsubmit

--- a/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
@@ -120,9 +120,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -343,9 +346,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-azure-6-postsubmit-arm
@@ -372,8 +378,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
@@ -24,9 +24,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-gcp-4-presubmit
@@ -53,9 +56,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-gcp-5-presubmit
@@ -82,9 +88,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-gcp-6-presubmit
@@ -142,9 +151,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gcp-3-postsubmit-arm
@@ -171,9 +183,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-gcp-4-postsubmit
@@ -200,9 +215,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gcp-4-postsubmit-arm
@@ -229,9 +247,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-gcp-5-postsubmit
@@ -258,9 +279,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gcp-5-postsubmit-arm
@@ -287,9 +311,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-gcp-6-postsubmit

--- a/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
@@ -120,9 +120,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -343,9 +346,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gcp-6-postsubmit-arm
@@ -372,8 +378,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
@@ -120,9 +120,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -343,9 +346,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-generic-6-postsubmit-arm
@@ -372,8 +378,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
@@ -24,9 +24,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-generic-4-presubmit
@@ -53,9 +56,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: valdiate-new-drivers-ubuntu-generic-5-presubmit
@@ -82,9 +88,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: valdiate-new-drivers-ubuntu-generic-6-presubmit
@@ -142,9 +151,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-generic-3-postsubmit-arm
@@ -171,9 +183,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-generic-4-postsubmit
@@ -200,9 +215,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-generic-4-postsubmit-arm
@@ -229,9 +247,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-generic-5-postsubmit
@@ -258,9 +279,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-generic-5-postsubmit-arm
@@ -287,9 +311,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-generic-6-postsubmit

--- a/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
@@ -120,9 +120,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
 postsubmits:
@@ -343,9 +346,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gke-6-postsubmit-arm
@@ -372,8 +378,11 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"

--- a/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
@@ -24,9 +24,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-gke-4-presubmit
@@ -53,9 +56,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-gke-5-presubmit
@@ -82,9 +88,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: validate-new-drivers-ubuntu-gke-6-presubmit
@@ -142,9 +151,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gke-3-postsubmit-arm
@@ -171,9 +183,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-gke-4-postsubmit
@@ -200,9 +215,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gke-4-postsubmit-arm
@@ -229,9 +247,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-gke-5-postsubmit
@@ -258,9 +279,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "x86"
   - name: build-new-drivers-ubuntu-gke-5-postsubmit-arm
@@ -287,9 +311,12 @@ postsubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
           requests:
-            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
-            memory: 6Gi
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
       nodeSelector:
         Archtype: "arm"
   - name: build-new-drivers-ubuntu-gke-6-postsubmit


### PR DESCRIPTION
This PR tunes the resource allocation to pods responsible for build-driver jobs.
The requested CPU and memory have been decreased and limits have been set to try to schedule two pods on the same node.
Since build processes are not very memory intensive, pods should not be affected by OOM kills.
On the other hand, requests and limits on the CPU might be not sufficient and cause throttling.
Also, the range between CPU requests and limits may be too small resulting in pods being unable to be scheduled.

WDYT @FedeDP @maxgio92?