### PR TITLE
update(docker): update Golang base image to 1.21

### DIFF
--- a/images/build-plugins/Dockerfile
+++ b/images/build-plugins/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.18 AS pullrequestcreator
+FROM golang:1.21 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
 
-FROM golang:1.18
+FROM golang:1.21
 
 LABEL usage="docker run -i -t -v /path/to/source:/workspace test-infra/build-plugins"
 

--- a/images/update-dbg/Dockerfile
+++ b/images/update-dbg/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS pullrequestcreator
+FROM golang:1.21 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go

--- a/images/update-dbg/Dockerfile
+++ b/images/update-dbg/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21 AS pullrequestcreator
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
 
-FROM debian:buster
+FROM golang:1.21-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/images/update-falco-k8s-manifests/Dockerfile
+++ b/images/update-falco-k8s-manifests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS pullrequestcreator
+FROM golang:1.21 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go

--- a/images/update-falco-k8s-manifests/Dockerfile
+++ b/images/update-falco-k8s-manifests/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21 AS pullrequestcreator
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && go build -v -o pr-creator ./main.go
 
-FROM debian:buster
+FROM golang:1.21-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/images/update-maintainers/Dockerfile
+++ b/images/update-maintainers/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.18 AS pullrequestcreator
+FROM golang:1.21 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
 
-FROM golang:1.18 AS maintainersgenerator
+FROM golang:1.21 AS maintainersgenerator
 
 RUN wget -qO- "https://api.github.com/repos/leodido/maintainers-generator/releases/latest" | grep -Po '"browser_download_url": "\K.*?(?=")' | xargs wget -qO- | tar -xvz
 
-FROM golang:1.18-buster
+FROM golang:1.21-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/images/update-rules-index/Dockerfile
+++ b/images/update-rules-index/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.18 AS pullrequestcreator
+FROM golang:1.21 AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
 
-FROM golang:1.18
+FROM golang:1.21
 
 LABEL usage="docker run -i -t -v /path/to/source:/workspace test-infra/update-rules-index"
 


### PR DESCRIPTION
As per title. This is preventing some jobs from running, see e.g. https://prow.falco.org/view/s3/falco-prow-logs/logs/build-plugins-on-registry-changed-postsubmit/1704176676482584576

```
 go: downloading github.com/rivo/uniseg v0.4.4
/home/prow/go/pkg/mod/github.com/pterm/pterm@v0.12.67/slog_handler.go:5:2: package log/slog is not in GOROOT (/usr/local/go/src/log/slog)
make[1]: *** [Makefile:25: registry] Error 1
make[1]: Leaving directory '/home/prow/go/src/github.com/falcosecurity/plugins/build/registry'
make: *** [Makefile:119: build/registry/registry] Error 2
> moving on since there are no changes...
> cloning distribution index repository (https://github.com/falcosecurity/falcoctl.git)...
/tmp /home/prow/go/src/github.com/falcosecurity/plugins
Cloning into 'falcoctl'...
/tmp/falcoctl /tmp /home/prow/go/src/github.com/falcosecurity/plugins
> checkout gh-pages branch...
Switched to a new branch 'gh-pages'
Branch 'gh-pages' set up to track remote branch 'gh-pages' from 'origin'.
/tmp /home/prow/go/src/github.com/falcosecurity/plugins
/home/prow/go/src/github.com/falcosecurity/plugins
make[1]: Entering directory '/home/prow/go/src/github.com/falcosecurity/plugins/build/registry'
/home/prow/go/pkg/mod/github.com/pterm/pterm@v0.12.67/slog_handler.go:5:2: package log/slog is not in GOROOT (/usr/local/go/src/log/slog)
make[1]: *** [Makefile:25: registry] Error 1
make[1]: Leaving directory '/home/prow/go/src/github.com/falcosecurity/plugins/build/registry'
make: *** [Makefile:119: build/registry/registry] Error 2
> pushing distribution index...
/tmp/falcoctl /home/prow/go/src/github.com/falcosecurity/plugins
On branch gh-pages
Your branch is up to date with 'origin/gh-pages'.
nothing to commit, working tree clean
Everything up-to-date
/home/prow/go/src/github.com/falcosecurity/plugins 
```