### PR TITLE
update(members): add Tero Kauppinen (terror96) as member of libs.

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -822,6 +822,7 @@ orgs:
           - geraldcombs
           - irozzo-1A
           - deepskyblue86
+          - terror96
         privacy: closed
         repos:
           libs: maintain


### PR DESCRIPTION
Required by https://github.com/falcosecurity/libs/pull/2631.