### PR TITLE
fix(iam): add CloudFront permissions to S3 access

### DIFF
--- a/config/clusters/iam.tf
+++ b/config/clusters/iam.tf
@@ -302,6 +302,16 @@ data "aws_iam_policy_document" "falco_dev_s3_access" {
       "arn:aws:s3:::falco-distribution/packages/*-dev/",
     ]
   }
+  statement {
+    sid    = "BuildFalcoDevCloudFrontAccess"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation"
+    ]
+    resources = [
+      "arn:aws:cloudfront::292999226676:distribution/E1CQNPFWRXLGQD"
+    ]
+  }
 }
 
 # Falco repository (releases)
@@ -339,6 +349,16 @@ data "aws_iam_policy_document" "falco_s3_access" {
     resources = [
       "arn:aws:s3:::falco-distribution/packages/*",
       "arn:aws:s3:::falco-distribution/packages/",
+    ]
+  }
+  statement {
+    sid    = "BuildFalcoCloudFrontAccess"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation"
+    ]
+    resources = [
+      "arn:aws:cloudfront::292999226676:distribution/E1CQNPFWRXLGQD"
     ]
   }
 }
@@ -391,41 +411,6 @@ data "aws_iam_policy_document" "falco_ecr_access" {
       "sts:GetServiceBearerToken"
     ]
     resources = ["*"]
-  }
-}
-
-# Falco repository (CloudFront)
-
-module "falco_cloudfront_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  name    = "github_actions-falco-cloudfront"
-  version = "5.10.0"
-  create = true
-  subjects = [
-    "falco/falco:ref:refs/heads/master",
-    "falco/falco:ref:refs/tags/*"
-  ]
-  policies = {
-    falco_cloudfront_access = "${aws_iam_policy.falco_cloudfront_access.arn}"
-  }
-}
-
-resource "aws_iam_policy" "falco_cloudfront_access" {
-  name_prefix = "github_actions-falco-cloudfront"
-  description = "GitHub actions CloudFront access policy for falco"
-  policy      = data.aws_iam_policy_document.falco_cloudfront_access.json
-}
-
-data "aws_iam_policy_document" "falco_cloudfront_access" {
-  statement {
-    sid    = "BuildFalcoCloudFrontAccess"
-    effect = "Allow"
-    actions = [
-      "cloudfront:CreateInvalidation"
-    ]
-    resources = [
-      "arn:aws:cloudfront::292999226676:distribution/E1CQNPFWRXLGQD"
-    ]
   }
 }
 


### PR DESCRIPTION
CloudFront cannot be a separate role but rather an addition to the S3 one, since S3 updates and CF invaliation happen in the same step.