### PR TITLE
fix(config/autobumper): fixed autobumper config adding `consistentImageExceptions`

### DIFF
--- a/config/autobump-config/prow-autobump-config.yaml
+++ b/config/autobump-config/prow-autobump-config.yaml
@@ -20,3 +20,14 @@ prefixes:
     repo: "https://github.com/kubernetes/test-infra"
     summarise: true
     consistentImages: true
+    consistentImageExceptions:
+      - "gcr.io/k8s-prow/alpine"
+      - "gcr.io/k8s-prow/analyze"
+      - "gcr.io/k8s-prow/commenter"
+      - "gcr.io/k8s-prow/configurator"
+      - "gcr.io/k8s-prow/gcsweb"
+      - "gcr.io/k8s-prow/gencred"
+      - "gcr.io/k8s-prow/git"
+      - "gcr.io/k8s-prow/issue-creator"
+      - "gcr.io/k8s-prow/label_sync"
+      - "gcr.io/k8s-prow/pr-creator"


### PR DESCRIPTION
Porting of upstream https://github.com/kubernetes/test-infra/pull/32420 to fix autobump prow jobs: https://prow.falco.org/view/s3/falco-prow-logs/logs/ci-test-infra-autobump-prow/1816019406883393536