### PR TITLE
chore(ci): switch to kubeconform since kubeval is deprecated.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,14 @@ jobs:
       - name: Checkout test-infra ⤵️
         uses: actions/checkout@v4
 
-      - name: Setup Kubeval ⛓️
-        uses: lra/setup-kubeval@v1.0.1
+      - name: Download kubeconform ⛓️
+        run: |
+          wget https://github.com/yannh/kubeconform/releases/download/v0.6.6/kubeconform-linux-amd64.tar.gz
+          tar -xvf kubeconform-linux-amd64.tar.gz
+          chmod +x kubeconform
         
       - name: yaml config validation 🔍
-        run: kubeval --directories config/prow --ignore-missing-schemas
+        run: ./kubeconform -ignore-filename-pattern ".json" -ignore-missing-schemas -verbose config/prow/
         
   scan-terraform:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Kubeval is no longer maintained since 2021: https://github.com/instrumenta/kubeval
Use the proposed replacement tool: https://github.com/yannh/kubeconform