### PR TITLE
update(config/org.yaml): add c2ndev to falcoctl and test-infra maintainers

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -711,6 +711,7 @@ orgs:
           - cpanato
           - alacuku
           - loresuso
+          - c2ndev
         privacy: closed
         repos:
           falcoctl: maintain
@@ -1045,6 +1046,7 @@ orgs:
           - ekoops
           - LucaGuerra
           - alacuku
+          - c2ndev
         privacy: closed
         repos:
           test-infra: maintain


### PR DESCRIPTION
Adds `c2ndev` (Alessandro Cannarella) to the `members:` list of the `falcoctl-maintainers` and `test-infra-maintainers` teams in `config/org.yaml`.