### PR TITLE
fix(clusters/iam): set correct oidc subject for prs

### DIFF
--- a/config/clusters/iam.tf
+++ b/config/clusters/iam.tf
@@ -266,7 +266,7 @@ module "test-infra_reader" {
   name    = "github_actions-test-infra-reader"
   create  = true
   subjects = [
-    "falcosecurity/test-infra:ref:*"
+    "falcosecurity/test-infra:pull_request"
   ]
   policies = {
     test-infra_read_access = "arn:aws:iam::aws:policy/ReadOnlyAccess"


### PR DESCRIPTION
As for official Github [documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#filtering-for-pull_request-events), the OIDC subject for pull requests needs to be updated AWS side to allow Github Actions to assume the AWS IAM Role needed to read resources during Terraform Plan.

In example, when the authentication is made during a workflow triggered by a pull request, the subject is structured like below:
`repo:<orgName/repoName>:pull_request`