### PR TITLE
cleanup(config): remove chisel jobs no more required

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -281,12 +281,10 @@ branch-protection:
             contexts:
               - "build-libs-linux-amd64 😁 (system_deps)"
               - "build-libs-linux-amd64 😁 (bundled_deps)"
-              - "build-libs-linux-amd64 😁 (system_deps_w_chisels)"
               - "build-libs-linux-amd64 😁 (system_deps_minimal)"
               - "build-libs-linux-amd64 😁 (sanitizers)"
               - "build-libs-linux-arm64 😁 (system_deps)"
               - "build-libs-linux-arm64 😁 (bundled_deps)"
-              - "build-libs-linux-arm64 😁 (system_deps_w_chisels)"
               - "build-libs-linux-arm64 😁 (system_deps_minimal)"
               - "build-libs-linux-arm64 😁 (sanitizers)"
               - "test-drivers-amd64 😇 (bundled_deps)"


### PR DESCRIPTION
This removes the "Required" mark from the chisel jobs given that the chisel will be deprecated. https://github.com/falcosecurity/libs/issues/1743