### PR TITLE
Sync Github Team evolution-maintainers with evolution owners

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -1,55 +1,51 @@
 orgs:
   falcosecurity:
-    name: Falco
-    description: Falco is Container Native Runtime Security
-
+    admins:
+    - caniszczyk
+    - ldegio
+    - leogr
+    - mstemm
+    - poiana
+    - thelinuxfoundation
+    - jasondellaluce
+    - LucaGuerra
     default_repository_permission: read
+    description: Falco is Container Native Runtime Security
     has_organization_projects: true
     has_repository_projects: true
-    members_can_create_repositories: false
-
-    admins:
-      - caniszczyk
-      - ldegio
-      - leogr
-      - mstemm
-      - poiana
-      - thelinuxfoundation
-      - jasondellaluce
-      - LucaGuerra
-
     members:
-      - admiral0
-      - alacuku
-      - Andreagit97
-      - araujof
-      - bencer
-      - cpanato
-      - cappellinsamuele
-      - darryk10
-      - dwindsor
-      - ewilderj
-      - EXONER4TED
-      - FedeDP
-      - fjogeleit
-      - gnosek
-      - hbrueckner
-      - incertum
-      - Issif
-      - jonahjon
-      - Kaizhe
-      - krisnova
-      - leodido
-      - loresuso
-      - markyjackson-taulia
-      - maxgio92
-      - mfdii
-      - mmat11
-      - Molter73
-      - terylt
-      - vjjmiras
-      - zuc
-
+    - admiral0
+    - alacuku
+    - Andreagit97
+    - araujof
+    - bencer
+    - cpanato
+    - cappellinsamuele
+    - darryk10
+    - dwindsor
+    - ewilderj
+    - EXONER4TED
+    - FedeDP
+    - fjogeleit
+    - gnosek
+    - hbrueckner
+    - incertum
+    - Issif
+    - jonahjon
+    - Kaizhe
+    - krisnova
+    - leodido
+    - loresuso
+    - markyjackson-taulia
+    - maxgio92
+    - mfdii
+    - mmat11
+    - Molter73
+    - terylt
+    - vjjmiras
+    - zuc
+    members_can_create_repositories: false
+    name: Falco
     repos:
       .github:
         allow_merge_commit: false
@@ -122,7 +118,7 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
-        description: "Kit for building Falco drivers: kernel modules or eBPF probes"
+        description: 'Kit for building Falco drivers: kernel modules or eBPF probes'
         has_projects: true
       ebpf-probe:
         allow_merge_commit: false
@@ -135,8 +131,7 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
-        description:
-          Generate a variety of suspect actions that are detected by Falco
+        description: Generate a variety of suspect actions that are detected by Falco
           rulesets
         has_projects: true
       evolution:
@@ -159,8 +154,8 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
-        description: Terraform Module for Falco AWS Resources
         default_branch: main
+        description: Terraform Module for Falco AWS Resources
         has_projects: true
       falco-exporter:
         allow_merge_commit: false
@@ -175,13 +170,6 @@ orgs:
         description: Source code of the official Falco website
         has_projects: true
         homepage: https://falco.org
-      flycheck-falco-rules:
-        allow_merge_commit: false
-        allow_rebase_merge: true
-        allow_squash_merge: false
-        description: Falco Rules Syntax Checker for Emacs, Using Flycheck
-        default_branch: main
-        has_projects: true
       falcoctl:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -203,6 +191,13 @@ orgs:
         description: A simple WebUI with latest events from Falco
         has_projects: true
         has_wiki: false
+      flycheck-falco-rules:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        default_branch: main
+        description: Falco Rules Syntax Checker for Emacs, Using Flycheck
+        has_projects: true
       kernel-crawler:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -221,15 +216,15 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
-        description: Kilt is a project that defines how to inject foreign apps into containers
+        description: Kilt is a project that defines how to inject foreign apps into
+          containers
         has_projects: true
         has_wiki: false
       libs:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
-        description:
-          libsinsp, libscap, the kernel module driver, and the eBPF driver
+        description: libsinsp, libscap, the kernel module driver, and the eBPF driver
           sources
         has_projects: true
         has_wiki: false
@@ -252,7 +247,7 @@ orgs:
         allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
