### PR TITLE
update(config/org.yaml): add c2ndev to charts and core maintainers

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -475,6 +475,7 @@ orgs:
           - Issif
           - alacuku
           - ekoops
+          - c2ndev
         privacy: closed
         repos:
           charts: maintain
@@ -557,6 +558,7 @@ orgs:
           - deepskyblue86
           - geraldcombs
           - irozzo-1A
+          - c2ndev
         privacy: closed
       dbg-go-maintainers:
         description: maintainers of falcosecurity/dbg-go


### PR DESCRIPTION
Adds `c2ndev` to the GitHub teams matching the charts maintainer onboarding:

- `charts-maintainers`
- `core-maintainers`

Follow-up of falcosecurity/charts#1007.

/hold until the PR falcosecurity/charts#1007 is merged