### PR TITLE
new(tf): add Falco ECR public repositories

### DIFF
--- a/config/distribution/containers.tf
+++ b/config/distribution/containers.tf
@@ -39,3 +39,93 @@ resource "aws_ecrpublic_repository" "falcosidekick_ui" {
     prevent_destroy = true
   }
 }
+
+data "http" "falco_readme" {
+  url = "https://raw.githubusercontent.com/falcosecurity/falco/master/README.md"
+}
+
+resource "aws_ecrpublic_repository" "falco" {
+  provider = aws.us
+
+  repository_name = "falco"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecrpublic_repository" "falco_driver_loader" {
+  provider = aws.us
+
+  repository_name = "falco-driver-loader"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecrpublic_repository" "falco_no_driver" {
+  provider = aws.us
+
+  repository_name = "falco-no-driver"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecrpublic_repository" "falco_distroless" {
+  provider = aws.us
+
+  repository_name = "falco-distroless"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecrpublic_repository" "falco_driver_loader_legacy" {
+  provider = aws.us
+
+  repository_name = "falco-driver-loader-legacy"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+


### PR DESCRIPTION
The Terraform distribution configuration was missing entries for `falco` and `falco-driver-loader`.

In addition, add the following images:
* falco-driver-loader-legacy for the older driver loader image
* falco-distroless for the experimental distroless/minimal image