### PR TITLE
Add driver for new hwe ubuntu generic kernel

### DIFF
--- a/driverkit/config/7.3.0+driver/x86_64/ubuntu-generic_5.15.0-124-generic_134~20.01.1.yaml
+++ b/driverkit/config/7.3.0+driver/x86_64/ubuntu-generic_5.15.0-124-generic_134~20.01.1.yaml
@@ -1,0 +1,7 @@
+kernelversion: 134~20.01.1
+kernelrelease: 5.15.0-124-generic
+target: ubuntu-generic
+architecture: amd64
+output:
+    module: output/7.3.0+driver/x86_64/falco_ubuntu-generic_5.15.0-124-generic_134~20.01.1.ko
+    probe: output/7.3.0+driver/x86_64/falco_ubuntu-generic_5.15.0-124-generic_134~20.01.1.o

--- a/driverkit/config/7.3.0+driver/x86_64/ubuntu-generic_5.15.0-130-generic_140~20.01.1.yaml
+++ b/driverkit/config/7.3.0+driver/x86_64/ubuntu-generic_5.15.0-130-generic_140~20.01.1.yaml
@@ -1,0 +1,7 @@
+kernelversion: 140~20.01.1
+kernelrelease: 5.15.0-130-generic
+target: ubuntu-generic
+architecture: amd64
+output:
+    module: output/7.3.0+driver/x86_64/falco_ubuntu-generic_5.15.0-130-generic_140~20.01.1.ko
+    probe: output/7.3.0+driver/x86_64/falco_ubuntu-generic_5.15.0-130-generic_140~20.01.1.o


### PR DESCRIPTION
Was receiving 404 errors from attempting to use a ubuntu-generic HWE kernel. Similar kernel drivers appear to have been built for previous versions, so opening this pull request to create one for my desired kernel