### PR TITLE
new(tf): add EKS permissions for GitHub Actions

### DIFF
--- a/config/clusters/eks.tf
+++ b/config/clusters/eks.tf
@@ -7,6 +7,7 @@ module "eks" {
   subnets                   = module.vpc.private_subnets
   write_kubeconfig          = true
   map_users                 = var.eks_users
+  map_roles                 = var.eks_roles
   enable_irsa               = true
   cluster_enabled_log_types = ["audit"]
 

--- a/config/clusters/eks_variables.tf
+++ b/config/clusters/eks_variables.tf
@@ -150,3 +150,19 @@ variable "eks_users" {
     }
   ]
 }
+variable "eks_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type = list(object({
+    rolearn = string
+    username = string
+    groups = list(string)
+  }))
+
+  default = [
+    {
+      rolearn  = "arn:aws:iam::292999226676:role/github_actions-test-infra-cluster"
+      username = "githubactions-test-infra-cluster"
+      groups   = ["system:masters"]
+    },
+  ]
+}


### PR DESCRIPTION
As per title. GitHub Actions needs permission in order to update the EKS cluster.