### PR TITLE
update(config/org.yaml): remove andreagit97 following step-down

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -550,7 +550,6 @@ orgs:
           - jasondellaluce
           - Molter73
           - LucaGuerra
-          - Andreagit97
           - alacuku
           - loresuso
           - sgaist
@@ -671,7 +670,6 @@ orgs:
         members:
           - FedeDP
           - jasondellaluce
-          - Andreagit97
           - LucaGuerra
           - sgaist
           - ekoops
@@ -853,7 +851,6 @@ orgs:
           - FedeDP
           - Molter73
           - LucaGuerra
-          - Andreagit97
           - hbrueckner
           - ekoops
           - geraldcombs
@@ -1018,7 +1015,6 @@ orgs:
         members:
           - fededp
           - jasondellaluce
-          - andreagit97
           - mstemm
           - darryk10
           - ekoops
@@ -1057,7 +1053,6 @@ orgs:
           - jasondellaluce
           - leogr
         members:
-          - andreagit97
           - lucaguerra
         privacy: closed
         repos:


### PR DESCRIPTION
Following @Andreagit97's step-down (falcosecurity/evolution#526), this removes him from the GitHub teams for the repositories he's stepping down from:

- `core-maintainers`
- `falco-maintainers`
- `libs-maintainers`
- `rules-maintainers`
- `testing-maintainers`

N.B. He stays a member of the falcosecurity org (emeritus maintainers keep org membership, as per our [guidelines](https://github.com/falcosecurity/evolution/blob/main/MAINTAINERS_GUIDELINES.md#organization-membership)), and he remains an active maintainer of `kernel-testing`, `syscalls-bumper`, `k8s-metacollector`, `plugin-sdk-rs`, and `community` - so those teams are untouched.

/kind cleanup

cc @falcosecurity/core-maintainers
