### PR TITLE
docs(OWNERS): add ekoops to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - fededp
   - LucaGuerra
   - alacuku
+  - ekoops
 emeritus_approvers:
   - leodido
   - fntlnz


### PR DESCRIPTION
I would like to propose myself (@ekoops) as a maintainer for the [test-infra](https://github.com/falcosecurity/test-infra) repository.