### PR TITLE
fix(config): add falco-operator chart updater ecr

### DIFF
--- a/config/clusters/TERRAFORM.md
+++ b/config/clusters/TERRAFORM.md
@@ -48,6 +48,7 @@
 | [aws_ecr_repository.golang](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.update_dbg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.update_deployment_files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository.update_falco_operator_chart](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.update_jobs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.update_rules_index](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository_policy.build_drivers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
@@ -56,6 +57,7 @@
 | [aws_ecr_repository_policy.golang](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.update_dbg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.update_deployment_files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
+| [aws_ecr_repository_policy.update_falco_operator_chart](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_ecr_repository_policy.update_jobs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_iam_policy.cluster_autoscaler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.driverkit_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |

--- a/config/clusters/ecr-iam.tf
+++ b/config/clusters/ecr-iam.tf
@@ -55,3 +55,8 @@ resource "aws_ecr_repository_policy" "update_dbg" {
   repository = aws_ecr_repository.update_dbg.name
   policy     = data.aws_iam_policy_document.ecr_standard.json
 }
+
+resource "aws_ecr_repository_policy" "update_falco_operator_chart" {
+  repository = aws_ecr_repository.update_falco_operator_chart.name
+  policy     = data.aws_iam_policy_document.ecr_standard.json
+}

--- a/config/clusters/ecr.tf
+++ b/config/clusters/ecr.tf
@@ -53,3 +53,10 @@ resource "aws_ecr_repository" "update_rules_index" {
     encryption_type = "KMS"
   }
 }
+
+resource "aws_ecr_repository" "update_falco_operator_chart" {
+  name = "test-infra/update-falco-operator-chart"
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}


### PR DESCRIPTION
This PR adds the missing ECR repository for the update-falco-operator-chart image and applies the same standard ECR policy used by the other test-infra updater images.

The merged Prow job currently points to 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/update-falco-operator-chart:latest, but the ECR repository does not exist yet, so the job cannot pull the image.

Safety note: merge only if the Terraform plan contains only the new ECR repository and repository policy: 2 to add, 0 to change, 0 to destroy. If the plan shows unrelated drift, we should stop and handle that separately.

Authored by @c2ndev 