### PR TITLE
update(config): adding hmadison to org.yaml

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -35,6 +35,7 @@ orgs:
       - fjogeleit
       - gnosek
       - hbrueckner
+      - hmadison
       - incertum
       - Issif
       - jonahjon


### PR DESCRIPTION
I'm sponsoring and [onboarding](https://github.com/falcosecurity/evolution/blob/main/MAINTAINERS_GUIDELINES.md#onboarding-a-reviewer) @hmadison as a reviewer of the Kafka plugin he's contributing to our organization (see [this comment](https://github.com/falcosecurity/plugins/pull/467#discussion_r1587656949)).

Since he's not yet an [organization member](https://github.com/orgs/falcosecurity/people), I've opened this PR to add him to the member's entry of `org.yaml`. 

@hmadison you will receive a GitHub invitation once this PR is merged.

:pray: 