### PR TITLE
chore(config/jobs): set the test presubmit syncer job command

### DIFF
--- a/config/jobs/update-github-teams/peribolos-syncer-test-infra-pre-test.yaml
+++ b/config/jobs/update-github-teams/peribolos-syncer-test-infra-pre-test.yaml
@@ -9,6 +9,8 @@ presubmits:
     spec:
       containers:
       - image: ghcr.io/falcosecurity/peribolos-syncer:0.2.0
+        command:
+        - peribolos-syncer
         args:
         - sync
         - github


### PR DESCRIPTION
This PR explicitely sets the job command to `peribolos-syncer` to the test presubmit syncer job.

/cc @FedeDP 