-        description: "System inspection library "
+        description: 'System inspection library '
         has_projects: true
       pdig:
         allow_merge_commit: false
@@ -280,8 +275,8 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
-        description: Falco plugins SDK for Go
         default_branch: main
+        description: Falco plugins SDK for Go
         has_projects: true
       plugins:
         allow_merge_commit: false
@@ -327,282 +322,281 @@ orgs:
         description: All-purpose test suite for Falco and its ecosystem
         has_projects: true
         has_wiki: false
-
     teams:
       admins:
         description: admins of the org
         maintainers:
-          - caniszczyk
-          - ldegio
-          - leogr
-          - thelinuxfoundation
-          - mstemm
+        - caniszczyk
+        - ldegio
+        - leogr
+        - thelinuxfoundation
+        - mstemm
         privacy: closed
         repos:
           advocacy: admin
       charts-maintainers:
         description: maintainers of falcosecurity/charts
         maintainers:
-          - leogr
+        - leogr
         members:
-          - cpanato
-          - Issif
+        - cpanato
+        - Issif
         privacy: closed
         repos:
           charts: maintain
       client-go-maintainers:
         description: maintainers of falcosecurity/client-go
         maintainers:
-          - leogr
+        - leogr
         members:
-          - leodido
+        - leodido
         privacy: closed
         repos:
           client-go: maintain
       client-py-maintainers:
         description: maintainers of falcosecurity/client-py
         members:
-          - leodido
-          - mmat11
+        - leodido
+        - mmat11
         privacy: closed
         repos:
           client-py: maintain
       client-rs-maintainers:
         description: maintainers of falcosecurity/client-rs
         members:
-          - leodido
+        - leodido
         privacy: closed
         repos:
           client-rs: maintain
       community-maintainers:
         description: maintainers of falcosecurity/community
         maintainers:
-          - leogr
+        - leogr
         members:
-          - Issif
-          - araujof
-          - maxgio92
-          - terylt
-          - Andreagit97
+        - Issif
+        - araujof
+        - maxgio92
+        - terylt
+        - Andreagit97
         privacy: closed
         repos:
           community: maintain
       contrib-maintainers:
         description: maintainers of falcosecurity/contrib
         maintainers:
-          - leogr
+        - leogr
         members:
-          - maxgio92
-          - jasondellaluce
+        - maxgio92
+        - jasondellaluce
         privacy: closed
         repos:
           contrib: maintain
       core-maintainers:
         description: Core maintainers of The Falco Project
         maintainers:
-          - leogr
-          - mstemm
+        - leogr
+        - mstemm
         members:
-          - gnosek
-          - cpanato
-          - Issif
-          - FedeDP
-          - maxgio92
-          - zuc
-          - jasondellaluce
-          - Molter73
-          - LucaGuerra
-          - Andreagit97
-          - incertum
+        - gnosek
+        - cpanato
+        - Issif
+        - FedeDP
+        - maxgio92
+        - zuc
+        - jasondellaluce
+        - Molter73
+        - LucaGuerra
+        - Andreagit97
+        - incertum
         privacy: closed
       deploy-kubernetes-maintainers:
         description: maintainers of falcosecurity/deploy-kubernetes
         maintainers:
-          - leogr
+        - leogr
         members:
-          - maxgio92
-          - zuc
-          - jasondellaluce
+        - maxgio92
+        - zuc
+        - jasondellaluce
         privacy: closed
         repos:
           deploy-kubernetes: maintain
       driverkit-maintainers:
         description: maintainers of falcosecurity/driverkit
         members:
-          - leodido
-          - dwindsor
-          - FedeDP
-          - EXONER4TED
+        - leodido
+        - dwindsor
+        - FedeDP
+        - EXONER4TED
         privacy: closed
         repos:
           driverkit: maintain
       event-generator-maintainers:
         description: maintainers of falcosecurity/event-generator
         maintainers:
-          - leogr
+        - leogr
         members:
-          - FedeDP
+        - FedeDP
         privacy: closed
         repos:
           event-generator: maintain
       evolution-maintainers:
         description: maintainers of falcosecurity/evolution
         maintainers:
-          - leogr
+        - leogr
         members:
