### PR TITLE
chore(k8s): add role binding to read aws-auth configmap

### DIFF
--- a/config/prow/aws-auth-config-rbac.yaml
+++ b/config/prow/aws-auth-config-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aws-auth-config-reader
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["aws-auth"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-auth-config-reader
+  namespace: kube-system
+subjects:
+- kind: Group
+  name: aws-config-readers
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: aws-auth-config-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR contains the following RBAC setup:
- one `Role` that allows to read (`GET`) the _aws-auth_ `ConfigMap` that contains the AWS identity mappings to the Kubernetes Groups.
- one `RoleBinding` that binds the Role above to the `Group` _aws-config-readers_.

**Use cases**

The first use case for that is the GitHub Actions identity that will run the Terraform Plan that in our case needs to:
- read over AWS resources.
- read (get) the _aws-auth_ `ConfigMap` because it's part of the EKS setup managed via Terraform ([here](https://github.com/falcosecurity/test-infra/blob/f5a4efaafd32564f7261dc3b9515b45e03240722/config/clusters/eks.tf#L10) and [here](https://github.com/falcosecurity/test-infra/blob/f5a4efaafd32564f7261dc3b9515b45e03240722/config/clusters/eks_variables.tf#L148)).

The mapping of the infra reader AWS role (of the use case just mentioned) to the Kubernetes Group _aws-config-readers_ will be addressed in the [dedicated PR](https://github.com/falcosecurity/test-infra/pull/1212).