### PR TITLE
update(iam): allow dev role for prerelease tags

### DIFF
--- a/config/clusters/iam.tf
+++ b/config/clusters/iam.tf
@@ -273,7 +273,8 @@ module "falco_dev_s3_role" {
   name = "github_actions-falco-dev-s3"
   create = true
   subjects = [
-    "falcosecurity/falco:ref:refs/heads/master"
+    "falcosecurity/falco:ref:refs/heads/master",
+    "falcosecurity/falco:ref:refs/tags/*"
   ]
   policies = {
     falco_s3_access = "${aws_iam_policy.falco_dev_s3_access.arn}"


### PR DESCRIPTION
When this role was set up we could only write to the `-dev` bucket from the master branch in Falco. This has since changed because prerelease support has been added which allow us to use development tags that will ultimately end up in the `-dev` bucket. Meaning that we need to add the appropriate permission here.