### PR TITLE
docs(org.yaml): add `ekoops` to rules and falco-website

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -658,6 +658,7 @@ orgs:
           - jasondellaluce
           - vjjmiras
           - LucaGuerra
+          - ekoops
         privacy: closed
         repos:
           falco-website: maintain
@@ -960,6 +961,7 @@ orgs:
           - andreagit97
           - mstemm
           - darryk10
+          - ekoops
         privacy: closed
         repos:
           rules: maintain


### PR DESCRIPTION
See
- https://github.com/falcosecurity/rules/pull/304
- https://github.com/falcosecurity/falco-website/pull/1491