### PR TITLE
vote: docs(OWNERS): add alacuku (Aldo Lacuku) to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - zuc
   - fededp
   - LucaGuerra
+  - alacuku
 emeritus_approvers:
   - leodido
   - fntlnz


### PR DESCRIPTION
I would like to propose myself (@alacuku) as a maintainer for the [test-infra](https://github.com/falcosecurity/test-infra) repository. Over time, I have contributed to improving and maintaining the repository, ensuring its stability and efficiency. I am committed to enhancing the project's CI/CD pipelines, automation, and overall infrastructure reliability.
