### PR TITLE
new: photonOS support for prebuilt drivers

### DIFF
--- a/config/jobs/build-drivers/build-new-photon.yaml
+++ b/config/jobs/build-drivers/build-new-photon.yaml
@@ -1,0 +1,119 @@
+presubmits:
+  falcosecurity/test-infra:
+  - name: validate-new-drivers-photon-presubmit
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/(.+/)?photon_.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - photon
+        env:
+        - name: DBG_MAKE_BUILD_TARGET
+          value: validate
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
+          requests:
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
+      tolerations:
+      - key: "Availability"
+        operator: "Equal"
+        value: "SingleAZ"
+        effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "x86"
+        Application: "jobs"
+postsubmits:
+  falcosecurity/test-infra:
+  - name: build-new-drivers-photon-postsubmit
+    annotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    error_on_eviction: true
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/x86_64/photon_.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - photon
+        env:
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
+          requests:
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
+      tolerations:
+      - key: "Availability"
+        operator: "Equal"
+        value: "SingleAZ"
+        effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "x86"
+        Application: "jobs"
+  - name: build-new-drivers-photon-postsubmit-arm
+    annotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    error_on_eviction: true
+    decorate: true
+    skip_report: false
+    agent: kubernetes
+    branches:
+      - ^master$
+    run_if_changed: '^driverkit/config/[a-z0-9.+-]{5,}/aarch64/photon_.+'
+    spec:
+      serviceAccountName: driver-kit
+      containers:
+      - command:
+        - /workspace/build-drivers.sh
+        - photon
+        env:
+        - name: PUBLISH_S3
+          value: "true"
+        image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/build-drivers:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 1.0
+            memory: 4Gi
+          requests:
+            cpu: 750m #m5large is 2vpcu and 8gb ram so this is 37.5% of a node
+            memory: 2Gi
+      tolerations:
+      - key: "Archtype"
+        operator: "Equal"
+        value: "arm"
+        effect: "NoSchedule"
+      - key: "Availability"
+        operator: "Equal"
+        value: "SingleAZ"
+        effect: "NoSchedule"
+      nodeSelector:
+        Archtype: "arm"
+        Application: "jobs"

--- a/config/jobs/update-dbg/update-dbg.yaml
+++ b/config/jobs/update-dbg/update-dbg.yaml
@@ -1,6 +1,6 @@
 periodics:
   - name: update-dbg
-    cron: "0 9 * * *"
+    cron: "0 8 * * *"
     decorate: true
     extra_refs:
     # Check out the falcosecurity/test-infra repo

--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -4,8 +4,8 @@ ARG TARGETARCH
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.12.0/dbg-go_0.12.0_linux_$TARGETARCH.tar.gz \
-    && tar -xvf dbg-go_0.12.0_linux_$TARGETARCH.tar.gz \
+RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.12.1/dbg-go_0.12.1_linux_$TARGETARCH.tar.gz \
+    && tar -xvf dbg-go_0.12.1_linux_$TARGETARCH.tar.gz \
     && chmod +x dbg-go \
     && mv dbg-go /bin/dbg-go
 

--- a/images/build-drivers/build-drivers.sh
+++ b/images/build-drivers/build-drivers.sh
@@ -61,7 +61,7 @@ function build_and_publish() {
 	done
 	
 	pretty_echo "Running DBG build with target $DBG_MAKE_BUILD_TARGET..."
-	if [[ "$DBG_MAKE_BUILD_TARGET" == "build" ]]; then
+	if [[ "$DBG_MAKE_BUILD_TARGET" = "build" ]]; then
 		# when building, ignore errors (just report them back to driverkit/output/failing.log)
 		DBG_MAKE_BUILD_OPTIONS="${DBG_MAKE_BUILD_OPTIONS} --ignore-errors --skip-existing --redirect-errors=driverkit/output/failing.log"
 		# If requested, publish too!

--- a/images/update-dbg/Dockerfile
+++ b/images/update-dbg/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     && apt-get clean
 
-RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.12.0/dbg-go_0.12.0_linux_amd64.tar.gz \
-    && tar -xvf dbg-go_0.12.0_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.12.1/dbg-go_0.12.1_linux_amd64.tar.gz \
+    && tar -xvf dbg-go_0.12.1_linux_amd64.tar.gz \
     && chmod +x dbg-go \
     && mv dbg-go /bin/dbg-go
 


### PR DESCRIPTION
Moreover:
* bumped dbg-go to 0.12.1 (for photon support + a fix)
* use `=` instead of the bash specific `==` for string comparison in build-drivers.sh
* Move `update-dbg` cron to 8am