### PR TITLE
update(config): let FedeDP become an admin on the falcosecurity.

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -17,6 +17,7 @@ orgs:
       - thelinuxfoundation
       - jasondellaluce
       - LucaGuerra
+      - FedeDP
 
     members:
       - admiral0
@@ -31,7 +32,6 @@ orgs:
       - dwindsor
       - ewilderj
       - EXONER4TED
-      - FedeDP
       - fjogeleit
       - gnosek
       - hbrueckner


### PR DESCRIPTION
Hi everyone!
I'd like to get admin privileges in the org, in the spirit of serving the entire falcosecurity organization.
Working on CIs around the falcosecurity org, i often would love to check eg: the env variables shared with the actions, or just install a self-hosted runner (eg: kernel-testing uses one, libs is going to use one for ppc64le).

For all of the above, i propose myself as an admin in the falcosecurity org.

/cc @leogr 

