### PR TITLE
chore(config): protect falco `release/0.45.x` branch

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -198,6 +198,8 @@ branch-protection:
               protect: true
             "release/0.44.x":
               protect: true
+            "release/0.45.x":
+              protect: true
         falcosidekick:
           required_status_checks:
             contexts:


### PR DESCRIPTION
This PR protects the falco `release/0.45.x` release branch, as required by our release process 👉 https://github.com/falcosecurity/falco/blob/master/RELEASE.md

Same change as for the previous release branches:
- #2061

```release-note
NONE
```