-          - maxgio92
-          - jasondellaluce
+        - maxgio92
+        - jasondellaluce
+        - leogr
         privacy: closed
         repos:
           evolution: maintain
       falco-aws-terraform-maintainers:
         description: maintainers of falcosecurity/falco-aws-terraform
         maintainers:
-          - ldegio
-          - leogr
-          - mstemm
+        - ldegio
+        - leogr
+        - mstemm
         members:
-          - zuc
-          - jasondellaluce
+        - zuc
+        - jasondellaluce
         privacy: closed
         repos:
           falco-aws-terraform: maintain
       falco-exporter-maintainers:
         description: maintainers of falcosecurity/falco-exporter
         maintainers:
-          - leogr
+        - leogr
         members:
-          - jasondellaluce
+        - jasondellaluce
         privacy: closed
         repos:
           falco-exporter: maintain
       falco-maintainers:
         description: maintainers of falcosecurity/falco
         maintainers:
-          - leogr
-          - mstemm
+        - leogr
+        - mstemm
         members:
-          - FedeDP
-          - jasondellaluce
-          - Andreagit97
+        - FedeDP
+        - jasondellaluce
+        - Andreagit97
         privacy: closed
         repos:
           falco: maintain
       falco-website-maintainers:
         description: maintainers of falcosecurity/falco-website
         maintainers:
-          - leogr
+        - leogr
         members:
-          - Issif
-          - jasondellaluce
-          - vjjmiras
+        - Issif
+        - jasondellaluce
+        - vjjmiras
         privacy: closed
         repos:
           falco-website: maintain
-      flycheck-falco-rules-maintainers:
-        description: maintainers of falcosecurity/flycheck-falco-rules
-        maintainers:
-          - mstemm
-          - ewilderj
-        members:
-        privacy: closed
-        repos:
-          flycheck-falco-rules: maintain
       falcoctl-maintainers:
         description: maintainers of falcosecurity/falcoctl
         maintainers:
-          - leogr
+        - leogr
         members:
-          - zuc
-          - maxgio92
-          - fededp
-          - cpanato
+        - zuc
+        - maxgio92
+        - fededp
+        - cpanato
         privacy: closed
         repos:
           falcoctl: maintain
       falcosidekick-maintainers:
         description: maintainers of falcosecurity/falcosidekick
         maintainers:
-          - leogr
+        - leogr
         members:
-          - cpanato
-          - Issif
-          - fjogeleit
+        - cpanato
+        - Issif
+        - fjogeleit
         privacy: closed
         repos:
           falcosidekick: maintain
       falcosidekick-ui-maintainers:
         description: maintainers of falcosecurity/falcosidekick-ui
         members:
-          - cpanato
-          - Issif
-          - fjogeleit
+        - cpanato
+        - Issif
+        - fjogeleit
         privacy: closed
         repos:
           falcosidekick-ui: maintain
+      flycheck-falco-rules-maintainers:
+        description: maintainers of falcosecurity/flycheck-falco-rules
+        maintainers:
+        - mstemm
+        - ewilderj
+        privacy: closed
+        repos:
+          flycheck-falco-rules: maintain
       github-maintainers:
         description: maintainers of falcosecurity/.github
         maintainers:
-          - leogr
+        - leogr
         members:
-          - maxgio92
-          - jasondellaluce
+        - maxgio92
+        - jasondellaluce
         privacy: closed
         repos:
           .github: maintain
       kernel-crawler-maintainers:
         description: maintainers of falcosecurity/kernel-crawler
         maintainers:
-          - leogr
+        - leogr
         members:
-          - FedeDP
-          - maxgio92
-          - zuc
+        - FedeDP
+        - maxgio92
+        - zuc
         privacy: closed
         repos:
           kernel-crawler: maintain
       kilt-maintainers:
         description: maintainers of falcosecurity/kilt
         members:
-          - gnosek
-          - leodido
-          - admiral0
+        - gnosek
+        - leodido
+        - admiral0
         privacy: closed
         repos:
           kilt: maintain
       libs-maintainers:
         description: maintainers of falcosecurity/libs
         maintainers:
-          - leogr
-          - mstemm
-          - jasondellaluce
+        - leogr
+        - mstemm
+        - jasondellaluce
         members:
