### PR TITLE
update(config.yaml): drop non-existent required job from falco

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -146,7 +146,6 @@ branch-protection:
           required_status_checks:
             contexts:
               - "test-dev-packages"
-              - "test-dev-packages-arm64"
               # note: we don't need build jobs, since tests depends on them
           branches:
             master:


### PR DESCRIPTION
The `test-dev-packages-arm64` is not existent when running workflows on PRs for Falco.