### PR TITLE
config(sync-charts): add event-generator and k8s-metacollector jobs

### DIFF
--- a/config/jobs/sync-charts/event-generator.yaml
+++ b/config/jobs/sync-charts/event-generator.yaml
@@ -1,0 +1,61 @@
+postsubmits:
+  falcosecurity/event-generator:
+    - name: sync-charts-event-generator
+      decorate: true
+      skip_report: false
+      agent: kubernetes
+      max_concurrency: 1
+      branches:
+        - ^main$
+      run_if_changed: "^chart/event-generator/"
+      extra_refs:
+        # Check out the falcosecurity/charts repo.
+        # This is the working directory because the job creates a PR there.
+        - org: falcosecurity
+          repo: charts
+          base_ref: master
+          workdir: true
+      spec:
+        containers:
+          # See images/sync-charts
+          - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/sync-charts:latest
+            imagePullPolicy: Always
+            command:
+              - /entrypoint.sh
+            args:
+              - /etc/github-token/oauth
+            env:
+              - name: GH_PROXY
+                value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+              - name: GH_ORG
+                value: falcosecurity
+              - name: GH_REPO
+                value: charts
+              - name: GH_REPO_BRANCH
+                value: master
+              - name: SOURCE_REPO_PATH
+                value: /home/prow/go/src/github.com/falcosecurity/event-generator
+              - name: SOURCE_REPO_URL
+                value: https://github.com/falcosecurity/event-generator/tree/main/chart/event-generator
+              - name: SOURCE_CHART_PATH
+                value: chart/event-generator
+              - name: TARGET_CHART_PATH
+                value: charts/event-generator
+            volumeMounts:
+              - name: github
+                mountPath: /etc/github-token
+                readOnly: true
+              - name: gpg-signing-key
+                mountPath: /root/gpg-signing-key/
+                readOnly: true
+        volumes:
+          - name: github
+            secret:
+              # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+              secretName: oauth-token
+          - name: gpg-signing-key
+            secret:
+              secretName: poiana-gpg-signing-key
+              defaultMode: 0400
+        nodeSelector:
+          Archtype: "x86"

--- a/config/jobs/sync-charts/k8s-metacollector.yaml
+++ b/config/jobs/sync-charts/k8s-metacollector.yaml
@@ -1,0 +1,61 @@
+postsubmits:
+  falcosecurity/k8s-metacollector:
+    - name: sync-charts-k8s-metacollector
+      decorate: true
+      skip_report: false
+      agent: kubernetes
+      max_concurrency: 1
+      branches:
+        - ^main$
+      run_if_changed: "^chart/k8s-metacollector/"
+      extra_refs:
+        # Check out the falcosecurity/charts repo.
+        # This is the working directory because the job creates a PR there.
+        - org: falcosecurity
+          repo: charts
+          base_ref: master
+          workdir: true
+      spec:
+        containers:
+          # See images/sync-charts
+          - image: 292999226676.dkr.ecr.eu-west-1.amazonaws.com/test-infra/sync-charts:latest
+            imagePullPolicy: Always
+            command:
+              - /entrypoint.sh
+            args:
+              - /etc/github-token/oauth
+            env:
+              - name: GH_PROXY
+                value: https://api.github.com # fixme > Can't reach http://ghproxy at the moment
+              - name: GH_ORG
+                value: falcosecurity
+              - name: GH_REPO
+                value: charts
+              - name: GH_REPO_BRANCH
+                value: master
+              - name: SOURCE_REPO_PATH
+                value: /home/prow/go/src/github.com/falcosecurity/k8s-metacollector
+              - name: SOURCE_REPO_URL
+                value: https://github.com/falcosecurity/k8s-metacollector/tree/main/chart/k8s-metacollector
+              - name: SOURCE_CHART_PATH
+                value: chart/k8s-metacollector
+              - name: TARGET_CHART_PATH
+                value: charts/k8s-metacollector
+            volumeMounts:
+              - name: github
+                mountPath: /etc/github-token
+                readOnly: true
+              - name: gpg-signing-key
+                mountPath: /root/gpg-signing-key/
+                readOnly: true
+        volumes:
+          - name: github
+            secret:
+              # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+              secretName: oauth-token
+          - name: gpg-signing-key
+            secret:
+              secretName: poiana-gpg-signing-key
+              defaultMode: 0400
+        nodeSelector:
+          Archtype: "x86"


### PR DESCRIPTION
Adds sync-charts postsubmit jobs for `event-generator` and `k8s-metacollector`.

The jobs reuse the existing generic `sync-charts` image and entrypoint already used by `falco-operator`. Only the repository name and chart paths are configured per source repo.

This lets the owning repositories become the source of truth for their Helm charts, while `falcosecurity/charts` remains the publication repository.