### PR TITLE
fix(sync-charts): reuse PRs from branch names with slashes

### DIFF
--- a/images/sync-charts/entrypoint.sh
+++ b/images/sync-charts/entrypoint.sh
@@ -318,7 +318,7 @@ create_pr() {
         --github-token-path="${token_path}" \
         --org="${GH_ORG}" --repo="${GH_REPO}" --branch="${GH_REPO_BRANCH}" \
         --title="${title}" \
-        --head-branch="${GH_ORG}:${branch}" \
+        --head-branch="${branch}" \
         --body="${body}" \
         --local --source="${branch}" \
         --allow-mods --confirm


### PR DESCRIPTION
## What this PR does

Fixes the `sync-charts` updater so `pr-creator` can reuse an already open chart sync PR when the generated branch name contains slashes.

The job already pushes to a branch in the target repository, for example:

```text
sync/charts/falco-operator
```

However, `pr-creator` was searching with an owner-qualified head branch:

```text
head:falcosecurity:sync/charts/falco-operator
```

GitHub search does not match that form for branch names with slashes, so the updater could push the commit but then fail while trying to create a duplicate PR.