### PR TITLE
update(images/build-plugins): bump base image to golang:1.23-bullseye

### DIFF
--- a/images/build-plugins/Dockerfile
+++ b/images/build-plugins/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21 AS pullrequestcreator
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go
 
-FROM golang:1.21
+FROM golang:1.23-bullseye
 
 LABEL usage="docker run -i -t -v /path/to/source:/workspace test-infra/build-plugins"
 


### PR DESCRIPTION
This is required to satisfy latest build tools requirements and aligns with the golang version used in falcosecurity/plugins repo.