### PR TITLE
chore(images)!: bump `dbg-go` to `0.18.0`

### DIFF
--- a/images/build-drivers/Dockerfile
+++ b/images/build-drivers/Dockerfile
@@ -4,8 +4,8 @@ ARG TARGETARCH
 
 ENV PUBLISH_S3="false"
 
-RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.17.0/dbg-go_0.17.0_linux_$TARGETARCH.tar.gz \
-    && tar -xvf dbg-go_0.17.0_linux_$TARGETARCH.tar.gz \
+RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.18.0/dbg-go_0.18.0_linux_$TARGETARCH.tar.gz \
+    && tar -xvf dbg-go_0.18.0_linux_$TARGETARCH.tar.gz \
     && chmod +x dbg-go \
     && mv dbg-go /bin/dbg-go
 

--- a/images/update-dbg/Dockerfile
+++ b/images/update-dbg/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     && apt-get clean
 
-RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.17.0/dbg-go_0.17.0_linux_amd64.tar.gz \
-    && tar -xvf dbg-go_0.17.0_linux_amd64.tar.gz \
+RUN wget -q https://github.com/falcosecurity/dbg-go/releases/download/v0.18.0/dbg-go_0.18.0_linux_amd64.tar.gz \
+    && tar -xvf dbg-go_0.18.0_linux_amd64.tar.gz \
     && chmod +x dbg-go \
     && mv dbg-go /bin/dbg-go
 


### PR DESCRIPTION
Notice that `dgb-go@0.18.0` dropped support for generating config for building legacy eBPF probe drivers.