### PR TITLE
cleanup(config/clusters/ecr.tf): removed old autobumper ecr resource.

### DIFF
--- a/config/clusters/TERRAFORM.md
+++ b/config/clusters/TERRAFORM.md
@@ -42,7 +42,6 @@
 | [aws_acm_certificate.deck](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
 | [aws_acm_certificate.monitor_prow](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
 | [aws_dynamodb_table.falco-test-infra-state-lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
-| [aws_ecr_repository.autobump](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.build_drivers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.build_plugins](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.docker_dind](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
@@ -51,7 +50,6 @@
 | [aws_ecr_repository.update_deployment_files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.update_jobs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.update_rules_index](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
-| [aws_ecr_repository_policy.autobump](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.build_drivers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.build_plugins](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.docker_dind](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |

--- a/config/clusters/ecr-iam.tf
+++ b/config/clusters/ecr-iam.tf
@@ -41,11 +41,6 @@ resource "aws_ecr_repository_policy" "docker_dind" {
   policy     = data.aws_iam_policy_document.ecr_standard.json
 }
 
-resource "aws_ecr_repository_policy" "autobump" {
-  repository = aws_ecr_repository.autobump.name
-  policy     = data.aws_iam_policy_document.ecr_standard.json
-}
-
 resource "aws_ecr_repository_policy" "build_plugins" {
   repository = aws_ecr_repository.build_plugins.name
   policy     = data.aws_iam_policy_document.ecr_standard.json

--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -26,14 +26,6 @@ resource "aws_ecr_repository" "docker_dind" {
   }
 }
 
-resource "aws_ecr_repository" "autobump" {
-  name = "test-infra/autobump"
-  force_delete = true
-  encryption_configuration {
-    encryption_type = "KMS"
-  }
-}
-
 resource "aws_ecr_repository" "build_plugins" {
   name = "test-infra/build-plugins"
   encryption_configuration {

--- a/docs/update-cluster.md
+++ b/docs/update-cluster.md
@@ -64,7 +64,7 @@
 
 ## Prow resources
 
-- Some resources get updated by the weekly job https://prow.falco.org/job-history/s3/falco-prow-logs/logs/ci-prow-autobump
+- Some resources get updated by the weekly job https://prow.falco.org/job-history/s3/falco-prow-logs/logs/ci-test-infra-autobump-prow
 - One's that are not udated and must be done manually
 - - [Check config](../config/prow/check-config.yaml)
 - - [Prowjob CRD](../config/prow/prowjob_custromresourcedefinition.yaml)

--- a/tools/create_ecr.sh
+++ b/tools/create_ecr.sh
@@ -6,6 +6,5 @@ aws ecr create-repository --repository-name test-infra/update-jobs || true
 aws ecr create-repository --repository-name test-infra/golang || true
 aws ecr create-repository --repository-name test-infra/build-drivers || true
 aws ecr create-repository --repository-name test-infra/docker-dind || true
-aws ecr create-repository --repository-name test-infra/autobump || true
 aws ecr create-repository --repository-name test-infra/update-maintainers || true
 aws ecr create-repository --repository-name test-infra/build-plugins || true


### PR DESCRIPTION
Completes #1132 and #1133 .