### PR TITLE
chore(drivekit/configs): needed to trigger building job for minikube …

### DIFF
--- a/driverkit/config/5.0.1+driver/x86_64/minikube_5.10.57_1_1.30.1.yaml
+++ b/driverkit/config/5.0.1+driver/x86_64/minikube_5.10.57_1_1.30.1.yaml
@@ -1,4 +1,4 @@
-kernelversion: 1_1.30.1
+kernelversion: 1_1.30.1 
 kernelrelease: 5.10.57
 target: minikube
 architecture: amd64


### PR DESCRIPTION
chore(drivekit/configs): needed to trigger building job for minikube drivers