### PR TITLE
update(config/jobs/build-drivers): added jobs for ubuntu 6.x and centos 6.x kernel versions

### DIFF
--- a/config/jobs/build-drivers/build-new-centos.yaml
+++ b/config/jobs/build-drivers/build-new-centos.yaml
@@ -115,6 +115,35 @@ presubmits:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
       nodeSelector:
+        Archtype: "x86"
+  - name: validate-new-drivers-centos-6-presubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/(.+/)?centos_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - centos
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
         Archtype: "x86"      
 postsubmits:
   falcosecurity/test-infra:
@@ -291,7 +320,7 @@ postsubmits:
             cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
             memory: 6Gi
       nodeSelector:
-        Archtype: "x86"      
+        Archtype: "x86"    
   - name: build-new-drivers-centos-5-postsubmit-arm
     decorate: true
     skip_report: false
@@ -306,6 +335,64 @@ postsubmits:
         - /workspace/build-drivers.sh
         - centos
         - "5.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "arm"
+  - name: build-new-drivers-centos-6-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/centos_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - centos
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"  
+  - name: build-new-drivers-centos-6-postsubmit-arm
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/centos_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - centos
+        - "6.*"
         env:
         - name: AWS_REGION
           value: eu-west-1

--- a/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
@@ -87,6 +87,35 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
+  - name: validate-new-drivers-ubuntu-aws-6-presubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/(.+/)?ubuntu-aws_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-aws
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
 postsubmits:
   falcosecurity/test-infra:
   - name: build-new-drivers-ubuntu-aws-3-postsubmit
@@ -248,6 +277,64 @@ postsubmits:
         - /workspace/build-drivers.sh
         - ubuntu-aws
         - "5.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "arm"
+  - name: build-new-drivers-ubuntu-aws-6-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-aws_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-aws
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-new-drivers-ubuntu-aws-6-postsubmit-arm
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-aws_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-aws
+        - "6.*"
         env:
         - name: AWS_REGION
           value: eu-west-1

--- a/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
@@ -87,6 +87,35 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
+  - name: validate-new-drivers-ubuntu-azure-6-presubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/(.+/)?ubuntu-azure_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-azure
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
 postsubmits:
   falcosecurity/test-infra:
   - name: build-new-drivers-ubuntu-azure-3-postsubmit
@@ -248,6 +277,64 @@ postsubmits:
         - /workspace/build-drivers.sh
         - ubuntu-azure
         - "5.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "arm"
+  - name: build-new-drivers-ubuntu-azure-6-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-azure_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-azure
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-new-drivers-ubuntu-azure-6-postsubmit-arm
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-azure_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-azure
+        - "6.*"
         env:
         - name: AWS_REGION
           value: eu-west-1

--- a/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
@@ -87,6 +87,35 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
+  - name: validate-new-drivers-ubuntu-gcp-6-presubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/(.+/)?ubuntu-gcp_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-gcp
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
 postsubmits:
   falcosecurity/test-infra:
   - name: build-new-drivers-ubuntu-gcp-3-postsubmit
@@ -248,6 +277,64 @@ postsubmits:
         - /workspace/build-drivers.sh
         - ubuntu-gcp
         - "5.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "arm"
+  - name: build-new-drivers-ubuntu-gcp-6-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gcp_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-gcp
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-new-drivers-ubuntu-gcp-6-postsubmit-arm
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gcp_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-gcp
+        - "6.*"
         env:
         - name: AWS_REGION
           value: eu-west-1

--- a/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
@@ -87,6 +87,35 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
+  - name: valdiate-new-drivers-ubuntu-generic-6-presubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/(.+/)?ubuntu-generic_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-generic
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
 postsubmits:
   falcosecurity/test-infra:
   - name: build-new-drivers-ubuntu-generic-3-postsubmit
@@ -248,6 +277,64 @@ postsubmits:
         - /workspace/build-drivers.sh
         - ubuntu-generic
         - "5.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "arm"
+  - name: build-new-drivers-ubuntu-generic-6-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-generic_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-generic
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-new-drivers-ubuntu-generic-6-postsubmit-arm
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-generic_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-generic
+        - "6.*"
         env:
         - name: AWS_REGION
           value: eu-west-1

--- a/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
@@ -87,6 +87,35 @@ presubmits:
             memory: 6Gi
       nodeSelector:
         Archtype: "x86"
+  - name: validate-new-drivers-ubuntu-gke-6-presubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/(.+/)?ubuntu-gke_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-gke
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
 postsubmits:
   falcosecurity/test-infra:
   - name: build-new-drivers-ubuntu-gke-3-postsubmit
@@ -248,6 +277,64 @@ postsubmits:
         - /workspace/build-drivers.sh
         - ubuntu-gke
         - "5.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "arm"
+  - name: build-new-drivers-ubuntu-gke-6-postsubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gke_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-gke
+        - "6.*"
+        env:
+        - name: AWS_REGION
+          value: eu-west-1
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1500m #m5large is 2vpcu and 8gb ram so this 75% of a node
+            memory: 6Gi
+      nodeSelector:
+        Archtype: "x86"
+  - name: build-new-drivers-ubuntu-gke-6-postsubmit-arm
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gke_6.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - ubuntu-gke
+        - "6.*"
         env:
         - name: AWS_REGION
           value: eu-west-1


### PR DESCRIPTION
This PR introduces the configurations for build-driver jobs of `ubuntu 6.x` and `centos 6.x` kernel versions.

Fixes #931