### PR TITLE
update(config): updated autobump image version and configuration.

### DIFF
--- a/config/autobump-config/prow-autobump-config.yaml
+++ b/config/autobump-config/prow-autobump-config.yaml
@@ -11,6 +11,8 @@ upstreamURLBase: "https://raw.githubusercontent.com/falcosecurity/test-infra/mas
 targetVersion: "latest"
 includedConfigPaths:
   - "."
+excludedConfigPaths:
+  - "driverkit/"
 prefixes:
   - name: "Prow"
     prefix: "gcr.io/k8s-prow/"

--- a/config/jobs/autobump/autobump.yaml
+++ b/config/jobs/autobump/autobump.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - cron: "05 15 * * 2"  # Run at 15:05 PST (15:05 UTC) Mon
+  - cron: "05 15 * * 1"  # Run at 15:05 PST (15:05 UTC) Mon
     name: ci-test-infra-autobump-prow
     decorate: true
     extra_refs:
@@ -8,7 +8,7 @@ periodics:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/generic-autobumper:v20230509-5e039b951c
+      - image: gcr.io/k8s-prow/generic-autobumper:latest
         command:
         - generic-autobumper
         args:


### PR DESCRIPTION
This PR updates the autobumper image and configuration to make Poiana signing its commits (see [#29591](https://github.com/kubernetes/test-infra/pull/29591)) and to exclude from the analysis the `driverkit` path.