### PR TITLE
fix(config/jobs/update-github-teams): set correct trigger branch

### DIFF
--- a/config/jobs/update-github-teams/peribolos-syncer-client-go.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-client-go.yaml
@@ -6,7 +6,7 @@ postsubmits:
   falcosecurity/client-go:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false

--- a/config/jobs/update-github-teams/peribolos-syncer-driverkit.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-driverkit.yaml
@@ -6,7 +6,7 @@ postsubmits:
   falcosecurity/driverkit:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false

--- a/config/jobs/update-github-teams/peribolos-syncer-falco-website.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-falco-website.yaml
@@ -6,7 +6,7 @@ postsubmits:
   falcosecurity/falco-website:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false

--- a/config/jobs/update-github-teams/peribolos-syncer-falco.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-falco.yaml
@@ -2,7 +2,7 @@ postsubmits:
   falcosecurity/falco:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false

--- a/config/jobs/update-github-teams/peribolos-syncer-falcosidekick-ui.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-falcosidekick-ui.yaml
@@ -6,7 +6,7 @@ postsubmits:
   falcosecurity/falcosidekick-ui:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false

--- a/config/jobs/update-github-teams/peribolos-syncer-falcosidekick.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-falcosidekick.yaml
@@ -6,7 +6,7 @@ postsubmits:
   falcosecurity/falcosidekick:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false

--- a/config/jobs/update-github-teams/peribolos-syncer-libs.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-libs.yaml
@@ -2,7 +2,7 @@ postsubmits:
   falcosecurity/libs:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false

--- a/config/jobs/update-github-teams/peribolos-syncer-test-infra.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-test-infra.yaml
@@ -6,7 +6,7 @@ postsubmits:
   falcosecurity/test-infra:
   - name: peribolos-syncer-post-submit
     branches:
-    - ^main$
+    - ^master$
     decorate: true
     max_concurrency: 1
     skip_report: false


### PR DESCRIPTION
This PR fixes errors on the update-github-teams jobs trigger branches, that erroneously were set to _main_.