### PR TITLE
new: allow pushing to ECR falco-driver-loader-legacy and falco-distroless

### DIFF
--- a/config/clusters/iam.tf
+++ b/config/clusters/iam.tf
@@ -403,7 +403,9 @@ data "aws_iam_policy_document" "falco_ecr_access" {
     resources = [
       "arn:aws:ecr-public::292999226676:repository/falco",
       "arn:aws:ecr-public::292999226676:repository/falco-driver-loader",
-      "arn:aws:ecr-public::292999226676:repository/falco-no-driver"
+      "arn:aws:ecr-public::292999226676:repository/falco-no-driver",
+      "arn:aws:ecr-public::292999226676:repository/falco-driver-loader-legacy",
+      "arn:aws:ecr-public::292999226676:repository/falco-distroless"
     ]
   }
   statement {


### PR DESCRIPTION
For Falco 0.36.0 we plan to distribute two new images:
* falco-driver-loader-legacy which will contain the old driver loader, for compatibility with older kernel
* falco-distroless which will contain an experimental minimal image to reduce attack surface

Add those to ECR