### PR TITLE
update(driverkit/config):add latest kernel version (6.1.90) for bottlerocket

### DIFF
--- a/driverkit/config/6.0.1+driver/aarch64/bottlerocket_6.1.90_1.yaml
+++ b/driverkit/config/6.0.1+driver/aarch64/bottlerocket_6.1.90_1.yaml
@@ -1,0 +1,9 @@
+kernelversion: "1"
+kernelrelease: 6.1.90
+target: bottlerocket
+architecture: arm64
+output:
+    module: output/6.0.1+driver/aarch64/falco_bottlerocket_6.1.90_1.ko
+    probe: output/6.0.1+driver/aarch64/falco_bottlerocket_6.1.90_1.o
+kernelurls:
+    - https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.90.tar.xz

--- a/driverkit/config/7.0.0+driver/aarch64/bottlerocket_6.1.90_1.yaml
+++ b/driverkit/config/7.0.0+driver/aarch64/bottlerocket_6.1.90_1.yaml
@@ -1,0 +1,9 @@
+kernelversion: "1"
+kernelrelease: 6.1.90
+target: bottlerocket
+architecture: arm64
+output:
+    module: output/7.0.0+driver/aarch64/falco_bottlerocket_6.1.90_1.ko
+    probe: output/7.0.0+driver/aarch64/falco_bottlerocket_6.1.90_1.o
+kernelurls:
+    - https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.90.tar.xz

--- a/driverkit/config/7.2.0+driver/aarch64/bottlerocket_6.1.90_1.yaml
+++ b/driverkit/config/7.2.0+driver/aarch64/bottlerocket_6.1.90_1.yaml
@@ -1,0 +1,9 @@
+kernelversion: "1"
+kernelrelease: 6.1.90
+target: bottlerocket
+architecture: arm64
+output:
+    module: output/7.2.0+driver/aarch64/falco_bottlerocket_6.1.90_1.ko
+    probe: output/7.2.0+driver/aarch64/falco_bottlerocket_6.1.90_1.o
+kernelurls:
+    - https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.90.tar.xz


### PR DESCRIPTION
We encountered an issue where `falco-driver-loader` was failing to download the corresponding version of the Falco driver at the moment. Our OS is bottlerocket with 6.1.90 kernel. It seems that there is a missing build for the latest Bottlerocket release (which was released a few days ago). Hence, I created this Pull Request (PR) in the hope that it will help publish the missing artifact.

```
2024-06-11 06:00:58 INFO  Trying to download a driver.                                                                                                                                           
                   └ url: https://download.falco.org/driver/7.0.0%2Bdriver/x86_64/falco_bottlerocket_6.1.90_1_1.20.1-aws.o                                                                    
 2024-06-11 06:00:58 WARN  Non-200 response from url. code: 404      
```

Note: I am not familiar with the project, and if I have made any mistakes, please kindly correct me. I basically followed the instructions from https://github.com/falcosecurity/test-infra/tree/master/driverkit#q-falco-doesnt-find-the-kernel-module-ebpf-probe-for-my-os-what-do-i-do

Another note: The latest version of Bottlerocket includes updates for three kernel versions. However, I am unaware of the `TARGET_KERNELRELEASE ` for the other two, so I did not patch those. For reference, please see https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.20.1

🙇 