### PR TITLE
update(config): unprotect charts gh-pages branch

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -85,12 +85,6 @@ branch-protection:
           branches:
             master:
               protect: true
-            gh-pages:
-              protect: true
-              enforce_admins: false # do not enforce all configured restrictions for admins, since our bot needs to push while the CI workflow is running
-              required_pull_request_reviews: # disable PR reviews since our bot needs to push while the CI workflow is running
-                require_code_owner_reviews: false
-                required_approving_review_count: 0
         client-go:
           branches:
             master:


### PR DESCRIPTION
The branch was protected before and allowed admins (the bot) to push to it. Now we are migrating that job to GitHub Actions, which cannot push to protected branches (https://github.com/orgs/community/discussions/25305). This allows the action to work.