### PR TITLE
update(config): temporarily remove required from asan build

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -287,7 +287,6 @@ branch-protection:
               - "build-libs-linux-arm64 😁 (bundled_deps)"
               - "build-libs-linux-arm64 😁 (system_deps_w_chisels)"
               - "build-libs-linux-arm64 😁 (system_deps_minimal)"
-              - "build-libs-linux-amd64-asan 🧐"
               - "test-drivers-amd64 😇 (bundled_deps)"
               - "test-drivers-arm64 😇 (bundled_deps)"
               - "test-libs-static (bundled_deps)"


### PR DESCRIPTION
This is in preparation for https://github.com/falcosecurity/libs/pull/1685 . That PR changes the name of the ASan job (which becomes `sanitizers`) and adds its ARM64 counterpart. After libs#1685 is merged we'll be able to add the new jobs as required.