### PR TITLE
update(tf): update distribution config to be consistent with the current state

### DIFF
--- a/config/distribution/containers.tf
+++ b/config/distribution/containers.tf
@@ -44,57 +44,6 @@ data "http" "falco_readme" {
   url = "https://raw.githubusercontent.com/falcosecurity/falco/master/README.md"
 }
 
-resource "aws_ecrpublic_repository" "falco" {
-  provider = aws.us
-
-  repository_name = "falco"
-
-  catalog_data {
-    description       = "Container Native Runtime Security for Cloud Native Platforms"
-    about_text        = substr(data.http.falco_readme.body, 0, 10240)
-    architectures     = ["x86-64", "ARM 64"]
-    operating_systems = ["Linux"]
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-resource "aws_ecrpublic_repository" "falco_driver_loader" {
-  provider = aws.us
-
-  repository_name = "falco-driver-loader"
-
-  catalog_data {
-    description       = "Container Native Runtime Security for Cloud Native Platforms"
-    about_text        = substr(data.http.falco_readme.body, 0, 10240)
-    architectures     = ["x86-64", "ARM 64"]
-    operating_systems = ["Linux"]
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-resource "aws_ecrpublic_repository" "falco_no_driver" {
-  provider = aws.us
-
-  repository_name = "falco-no-driver"
-
-  catalog_data {
-    description       = "Container Native Runtime Security for Cloud Native Platforms"
-    about_text        = substr(data.http.falco_readme.body, 0, 10240)
-    architectures     = ["x86-64", "ARM 64"]
-    operating_systems = ["Linux"]
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "aws_ecrpublic_repository" "falco_distroless" {
   provider = aws.us
 

--- a/config/distribution/containers.tf
+++ b/config/distribution/containers.tf
@@ -44,6 +44,57 @@ data "http" "falco_readme" {
   url = "https://raw.githubusercontent.com/falcosecurity/falco/master/README.md"
 }
 
+resource "aws_ecrpublic_repository" "falco" {
+  provider = aws.us
+
+  repository_name = "falco"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecrpublic_repository" "falco_driver_loader" {
+  provider = aws.us
+
+  repository_name = "falco-driver-loader"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecrpublic_repository" "falco_no_driver" {
+  provider = aws.us
+
+  repository_name = "falco-no-driver"
+
+  catalog_data {
+    description       = "Container Native Runtime Security for Cloud Native Platforms"
+    about_text        = substr(data.http.falco_readme.body, 0, 10240)
+    architectures     = ["x86-64", "ARM 64"]
+    operating_systems = ["Linux"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_ecrpublic_repository" "falco_distroless" {
   provider = aws.us
 

--- a/config/distribution/distribution.tf
+++ b/config/distribution/distribution.tf
@@ -42,6 +42,16 @@ EOF
     max_age_seconds = 3000
   }
 
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+      
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }
@@ -78,6 +88,16 @@ resource "aws_s3_bucket" "logging_bucket" {
 
   tags = {
     Name = var.logging_bucket_name
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+      
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 

--- a/config/distribution/terraform_state.tf
+++ b/config/distribution/terraform_state.tf
@@ -6,6 +6,16 @@ resource "aws_s3_bucket" "falco-distribution-state-bucket" {
   lifecycle {
     prevent_destroy = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+      
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_dynamodb_table" "falco-distribution-state-bucket-lock" {

--- a/config/distribution/terraform_versions.tf
+++ b/config/distribution/terraform_versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.14.11"
+  required_version = ">=1.3.7"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This updates terraform for distribution:
* The tf version is updated, the same we use for Prow
* I removed the three repos that were apparently created without tf as terraform refuses to touch those. I wonder if we can fix it?
* I added encryption configuration to the buckets to reflect what is already live (those configs result in no change when applied)