### PR TITLE
Add postsubmit job to sync Peribolos GitHub Teams from OWNERS

### DIFF
--- a/config/jobs/update-github-teams/peribolos-syncer.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer.yaml
@@ -9,7 +9,7 @@ postsubmits:
     run_if_changed: 'OWNERS$'
     spec:
       containers:
-      - image: gcr.io/maxgio92/peribolos-syncer:0.1.0
+      - image: gcr.io/maxgio92/peribolos-syncer:0.2.0
         args:
         - sync
         - github
@@ -20,7 +20,7 @@ postsubmits:
         - --peribolos-config-git-ref=master
         - --owners-repository=evolution
         - --owners-git-ref=main
-        - --owners-path=OWNERS
+        - --approvers-only=true
         - --git-author-name=poiana
         - --git-author-email="51138685+poiana@users.noreply.github.com"
         - --gpg-public-key=/tmp/gpg-pub/poiana.pub

--- a/config/jobs/update-github-teams/peribolos-syncer.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer.yaml
@@ -1,0 +1,116 @@
+postsubmits:
+  falcosecurity/evolution:
+  - name: peribolos-syncer-post-submit
+    branches:
+    - ^main$
+    decorate: true
+    max_concurrency: 1
+    skip_report: false
+    run_if_changed: 'OWNERS$'
+    spec:
+      containers:
+      - image: gcr.io/maxgio92/peribolos-syncer:0.1.0
+        args:
+        - sync
+        - github
+        - --org=falcosecurity
+        - --team=evolution-maintainers
+        - --peribolos-config-path=config/org.yaml
+        - --peribolos-config-repository=test-infra
+        - --peribolos-config-git-ref=master
+        - --owners-repository=evolution
+        - --owners-git-ref=main
+        - --owners-path=OWNERS
+        - --git-author-name=poiana
+        - --git-author-email="51138685+poiana@users.noreply.github.com"
+        - --gpg-public-key=/tmp/gpg-pub/poiana.pub
+        - --gpg-private-key=/tmp/gpg/poiana.asc
+        - --github-username=poiana
+        - --github-endpoint=http://ghproxy.default.svc.cluster.local
+        - --github-endpoint=https://api.github.com
+        - --github-hourly-tokens=1200
+        - --github-token-path=/etc/github-token/oauth
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+        - name: gpg-signing-key
+          mountPath: /tmp/gpg
+          readOnly: true
+        - name: gpg-signing-key-pub
+          mountPath: /tmp/gpg-pub
+          readOnly: true
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token
+      - name: gpg-signing-key
+        secret:
+          secretName: poiana-gpg-signing-key
+          defaultMode: 0400
+      - name: gpg-signing-key-pub
+        secret:
+          secretName: poiana-gpg-signing-key-pub
+          defaultMode: 0400
+      nodeSelector:
+        Archtype: "x86"
+  # Place here other repository OWNERS to synchronize GitHub Team Peribolos configuration from.
+  #
+  # More on this here: https://github.com/maxgio92/peribolos-syncer/blob/v0.1.0/docs/peribolos-syncer_sync_github.md#peribolos-syncer-sync-github
+  #
+  #postsubmits:
+  #  falcosecurity/<REPOSITORY>:
+  #  - name: peribolos-syncer-post-submit
+  #    branches:
+  #    - ^main$
+  #    decorate: true
+  #    max_concurrency: 1
+  #    skip_report: false
+  #    run_if_changed: 'OWNERS$'
+  #    spec:
+  #      containers:
+  #      - image: gcr.io/maxgio92/peribolos-syncer:0.1.0
+  #        args:
+  #        - sync
+  #        - github
+  #        - --org=falcosecurity
+  #        - --team=<REPOSITORY>-maintainers
+  #        - --peribolos-config-path=config/org.yaml
+  #        - --peribolos-config-repository=test-infra
+  #        - --peribolos-config-git-ref=master
+  #        - --owners-repository=<REPOSITORY>
+  #        - --owners-git-ref=main
+  #        - --owners-path=OWNERS
+  #        - --git-author-name=poiana
+  #        - --git-author-email="51138685+poiana@users.noreply.github.com"
+  #        - --gpg-public-key=/tmp/gpg-pub/poiana.pub
+  #        - --gpg-private-key=/tmp/gpg/poiana.asc
+  #        - --github-username=poiana
+  #        - --github-endpoint=http://ghproxy.default.svc.cluster.local
+  #        - --github-endpoint=https://api.github.com
+  #        - --github-hourly-tokens=1200
+  #        - --github-token-path=/etc/github-token/oauth
+  #        volumeMounts:
+  #        - name: github
+  #          mountPath: /etc/github-token
+  #          readOnly: true
+  #        - name: gpg-signing-key
+  #          mountPath: /tmp/gpg
+  #          readOnly: true
+  #        - name: gpg-signing-key-pub
+  #          mountPath: /tmp/gpg-pub
+  #          readOnly: true
+  #      volumes:
+  #      - name: github
+  #        secret:
+  #          secretName: oauth-token
+  #      - name: gpg-signing-key
+  #        secret:
+  #          secretName: poiana-gpg-signing-key
+  #          defaultMode: 0400
+  #      - name: gpg-signing-key-pub
+  #        secret:
+  #          secretName: poiana-gpg-signing-key-pub
+  #          defaultMode: 0400
+  #      nodeSelector:
+  #        Archtype: "x86"


### PR DESCRIPTION
The post-submit Prow Job runs on changes on OWNERS files - i.e. in the evolution repository.

It synchronizes the Peribolos config - in the test-infra repository - updating the specified evolution-maintainers GitHub Team, with the additional approvers specified in the OWNERS file.

More [here](https://github.com/maxgio92/peribolos-syncer/blob/v0.1.0/docs/peribolos-syncer_sync_github.md#peribolos-syncer-sync-github).

Closes #777 