### PR TITLE
chore(config): add c2ndev to falco-maintainers

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -672,6 +672,7 @@ orgs:
           - sgaist
           - ekoops
           - irozzo-1A
+          - c2ndev
         privacy: closed
         repos:
           falco: maintain


### PR DESCRIPTION
Add `c2ndev` to the `falco-maintainers` team in `config/org.yaml`.