### PR TITLE
update(config/org.yaml): add therealbobo as kernel-testing maintainer

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -625,6 +625,7 @@ orgs:
           - alacuku
           - Andreagit97
           - FedeDP
+          - therealbobo
         members: []
         privacy: closed
         repos:


### PR DESCRIPTION
Following https://github.com/falcosecurity/kernel-testing/pull/72 this adds me as maintainer of kernel-testing repository. 🥳 