### PR TITLE
update(config): add Aldo Lacuku to cluster maintainers

### DIFF
--- a/config/clusters/eks_variables.tf
+++ b/config/clusters/eks_variables.tf
@@ -142,6 +142,11 @@ variable "eks_users" {
       userarn  = "arn:aws:iam::292999226676:user/luca.guerra"
       username = "luca.guerra"
       groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::292999226676:user/aldo.lacuku"
+      username = "aldo.lacuku"
+      groups   = ["system:masters"]
     }
   ]
 }


### PR DESCRIPTION
After a discussion with @alacuku (Falco Core Maintainer) I learned that he is interested in helping with maintenance of our cluster, incl. adding monitoring and other things. Given his expertise with Kubernetes I'm very happy about that interest 😁 . Also, considering that he is a core maintainer he can be a cluster admin (see [governance](https://github.com/falcosecurity/test-infra/blob/master/proposals/20200925-admins.md#proposal))

Please confirm @alacuku 🙏 