### PR TITLE
prow: sync Falco chart from release branches

### DIFF
--- a/config/jobs/sync-charts/falco.yaml
+++ b/config/jobs/sync-charts/falco.yaml
@@ -6,7 +6,7 @@ postsubmits:
       agent: kubernetes
       max_concurrency: 1
       branches:
-        - ^master$
+        - ^release/.*$
       run_if_changed: "^chart/falco/"
       extra_refs:
         # Check out the falcosecurity/charts repo.
@@ -35,8 +35,6 @@ postsubmits:
                 value: master
               - name: SOURCE_REPO_PATH
                 value: /home/prow/go/src/github.com/falcosecurity/falco
-              - name: SOURCE_REPO_URL
-                value: https://github.com/falcosecurity/falco/tree/master/chart/falco
               - name: SOURCE_CHART_PATH
                 value: chart/falco
               - name: TARGET_CHART_PATH

--- a/images/sync-charts/entrypoint.sh
+++ b/images/sync-charts/entrypoint.sh
@@ -246,7 +246,10 @@ pr_branch() {
 }
 
 source_repo_root_url() {
-    local source_url="${SOURCE_REPO_URL%/}"
+    local source_url
+
+    source_url="$(source_repo_url)"
+    source_url="${source_url%/}"
 
     if [[ -z "${source_url}" ]]; then
         return 0
@@ -257,6 +260,25 @@ source_repo_root_url() {
         *"/blob/"*) printf "%s" "${source_url%%/blob/*}" ;;
         *) printf "%s" "${source_url}" ;;
     esac
+}
+
+source_repo_url() {
+    if [[ -n "${SOURCE_REPO_URL}" ]]; then
+        printf "%s" "${SOURCE_REPO_URL}"
+        return 0
+    fi
+
+    if [[ -n "${REPO_OWNER:-}" && -n "${REPO_NAME:-}" && -n "${PULL_BASE_SHA:-}" ]]; then
+        printf "https://github.com/%s/%s/tree/%s/%s" "${REPO_OWNER}" "${REPO_NAME}" "${PULL_BASE_SHA}" "${SOURCE_CHART_PATH}"
+        return 0
+    fi
+
+    if [[ -n "${REPO_OWNER:-}" && -n "${REPO_NAME:-}" && -n "${PULL_BASE_REF:-}" ]]; then
+        printf "https://github.com/%s/%s/tree/%s/%s" "${REPO_OWNER}" "${REPO_NAME}" "${PULL_BASE_REF}" "${SOURCE_CHART_PATH}"
+        return 0
+    fi
+
+    return 0
 }
 
 source_commit() {
@@ -299,7 +321,8 @@ pr_body() {
     local source_commit
 
     chart_name="$(target_chart_name)"
-    source_ref="${SOURCE_REPO_URL:-${source_dir}}"
+    source_ref="$(source_repo_url)"
+    source_ref="${source_ref:-${source_dir}}"
     source_commit="$(source_commit_ref "${source_dir}")"
 
     cat <<EOF


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Falco chart sync job to follow the chart release branch workflow.

The Falco chart sync now runs from `release/*` branches instead of `master`, so unreleased chart development can continue on `master` without publishing a chart.

The sync script can now derive the source chart URL from Prow-provided repository metadata when `SOURCE_REPO_URL` is not set. Existing jobs that still set `SOURCE_REPO_URL` keep the current behavior.