### PR TITLE
chore(charts): drop go-unit-tests required check

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -83,7 +83,6 @@ branch-protection:
             contexts:
               - "test"
               - "readme"
-              - "go-unit-tests"
           branches:
             master:
               protect: true


### PR DESCRIPTION
## What this PR does

Removes `go-unit-tests` from the required checks for `falcosecurity/charts`.

The charts repo no longer owns chart-specific Go unit tests. Those tests now belong to the source repositories for managed charts, while the charts repo keeps the generic `test` and `readme` checks.

## Why

Without this branch protection update, charts PRs would wait for a required check that no longer exists.