### PR TITLE
new(config/prow): add pod-identity-webhook

### DIFF
--- a/config/prow/pod-identity-webhook/auth.yaml
+++ b/config/prow/pod-identity-webhook/auth.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+  - patch
+  resourceNames:
+  - "pod-identity-webhook"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-identity-webhook
+subjects:
+- kind: ServiceAccount
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-identity-webhook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-identity-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-identity-webhook
+subjects:
+- kind: ServiceAccount
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook

--- a/config/prow/pod-identity-webhook/deployment-base.yaml
+++ b/config/prow/pod-identity-webhook/deployment-base.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod-identity-webhook
+  template:
+    metadata:
+      labels:
+        app: pod-identity-webhook
+    spec:
+      serviceAccountName: pod-identity-webhook
+      containers:
+      - name: pod-identity-webhook
+        image: amazon/amazon-eks-pod-identity-webhook:v0.5.5
+        imagePullPolicy: Always
+        command:
+        - /webhook
+        - --in-cluster=false
+        - --namespace=default
+        - --service-name=pod-identity-webhook
+        - --annotation-prefix=eks.amazonaws.com
+        - --token-audience=sts.amazonaws.com
+        - --logtostderr
+        volumeMounts:
+        - name: cert
+          mountPath: "/etc/webhook/certs"
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          secretName: pod-identity-webhook-cert
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+spec:
+  secretName: pod-identity-webhook-cert
+  commonName: "pod-identity-webhook.pod-identity-webhook.svc"
+  dnsNames:
+  - "pod-identity-webhook"
+  - "pod-identity-webhook.pod-identity-webhook"
+  - "pod-identity-webhook.pod-identity-webhook.svc"
+  - "pod-identity-webhook.pod-identity-webhook.svc.local"
+  isCA: true
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer

--- a/config/prow/pod-identity-webhook/mutatingwebhook.yaml
+++ b/config/prow/pod-identity-webhook/mutatingwebhook.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: pod-identity-webhook/pod-identity-webhook
+webhooks:
+- name: pod-identity-webhook.amazonaws.com
+  failurePolicy: Ignore
+  clientConfig:
+    service:
+      name: pod-identity-webhook
+      namespace: pod-identity-webhook
+      path: "/mutate"
+  objectSelector:
+    matchExpressions:
+      - key: eks.amazonaws.com/skip-pod-identity-webhook
+        operator: "DoesNotExist"
+        values: []
+  rules:
+  - operations: [ "CREATE" ]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+  sideEffects: None
+  admissionReviewVersions: ["v1beta1"]

--- a/config/prow/pod-identity-webhook/namespace.yaml
+++ b/config/prow/pod-identity-webhook/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pod-identity-webhook

--- a/config/prow/pod-identity-webhook/service.yaml
+++ b/config/prow/pod-identity-webhook/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pod-identity-webhook
+  namespace: pod-identity-webhook
+  annotations:
+    prometheus.io/port: "443"
+    prometheus.io/scheme: "https"
+    prometheus.io/scrape: "true"
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: pod-identity-webhook

--- a/tools/deploy_prow.sh
+++ b/tools/deploy_prow.sh
@@ -40,6 +40,13 @@ function launchEBSCSIDriver() {
   kubectl apply -f "config/prow/ebs-csi-driver/ebs-csi-controller.yaml"
 }
 
+function launchPodIdentityWebhook() {
+  # Create the namespace.
+  kubectl apply -f "config/prow/pod-identity-webhook/namespace.yaml"
+  # Apply the other manifests.
+  kubectl apply -f "config/prow/pod-identity-webhook/"
+}
+
 function launchMetricsServer() {
   # Metrics Server
   local metrics_server_version="v0.4.4"
@@ -74,6 +81,7 @@ function launchProwConfig() {
 function launchConfig(){
   launchEBSCSIDriver
   launchMetricsServer
+  launchPodIdentityWebhook
   launchProwConfig
 }
 


### PR DESCRIPTION
Now the service accounts can be annotated with iam roles in order to get the right permissions.