### PR TITLE
update(config): remove a no more required job for libs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -257,7 +257,6 @@ branch-protection:
               - "build-libs-linux-amd64 😁 (system_deps_minimal)"
               - "build-libs-linux-amd64-asan 🧐"
               - "test-drivers-x86 😇 (bundled_deps)"
-              - "build-modern-bpf-s390x 😁 (system_deps)"
           branches:
             master:
               protect: true


### PR DESCRIPTION
This PR removes a  no more required job on libs, instead of `build-modern-bpf-s390x 😁 (system_deps)`  no we use `build-libs-s390x 😁 (system_deps)`