### PR TITLE
chore(config/jobs): workaround #1158

### DIFF
--- a/config/jobs/build-drivers/build-new-almalinux.yaml
+++ b/config/jobs/build-drivers/build-new-almalinux.yaml
@@ -48,7 +48,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/almalinux_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/almalinux_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -88,7 +88,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/almalinux_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/almalinux_.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-amazonlinux.yaml
+++ b/config/jobs/build-drivers/build-new-amazonlinux.yaml
@@ -159,7 +159,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/amazonlinux_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/amazonlinux_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -199,7 +199,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/amazonlinux_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/amazonlinux_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -243,7 +243,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/amazonlinux2_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/amazonlinux2_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -283,7 +283,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/amazonlinux2_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/amazonlinux2_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -327,7 +327,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/amazonlinux2022_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/amazonlinux2022_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -367,7 +367,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/amazonlinux2022_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/amazonlinux2022_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -408,7 +408,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/amazonlinux2023_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/amazonlinux2023_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -445,7 +445,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/amazonlinux2023_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/amazonlinux2023_.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-bottlerocket.yaml
+++ b/config/jobs/build-drivers/build-new-bottlerocket.yaml
@@ -48,7 +48,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/bottlerocket_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/bottlerocket_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -88,7 +88,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/bottlerocket_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/bottlerocket_.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-centos.yaml
+++ b/config/jobs/build-drivers/build-new-centos.yaml
@@ -201,7 +201,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/centos_2.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/centos_2.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -242,7 +242,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/centos_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/centos_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -283,7 +283,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/centos_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/centos_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -328,7 +328,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/centos_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/centos_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -369,7 +369,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/centos_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/centos_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -414,7 +414,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/centos_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/centos_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -455,7 +455,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/centos_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/centos_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -500,7 +500,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/centos_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/centos_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -541,7 +541,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/centos_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/centos_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-debian.yaml
+++ b/config/jobs/build-drivers/build-new-debian.yaml
@@ -48,7 +48,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/debian_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/debian_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -88,7 +88,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/debian_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/debian_.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-fedora.yaml
+++ b/config/jobs/build-drivers/build-new-fedora.yaml
@@ -48,7 +48,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/fedora_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/fedora_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -88,7 +88,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/fedora_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/fedora_.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-minikube.yaml
+++ b/config/jobs/build-drivers/build-new-minikube.yaml
@@ -48,7 +48,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/minikube_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/minikube_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -88,7 +88,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/minikube_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/minikube_.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-talos.yaml
+++ b/config/jobs/build-drivers/build-new-talos.yaml
@@ -48,7 +48,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/talos_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/talos_.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -88,7 +88,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/talos_.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/talos_.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-aws.yaml
@@ -163,7 +163,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-aws_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-aws_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -204,7 +204,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-aws_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-aws_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -249,7 +249,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-aws_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-aws_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -290,7 +290,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-aws_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-aws_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -335,7 +335,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-aws_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-aws_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -376,7 +376,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-aws_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-aws_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -421,7 +421,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-aws_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-aws_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -462,7 +462,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-aws_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-aws_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-azure.yaml
@@ -163,7 +163,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-azure_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-azure_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -204,7 +204,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-azure_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-azure_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -249,7 +249,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-azure_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-azure_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -290,7 +290,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-azure_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-azure_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -335,7 +335,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-azure_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-azure_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -376,7 +376,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-azure_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-azure_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -421,7 +421,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-azure_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-azure_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -462,7 +462,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-azure_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-azure_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gcp.yaml
@@ -163,7 +163,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gcp_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gcp_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -204,7 +204,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gcp_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gcp_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -249,7 +249,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gcp_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gcp_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -290,7 +290,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gcp_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gcp_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -335,7 +335,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gcp_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gcp_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -376,7 +376,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gcp_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gcp_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -421,7 +421,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gcp_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gcp_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -462,7 +462,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gcp_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gcp_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-generic.yaml
@@ -163,7 +163,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-generic_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-generic_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -204,7 +204,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-generic_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-generic_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -249,7 +249,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-generic_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-generic_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -290,7 +290,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-generic_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-generic_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -335,7 +335,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-generic_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-generic_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -376,7 +376,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-generic_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-generic_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -421,7 +421,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-generic_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-generic_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -462,7 +462,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-generic_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-generic_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:

--- a/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
+++ b/config/jobs/build-drivers/build-new-ubuntu-gke.yaml
@@ -163,7 +163,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gke_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gke_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -204,7 +204,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gke_3.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gke_3.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -249,7 +249,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gke_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gke_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -290,7 +290,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gke_4.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gke_4.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -335,7 +335,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gke_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gke_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -376,7 +376,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gke_5.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gke_5.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -421,7 +421,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/ubuntu-gke_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #x86_64/ubuntu-gke_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:
@@ -462,7 +462,7 @@ postsubmits:
     agent: kubernetes
     branches:
       - ^master$
-    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/ubuntu-gke_6.+'
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/' #aarch64/ubuntu-gke_6.+'
     spec:
       serviceAccountName: driver-kit
       containers:


### PR DESCRIPTION
Proposed way to workaround #1158 , even if this is not a real fix: trigger all build-drivers jobs on any new config.
See https://github.com/falcosecurity/test-infra/issues/1158#issuecomment-1710018485

PROs:
* super easy workaround

CONs:
* we will spawn useless pods
* we will spawn more nodes than needed

However, please note that:
* nowadays, since kernel-crawler automation was implemented, we rarely have PRs with a single config being added (it did not happen in 1yr)
* normally, we trigger the build of drivers when: either the kernel-crawler automation triggers, or we add a new driver version; those jobs normally trigger most of our jobs (~90/100%), therefore spawning all pods in this case would make no real difference
* Only case where we would scale badly is when we manually run the kernel-crawler automation against a single distro; in this case, instead of only triggering the distro build-drivers jobs, we would trigger all (even if `skip existing` prevent us from rebuilding everything of course)

In this PR, i trigger indifferently x86_64 and aarch64 jobs, since when eg: we add a new driver version, we basically only trigger aarch64 jobs before the Github API cuts our list of changed files. 
In that case, to actually trigger x86_64 jobs, we need this fix.