### PR TITLE
fix(images/build-plugins): fix pr-creator

### DIFF
--- a/images/build-plugins/Dockerfile
+++ b/images/build-plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS pullrequestcreator
+FROM golang:1.23-bullseye AS pullrequestcreator
 
 RUN git clone https://github.com/kubernetes/test-infra
 RUN cd test-infra/robots/pr-creator && env GO111MODULE=on go build -v -o pr-creator ./main.go


### PR DESCRIPTION
Trying to fix:
```
> creating pull-request to merge poiana:docs/update-readme-registry-table into main...
pr-creator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by pr-creator)
pr-creator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by pr-creator)
```