### PR TITLE
chore(config/prow/arc): increment falco arm64 runners replicas.

### DIFF
--- a/config/prow/arc/arm-runner.yaml
+++ b/config/prow/arc/arm-runner.yaml
@@ -3,7 +3,7 @@ kind: RunnerDeployment
 metadata:
   name: falco-runner-arm64
 spec:
-  replicas: 1
+  replicas: 5
   template:
     spec:
       dockerdWithinRunnerContainer: true

--- a/config/prow/arc/arm-runner.yaml
+++ b/config/prow/arc/arm-runner.yaml
@@ -3,7 +3,6 @@ kind: RunnerDeployment
 metadata:
   name: falco-runner-arm64
 spec:
-  replicas: 5
   template:
     spec:
       dockerdWithinRunnerContainer: true
@@ -21,3 +20,18 @@ spec:
         operator: "Equal"
         value: "SingleAZ"
         effect: "NoSchedule"
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: falco-runner-arm64-autoscaler
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: falco-runner-arm64
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - falco


### PR DESCRIPTION
This way, we can support: PR CI on arm64 and master/release CI static arm64 binary.