### PR TITLE
cleanup(config/clusters/ecr.tf): autobump ecr force delete.

### DIFF
--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -28,6 +28,7 @@ resource "aws_ecr_repository" "docker_dind" {
 
 resource "aws_ecr_repository" "autobump" {
   name = "test-infra/autobump"
+  force_delete = true
   encryption_configuration {
     encryption_type = "KMS"
   }


### PR DESCRIPTION
This PR forces delete `autobump` ecr resource.