### PR TITLE
update(config): (re)move zig

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -291,12 +291,12 @@ branch-protection:
               - "build-libs-linux-amd64 😁 (bundled_deps)"
               - "build-libs-linux-amd64 😁 (system_deps_minimal)"
               - "build-libs-linux-amd64 😁 (sanitizers)"
-              - "build-libs-linux-amd64 😁 (zig)"
+              # - "build-libs-linux-amd64 😁 (zig)" # temporarily removed
               - "build-libs-linux-arm64 😁 (system_deps)"
               - "build-libs-linux-arm64 😁 (bundled_deps)"
               - "build-libs-linux-arm64 😁 (system_deps_minimal)"
               - "build-libs-linux-arm64 😁 (sanitizers)"
-              - "build-libs-linux-arm64 😁 (zig)"
+              # - "build-libs-linux-arm64 😁 (zig)" # temporarily removed
               - "test-drivers-amd64 😇 (bundled_deps)"
               - "test-drivers-arm64 😇 (bundled_deps)"
               - "test-libs-static (bundled_deps)"


### PR DESCRIPTION
Due to a necessary patch release in libs we need to disable required checks for zig builds since that is not enabled on the release branch. Partially reverts https://github.com/falcosecurity/test-infra/pull/1635 (we know what we doing).