### PR TITLE
chore(config): protect libs `release/0.26.x` branch

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -423,6 +423,8 @@ branch-protection:
               protect: true
             "release/0.25.x":
               protect: true
+            "release/0.26.x":
+              protect: true
         libs-sdk-go:
           branches:
             main:


### PR DESCRIPTION
This PR protects the libs `release/0.26.x` release branch, as required by our libs release process 👉 https://github.com/falcosecurity/libs/blob/master/release.md

Same change as for the previous release branches:
- #2009

```release-note
NONE
```