-          - gnosek
-          - FedeDP
-          - Molter73
-          - LucaGuerra
-          - Andreagit97
-          - hbrueckner
-          - incertum
+        - gnosek
+        - FedeDP
+        - Molter73
+        - LucaGuerra
+        - Andreagit97
+        - hbrueckner
+        - incertum
         privacy: closed
         repos:
           libs: maintain
       libs-sdk-go-maintainers:
         description: maintainers of falcosecurity/libs-sdk-go
         maintainers:
-          - leogr
+        - leogr
         members:
-          - araujof
-          - jasondellaluce
-          - terylt
-          - Andreagit97
+        - araujof
+        - jasondellaluce
+        - terylt
+        - Andreagit97
         privacy: closed
         repos:
           libs-sdk-go: maintain
       machine_users:
         description: bots
         maintainers:
-          - poiana
+        - poiana
         privacy: closed
         repos:
           .github: admin
@@ -639,97 +633,97 @@ orgs:
       pdig-maintainers:
         description: maintainers of falcosecurity/pdig
         maintainers:
-          - ldegio
+        - ldegio
         members:
-          - gnosek
-          - leodido
+        - gnosek
+        - leodido
         privacy: closed
         repos:
           pdig: maintain
       pigeon-maintainers:
         description: maintainers of falcosecurity/pigeon
         maintainers:
-          - jasondellaluce
+        - jasondellaluce
         members:
-          - cappellinsamuele
-          - fededp
+        - cappellinsamuele
+        - fededp
         privacy: closed
         repos:
           pigeon: maintain
       plugin-sdk-cpp-maintainers:
         description: maintainers of falcosecurity/plugin-sdk-cpp
         maintainers:
-          - ldegio
-          - leogr
-          - mstemm
+        - ldegio
+        - leogr
+        - mstemm
         members:
-          - leodido
-          - FedeDP
+        - leodido
+        - FedeDP
         privacy: closed
         repos:
           plugin-sdk-cpp: maintain
       plugin-sdk-go-maintainers:
         description: maintainers of falcosecurity/plugin-sdk-go
         maintainers:
-          - leogr
+        - leogr
         members:
-          - jasondellaluce
+        - jasondellaluce
         privacy: closed
         repos:
           plugin-sdk-go: maintain
       plugins-maintainers:
         description: maintainers of falcosecurity/plugins
         maintainers:
-          - leogr
-          - mstemm
+        - leogr
+        - mstemm
         members:
-          - jasondellaluce
+        - jasondellaluce
         privacy: closed
         repos:
           plugins: maintain
       rules-maintainers:
         description: maintainers of falcosecurity/rules
         maintainers:
-          - leogr
-          - LucaGuerra
+        - leogr
+        - LucaGuerra
         members:
-          - fededp
-          - jasondellaluce
-          - andreagit97
-          - mstemm
+        - fededp
+        - jasondellaluce
+        - andreagit97
+        - mstemm
         privacy: closed
         repos:
           rules: maintain
       syscalls-bumper-maintainers:
         description: maintainers of falcosecurity/syscalls-bumper
         maintainers:
-          - leogr
+        - leogr
         members:
-          - FedeDP
-          - Andreagit97
+        - FedeDP
+        - Andreagit97
         privacy: closed
         repos:
           syscalls-bumper: maintain
       test-infra-maintainers:
         description: maintainers of falcosecurity/test-infra
         maintainers:
-          - leogr
+        - leogr
         members:
-          - maxgio92
-          - zuc
-          - jonahjon
-          - fededp
+        - maxgio92
+        - zuc
+        - jonahjon
+        - fededp
         privacy: closed
         repos:
           test-infra: maintain
       testing-maintainers:
         description: maintainers of falcosecurity/testing
         maintainers:
-          - jasondellaluce
-          - leogr
+        - jasondellaluce
+        - leogr
         members:
-          - andreagit97
-          - lucaguerra
+        - andreagit97
+        - lucaguerra
         privacy: closed
         repos:
           testing: maintain


### PR DESCRIPTION
This PR synchronizes the Github Team evolution-maintainers with the leaf approvers declared in evolution repository's [OWNERS](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) file.

Autogenerated with [orgs-owners-syncer](https://github.com/maxgio92/orgs-owners-syncer).
