### PR TITLE
chore(config): cleaning up unexisting user

### DIFF
--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,8 +1,6 @@
 approvers:
   - jonahjon
   - maxgio92
-reviewers:
-  - markyjackson-taulia
 emeritus_approvers:
   - leodido
   - fntlnz

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -44,7 +44,6 @@ orgs:
       - leodido
       - loresuso
       - Lowaiz
-      - markyjackson-taulia
       - maxgio92
       - mfdii
       - mmat11


### PR DESCRIPTION
The following account (of an emeritus maintainer) no longer exists, and https://github.com/markyjackson-taulia doesn't either. So, thus PR is just cleaning it up.

Note: Marky, if you read this, I wanted just to let you know that you will always be welcome here :hugs: 