### PR TITLE
chore(config/jobs): move update-dbg to cron type.

### DIFF
--- a/config/jobs/update-dbg/update-dbg.yaml
+++ b/config/jobs/update-dbg/update-dbg.yaml
@@ -1,44 +1,41 @@
-postsubmits:
-  falcosecurity/kernel-crawler:
-    - name: update-dbg
-      decorate: true
-      branches:
-        - ^kernels$
-      run_if_changed: 'list.json$'  
-      extra_refs:
-      # Check out the falcosecurity/test-infra repo
-      # This will be the working directory
-      - org: falcosecurity
-        repo: test-infra
-        base_ref: master
-        workdir: true
-      spec:
-        containers:
-        # See images/update-dbg
-        - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-dbg
-          imagePullPolicy: Always
-          command:
-            - /entrypoint.sh
-          args:
-            - /etc/github-token/oauth
-          env:
-            - name: GH_PROXY
-              value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
-          volumeMounts:
-            - name: github
-              mountPath: /etc/github-token
-              readOnly: true
-            - name: gpg-signing-key
-              mountPath: /root/gpg-signing-key/
-              readOnly: true
-        volumes:
+periodics:
+  - name: update-dbg
+    cron: "0 9 * * *"
+    decorate: true
+    extra_refs:
+    # Check out the falcosecurity/test-infra repo
+    # This will be the working directory
+    - org: falcosecurity
+      repo: test-infra
+      base_ref: master
+      workdir: true
+    spec:
+      containers:
+      # See images/update-dbg
+      - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-dbg
+        imagePullPolicy: Always
+        command:
+          - /entrypoint.sh
+        args:
+          - /etc/github-token/oauth
+        env:
+          - name: GH_PROXY
+            value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+        volumeMounts:
           - name: github
-            secret:
-            # Secret containing a GitHub user access token with `repo` scope for creating PRs.
-              secretName: oauth-token
+            mountPath: /etc/github-token
+            readOnly: true
           - name: gpg-signing-key
-            secret:
-              secretName: poiana-gpg-signing-key
-              defaultMode: 0400
-        nodeSelector:
-          Archtype: "x86"
+            mountPath: /root/gpg-signing-key/
+            readOnly: true
+      volumes:
+        - name: github
+          secret:
+          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+            secretName: oauth-token
+        - name: gpg-signing-key
+          secret:
+            secretName: poiana-gpg-signing-key
+            defaultMode: 0400
+      nodeSelector:
+        Archtype: "x86"


### PR DESCRIPTION
/hold

Following https://github.com/falcosecurity/kernel-crawler/pull/179 discussion, moving `update-dbg` to periodic trigger.
NOTE: kernel-crawler job will run at 6.30 UTC, and the job lasts around 35minutes. This job is triggered at 9 UTC, we have plenty of time :)